### PR TITLE
build: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
-labels: ["bug"]
+labels:
+  - bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
-labels: ["enhancement"]
+labels:
+  - enhancement
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
## Summary

- Add bug report template requiring `:info` metacommand output for environment information
- Add feature request template with description, motivation, and alternatives fields
- `:info` output is rendered as a markdown-highlighted code block, keeping headers readable

## Test plan

- [x] Verify templates appear on the "New Issue" page
- [ ] Submit a test bug report and confirm `:info` output renders as a code block
- [ ] Submit a test feature request and confirm form fields work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)