### PR TITLE
chore: prepare release version 0.2.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
       placeholder: |
         # Session Information
 
-        arf version:    0.2.0
+        arf version:    0.2.1
         OS:             linux (x86_64)
         Config file:    ~/.config/arf/arf.toml
         R version:      4.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.1] - 2026-02-07
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arf-console"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arf-libr",
  "log",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "encoding_rs",
  "exec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"

--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_style_info_line_key_value() {
-        let line = "arf version:    0.2.0";
+        let line = "arf version:    0.2.1";
         let styled = style_info_line(line);
         // Should contain ANSI codes for cyan key
         assert!(styled.contains("\x1b"), "Key-value should be styled");

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0
+# arf console v0.2.1
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0
+# arf console v0.2.1
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0
+# arf console v0.2.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0
+# arf console v0.2.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.0
+# arf console v0.2.1
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.2.0 to 0.2.1
- Finalize CHANGELOG `[Unreleased]` → `[0.2.1] - 2026-02-07`
- Update version references in issue template, test fixtures, and insta snapshots

## Changes in v0.2.1

### Added
- `:cd`, `:pushd`, `:popd` meta commands for directory navigation (#60)
- Experimental `{duration}` prompt placeholder for command execution time (#67)

### Fixed
- Windows: `~` now correctly resolves to the Documents folder (#65)

🤖 Generated with [Claude Code](https://claude.com/claude-code)