### PR TITLE
fix: flush stdout after print in r_write_console_ex

### DIFF
--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -371,6 +371,9 @@ unsafe extern "C" fn r_write_console_ex(buf: *const c_char, buflen: c_int, otype
         eprint!("{}", format_error_output(&s));
     } else {
         print!("{}", s);
+        // Flush stdout immediately so progress bars using \r without \n
+        // are displayed in real time instead of accumulating in the buffer.
+        let _ = std::io::Write::flush(&mut std::io::stdout());
     }
 }
 


### PR DESCRIPTION
## Summary
- Add explicit `stdout` flush after `print!()` in `r_write_console_ex` so that R output using `\r` without newline (e.g., progress bars from `pak::pak()`) is displayed immediately instead of accumulating in the buffer and appearing in choppy bursts.

## Test plan
- [x] Manual test: confirmed progress bar animations display smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)