### PR TITLE
chore(deps): update crokey to 1.4 and remove workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crokey"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51360853ebbeb3df20c76c82aecf43d387a62860f1a59ba65ab51f00eea85aad"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
  "crossterm",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf1a727caeb5ee5e0a0826a97f205a9cf84ee964b0b48239fef5214a00ae439"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
  "crossterm",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libloading = "0.9"
 
 # Terminal UI
 crossterm = "0.29"
-crokey = "1.3"
+crokey = "1.4"
 nu-ansi-term = { version = "0.50", features = ["derive_serde_style"] }
 reedline = { git = "https://github.com/nushell/reedline.git", rev = "refs/pull/1015/head", features = ["sqlite", "idle_callback"] }
 

--- a/crates/arf-console/src/config/editor.rs
+++ b/crates/arf-console/src/config/editor.rs
@@ -3,7 +3,7 @@
 use crokey::KeyCombination;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// Editor configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -19,29 +19,13 @@ pub struct EditorConfig {
     /// Keyboard shortcuts that insert text.
     /// Format: "modifier-key" = "text to insert"
     /// Examples: "alt-hyphen" = " <- ", "alt-p" = " |> "
-    #[serde(
-        default = "default_key_map",
-        serialize_with = "serialize_key_map_sorted"
-    )]
+    #[serde(default = "default_key_map")]
     #[schemars(schema_with = "key_map_schema")]
-    pub key_map: HashMap<KeyCombination, String>,
+    pub key_map: BTreeMap<KeyCombination, String>,
 }
 
-/// Serialize key_map with keys sorted alphabetically for deterministic output.
-fn serialize_key_map_sorted<S>(
-    map: &HashMap<KeyCombination, String>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    // Convert to BTreeMap<String, &String> for sorted serialization
-    let sorted: BTreeMap<String, &String> = map.iter().map(|(k, v)| (k.to_string(), v)).collect();
-    sorted.serialize(serializer)
-}
-
-fn default_key_map() -> HashMap<KeyCombination, String> {
-    let mut map = HashMap::new();
+fn default_key_map() -> BTreeMap<KeyCombination, String> {
+    let mut map = BTreeMap::new();
     // Alt+- for assignment operator
     if let Ok(key) = "alt-hyphen".parse() {
         map.insert(key, " <- ".to_string());

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -6,7 +6,7 @@ use crate::editor::mode::{
 };
 use crokey::KeyCombination;
 use reedline::{EditCommand, EditMode, KeyCode, KeyModifiers, Keybindings, ReedlineEvent};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Add common keybindings to an existing keybinding set.
 ///
@@ -168,7 +168,7 @@ pub fn add_auto_match_keybindings(keybindings: &mut Keybindings) {
 /// Example: "alt-hyphen" = " <- ", "alt-p" = " |> "
 pub fn add_key_map_keybindings(
     keybindings: &mut Keybindings,
-    key_map: &HashMap<KeyCombination, String>,
+    key_map: &BTreeMap<KeyCombination, String>,
 ) {
     use crossterm::event::KeyEvent;
 


### PR DESCRIPTION
crokey 1.4.0 supports deterministic serialization for KeyCombination, so we can remove our custom `serialize_key_map_sorted` workaround.