### PR TITLE
chore: bump version to 0.2.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0-rc.1] - 2026-02-01
+
 ### Added
 
 - Experimental `arf history import` subcommand for importing history from radian, R, or another arf database (#31)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arf-console"
-version = "0.2.0-beta.1"
+version = "0.2.0-rc.1"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.2.0-beta.1"
+version = "0.2.0-rc.1"
 dependencies = [
  "arf-libr",
  "log",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.2.0-beta.1"
+version = "0.2.0-rc.1"
 dependencies = [
  "encoding_rs",
  "exec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.2.0-beta.1"
+version = "0.2.0-rc.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0-beta.1
+# arf console v0.2.0-rc.1
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0-beta.1
+# arf console v0.2.0-rc.1
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0-beta.1
+# arf console v0.2.0-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0-beta.1
+# arf console v0.2.0-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0-beta.1
+# arf console v0.2.0-rc.1
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump version from 0.2.0-beta.1 to 0.2.0-rc.1
- Update CHANGELOG with new version section
- Update banner snapshots

🤖 Generated with [Claude Code](https://claude.ai/code)