### PR TITLE
feat: accept `--slave` and `--no-echo` R-compatible CLI flags

### DIFF
--- a/crates/arf-console/src/cli.rs
+++ b/crates/arf-console/src/cli.rs
@@ -103,6 +103,14 @@ pub struct Cli {
     #[arg(long = "interactive", hide = true)]
     pub interactive: bool,
 
+    /// [R] Don't echo input (no-op, arf controls its own echo)
+    #[arg(long = "no-echo", hide_short_help = true)]
+    pub no_echo: bool,
+
+    /// [R] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)
+    #[arg(long = "slave", hide = true)]
+    pub slave: bool,
+
     /// [R] Don't use readline (no-op)
     #[arg(long = "no-readline", hide = true)]
     pub no_readline: bool,

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -108,7 +108,7 @@ _arf() {
 
     case "${cmd}" in
         arf)
-            opts="-e -c -q -h -V --eval --reprex --auto-format --config --no-banner --with-r-version --r-home --vanilla --quiet --no-save --save --no-restore --no-restore-data --restore-data --no-environ --no-site-file --no-init-file --interactive --no-readline --no-restore-history --no-auto-match --no-completion --history-dir --no-history --help --version [SCRIPT] completions config history help"
+            opts="-e -c -q -h -V --eval --reprex --auto-format --config --no-banner --with-r-version --r-home --vanilla --quiet --no-save --save --no-restore --no-restore-data --restore-data --no-environ --no-site-file --no-init-file --interactive --no-echo --slave --no-readline --no-restore-history --no-auto-match --no-completion --history-dir --no-history --help --version [SCRIPT] completions config history help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
@@ -4,7 +4,7 @@ expression: completions
 ---
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_arf_global_optspecs
-	string join \n e/eval= reprex auto-format c/config= no-banner with-r-version= r-home= vanilla q/quiet no-save save no-restore no-restore-data restore-data no-environ no-site-file no-init-file interactive no-readline no-restore-history no-auto-match no-completion history-dir= no-history h/help V/version
+	string join \n e/eval= reprex auto-format c/config= no-banner with-r-version= r-home= vanilla q/quiet no-save save no-restore no-restore-data restore-data no-environ no-site-file no-init-file interactive no-echo slave no-readline no-restore-history no-auto-match no-completion history-dir= no-history h/help V/version
 end
 
 function __fish_arf_needs_command
@@ -47,6 +47,8 @@ complete -c arf -n "__fish_arf_needs_command" -l no-environ -d '[R] Don\'t read 
 complete -c arf -n "__fish_arf_needs_command" -l no-site-file -d '[R] Don\'t read the site-wide Rprofile'
 complete -c arf -n "__fish_arf_needs_command" -l no-init-file -d '[R] Don\'t read the user\'s .Rprofile'
 complete -c arf -n "__fish_arf_needs_command" -l interactive -d '[R] Force R to run interactively (no-op, always interactive)'
+complete -c arf -n "__fish_arf_needs_command" -l no-echo -d '[R] Don\'t echo input (no-op, arf controls its own echo)'
+complete -c arf -n "__fish_arf_needs_command" -l slave -d '[R] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)'
 complete -c arf -n "__fish_arf_needs_command" -l no-readline -d '[R] Don\'t use readline (no-op)'
 complete -c arf -n "__fish_arf_needs_command" -l no-restore-history -d '[R] Don\'t restore history (no-op)'
 complete -c arf -n "__fish_arf_needs_command" -l no-auto-match -d 'Disable auto-matching of brackets and quotes (for testing)'

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
@@ -47,6 +47,8 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--no-site-file', '--no-site-file', [CompletionResultType]::ParameterName, '[R] Don''t read the site-wide Rprofile')
             [CompletionResult]::new('--no-init-file', '--no-init-file', [CompletionResultType]::ParameterName, '[R] Don''t read the user''s .Rprofile')
             [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, '[R] Force R to run interactively (no-op, always interactive)')
+            [CompletionResult]::new('--no-echo', '--no-echo', [CompletionResultType]::ParameterName, '[R] Don''t echo input (no-op, arf controls its own echo)')
+            [CompletionResult]::new('--slave', '--slave', [CompletionResultType]::ParameterName, '[R] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)')
             [CompletionResult]::new('--no-readline', '--no-readline', [CompletionResultType]::ParameterName, '[R] Don''t use readline (no-op)')
             [CompletionResult]::new('--no-restore-history', '--no-restore-history', [CompletionResultType]::ParameterName, '[R] Don''t restore history (no-op)')
             [CompletionResult]::new('--no-auto-match', '--no-auto-match', [CompletionResultType]::ParameterName, 'Disable auto-matching of brackets and quotes (for testing)')

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -41,6 +41,8 @@ _arf() {
 '--no-site-file[\[R\] Don'\''t read the site-wide Rprofile]' \
 '--no-init-file[\[R\] Don'\''t read the user'\''s .Rprofile]' \
 '--interactive[\[R\] Force R to run interactively (no-op, always interactive)]' \
+'--no-echo[\[R\] Don'\''t echo input (no-op, arf controls its own echo)]' \
+'--slave[\[R\] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)]' \
 '--no-readline[\[R\] Don'\''t use readline (no-op)]' \
 '--no-restore-history[\[R\] Don'\''t restore history (no-op)]' \
 '--no-auto-match[Disable auto-matching of brackets and quotes (for testing)]' \

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
@@ -78,6 +78,9 @@ Options:
       --no-init-file
           [R] Don't read the user's .Rprofile
 
+      --no-echo
+          [R] Don't echo input (no-op, arf controls its own echo)
+
       --history-dir <HISTORY_DIR>
           Custom history directory (overrides default XDG location)
           


### PR DESCRIPTION
## Summary

- Add `--slave` and `--no-echo` as R-compatible no-op CLI flags
- `--slave` is fully hidden (deprecated in R 4.0)
- `--no-echo` is shown in long help (`--help`) only
- Prevents errors when tools like R.nvim pass these flags to arf

## Background

A user reported that arf fails when launched with `--slave` from R.nvim.
radian had the same issue, causing [multiple bug reports](https://github.com/REditorSupport/languageserver/issues/228).
arf already accepts several R-compatible no-op flags (`--interactive`, `--no-readline`, `--no-restore-history`), so this follows the same pattern.

## Test plan

- [x] `cargo clippy` passes
- [x] CLI snapshot tests updated and passing
- [x] CLI integration tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)