### PR TITLE
refactor: replace PromptRuntimeConfig positional constructor with builder pattern

### DIFF
--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -403,38 +403,10 @@ fn process_history_clear(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{
-        Indicators, ModeIndicatorPosition, PromptDurationConfig, SpinnerConfig, StatusColorConfig,
-        StatusConfig, ViColorConfig, ViConfig,
-    };
     use crate::editor::prompt::PromptFormatter;
-    use nu_ansi_term::Color;
 
     fn create_test_prompt_config() -> PromptRuntimeConfig {
-        // Create a test prompt formatter with fixed values
-        let formatter = PromptFormatter::default();
-        PromptRuntimeConfig::new(
-            formatter,
-            "r> ".to_string(),
-            "+  ".to_string(),
-            "[bash] $ ".to_string(),
-            ModeIndicatorPosition::Prefix,
-            false,
-            "#> ".to_string(),
-            Indicators::default(),
-            false,
-            Color::Default,
-            Color::Default,
-            Color::Default,
-            Color::Default,
-            StatusConfig::default(),
-            StatusColorConfig::default(),
-            PromptDurationConfig::default(),
-            Color::Default,
-            SpinnerConfig::default(),
-            ViConfig::default(),
-            ViColorConfig::default(),
-        )
+        PromptRuntimeConfig::builder(PromptFormatter::default(), "r> ", "+  ", "[bash] $ ").build()
     }
 
     /// Default r_source_status for tests (PATH mode, rig not enabled).

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -304,28 +304,37 @@ impl Repl {
 
         // Create prompt runtime config with unexpanded templates
         // Templates are expanded dynamically in build_main_prompt() to track cwd changes
-        let prompt_config = PromptRuntimeConfig::new(
+        let prompt_config = PromptRuntimeConfig::builder(
             self.prompt_formatter.clone(),
             self.config.prompt.format.clone(),
             self.config.prompt.continuation.clone(),
             self.config.prompt.shell_format.clone(),
-            self.config.prompt.mode_indicator,
+        )
+        .mode_indicator_position(self.config.prompt.mode_indicator)
+        .reprex(
             self.config.startup.mode.reprex,
             self.config.mode.reprex.comment.clone(),
-            self.config.prompt.indicators.clone(),
-            self.config.startup.mode.autoformat,
-            self.config.colors.prompt.main,
-            self.config.colors.prompt.continuation,
-            self.config.colors.prompt.shell,
-            self.config.colors.prompt.indicator,
+        )
+        .indicators(self.config.prompt.indicators.clone())
+        .autoformat(self.config.startup.mode.autoformat)
+        .main_color(self.config.colors.prompt.main)
+        .continuation_color(self.config.colors.prompt.continuation)
+        .shell_color(self.config.colors.prompt.shell)
+        .mode_indicator_color(self.config.colors.prompt.indicator)
+        .status(
             self.config.prompt.status.clone(),
             self.config.colors.prompt.status.clone(),
+        )
+        .duration(
             self.config.experimental.prompt_duration.clone(),
             self.config.colors.prompt.duration,
-            self.config.experimental.prompt_spinner.clone(),
+        )
+        .spinner(self.config.experimental.prompt_spinner.clone())
+        .vi(
             self.config.prompt.vi.clone(),
             self.config.colors.prompt.vi.clone(),
-        );
+        )
+        .build();
 
         // Get history paths for :history commands
         let r_history_path = self.r_history_path();
@@ -464,28 +473,27 @@ impl Repl {
         );
 
         // Minimal prompt config for meta commands (R not available)
-        let mut prompt_config = PromptRuntimeConfig::new(
-            self.prompt_formatter.clone(),
-            "R > ".to_string(),
-            "+   ".to_string(),
-            "$ ".to_string(),
-            ModeIndicatorPosition::None,
-            false,
-            "#> ".to_string(),
-            crate::config::Indicators::default(),
-            false,
-            self.config.colors.prompt.main,
-            self.config.colors.prompt.continuation,
-            self.config.colors.prompt.shell,
-            self.config.colors.prompt.indicator,
-            self.config.prompt.status.clone(),
-            self.config.colors.prompt.status.clone(),
-            self.config.experimental.prompt_duration.clone(),
-            self.config.colors.prompt.duration,
-            self.config.experimental.prompt_spinner.clone(),
-            self.config.prompt.vi.clone(),
-            self.config.colors.prompt.vi.clone(),
-        );
+        let mut prompt_config =
+            PromptRuntimeConfig::builder(self.prompt_formatter.clone(), "R > ", "+   ", "$ ")
+                .mode_indicator_position(ModeIndicatorPosition::None)
+                .main_color(self.config.colors.prompt.main)
+                .continuation_color(self.config.colors.prompt.continuation)
+                .shell_color(self.config.colors.prompt.shell)
+                .mode_indicator_color(self.config.colors.prompt.indicator)
+                .status(
+                    self.config.prompt.status.clone(),
+                    self.config.colors.prompt.status.clone(),
+                )
+                .duration(
+                    self.config.experimental.prompt_duration.clone(),
+                    self.config.colors.prompt.duration,
+                )
+                .spinner(self.config.experimental.prompt_spinner.clone())
+                .vi(
+                    self.config.prompt.vi.clone(),
+                    self.config.colors.prompt.vi.clone(),
+                )
+                .build();
         let r_history_path = self.r_history_path();
         let shell_history_path = self.shell_history_path();
 


### PR DESCRIPTION
## Summary

- Replace `PromptRuntimeConfig::new()` (20 positional parameters) with a builder pattern via `PromptRuntimeConfig::builder(formatter, main, continuation, shell)` + named setter methods
- Rename `cont_template` to `continuation_template` for clarity
- Net reduction of 195 lines (-488 / +293)

## Test plan

- [x] All 47 existing tests pass (`cargo test -p arf-console -- state:: meta_command::`)
- [x] `cargo fmt` clean
- [x] `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)