### PR TITLE
docs(docs/configuration): add blank line before prompt example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,12 +308,13 @@ format = "{status}R {version}> "
 format = "[{cwd_short}] r> "
 # Result: "[project] r> "
 
+# Add a blank line before the prompt
+# (double-quoted strings interpret \n as a newline)
+format = "\n{status}R {version}> "
+
 # Custom shell mode prompt
 shell_format = "{shell}:{cwd_short}$ "
 # Result: "bash:project$ "
-
-# Add a blank line before the prompt (\n becomes a newline)
-format = "\n{status}R {version}> "
 ```
 
 ## Command Status Indicator


### PR DESCRIPTION
## Summary
- Add a configuration example to docs/configuration.md showing how to insert a blank line before each prompt using `\n` in the format string

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)