### PR TITLE
chore: update reedline to upstream with idle_callback support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.45.0"
-source = "git+https://github.com/nushell/reedline.git?rev=8afe75ec78c2631728244b7f13a0d8df289dafeb#8afe75ec78c2631728244b7f13a0d8df289dafeb"
+source = "git+https://github.com/nushell/reedline.git?rev=99764ee6d6b05a3ce4b31eb8797c5d68b277d054#99764ee6d6b05a3ce4b31eb8797c5d68b277d054"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libloading = "0.9"
 crossterm = "0.29"
 crokey = "1.4"
 nu-ansi-term = { version = "0.50", features = ["derive_serde_style"] }
-reedline = { git = "https://github.com/nushell/reedline.git", rev = "8afe75ec78c2631728244b7f13a0d8df289dafeb", features = ["sqlite", "idle_callback"] }
+reedline = { git = "https://github.com/nushell/reedline.git", rev = "99764ee6d6b05a3ce4b31eb8797c5d68b277d054", features = ["sqlite", "idle_callback"] }
 
 # Configuration
 dirs = "6.0"

--- a/crates/arf-console/src/completion/completer.rs
+++ b/crates/arf-console/src/completion/completer.rs
@@ -161,6 +161,7 @@ impl MetaCommandCompleter {
                     .filter(|cmd| !self.excluded_commands.contains(&cmd.name))
                     .map(|cmd| Suggestion {
                         value: cmd.name.to_string(),
+                        display_override: None,
                         description: Some(cmd.description.to_string()),
                         extra: None,
                         span: Span { start, end: pos },
@@ -183,6 +184,7 @@ impl MetaCommandCompleter {
                     .filter_map(|cmd| {
                         fuzzy_match(partial, cmd.name).map(|m| Suggestion {
                             value: cmd.name.to_string(),
+                            display_override: None,
                             description: Some(cmd.description.to_string()),
                             extra: None,
                             span: Span { start, end: pos },
@@ -304,6 +306,7 @@ impl MetaCommandCompleter {
                 };
                 Suggestion {
                     value: v.name.clone(),
+                    display_override: None,
                     description: Some(description),
                     extra: None,
                     span: Span { start, end: pos },
@@ -325,6 +328,7 @@ impl MetaCommandCompleter {
                     };
                     suggestions.push(Suggestion {
                         value: alias.clone(),
+                        display_override: None,
                         description: Some(format!("R {} (alias)", v.version)),
                         extra: None,
                         span: Span { start, end: pos },
@@ -359,6 +363,7 @@ impl MetaCommandCompleter {
                 };
                 Suggestion {
                     value: name.to_string(),
+                    display_override: None,
                     description: Some(desc.to_string()),
                     extra: None,
                     span: Span {
@@ -392,6 +397,7 @@ impl MetaCommandCompleter {
                 };
                 Suggestion {
                     value: name.to_string(),
+                    display_override: None,
                     description: Some(desc.to_string()),
                     extra: None,
                     span: Span {
@@ -703,6 +709,7 @@ impl Completer for RCompleter {
 
                 Suggestion {
                     value,
+                    display_override: None,
                     description: extra_info,
                     extra: None,
                     span: Span { start, end: pos },
@@ -1020,6 +1027,7 @@ fn complete_path_in_string(_line: &str, pos: usize, ctx: &StringContext) -> Vec<
 
             Suggestion {
                 value: c.path,
+                display_override: None,
                 description: if c.is_dir {
                     Some("directory".to_string())
                 } else {

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -293,12 +293,11 @@ impl Repl {
         // Set up idle callback to process R events during input waiting.
         // This allows graphics windows (plot(), help browser) to remain responsive
         // while the user is typing or the editor is waiting for input.
-        line_editor = line_editor.with_idle_callback(
-            Box::new(|| {
+        line_editor = line_editor
+            .with_poll_interval(std::time::Duration::from_millis(33))
+            .with_idle_callback(Box::new(|| {
                 arf_libr::process_r_events();
-            }),
-            std::time::Duration::from_millis(33),
-        );
+            }));
 
         // Create shell line editor with separate history
         let shell_line_editor = self.create_shell_line_editor();
@@ -644,12 +643,11 @@ impl Repl {
 
         // Set up idle callback to process R events during input waiting.
         // Even in shell mode, R graphics windows may be open and need event processing.
-        shell_editor = shell_editor.with_idle_callback(
-            Box::new(|| {
+        shell_editor = shell_editor
+            .with_poll_interval(std::time::Duration::from_millis(33))
+            .with_idle_callback(Box::new(|| {
                 arf_libr::process_r_events();
-            }),
-            std::time::Duration::from_millis(33),
-        );
+            }));
 
         shell_editor
     }


### PR DESCRIPTION
## Summary

- Update reedline dependency from pinned fork commit (`8afe75e`) to upstream (`99764ee`) now that [nushell/reedline#1015](https://github.com/nushell/reedline/pull/1015) has been merged
- Adapt to upstream API changes: `.with_idle_callback(cb, duration)` → `.with_poll_interval(duration).with_idle_callback(cb)`
- Add new `display_override` field to all `Suggestion` initializers (from [nushell/reedline#1002](https://github.com/nushell/reedline/pull/1002))

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 560 tests pass
- [x] `cargo clippy` clean
- [x] Manual test: verify R graphics windows remain responsive during input

🤖 Generated with [Claude Code](https://claude.com/claude-code)