### PR TITLE
feat: add bottom_margin config for prompt positioning

### DIFF
--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -54,6 +54,7 @@
       "default": {
         "auto_match": true,
         "auto_suggestions": "all",
+        "bottom_margin": "disabled",
         "highlight_matching_bracket": false,
         "key_map": {
           "Alt-Hyphen": " <- ",
@@ -167,6 +168,50 @@
             "none",
             "all",
             "cwd"
+          ]
+        }
+      ]
+    },
+    "BottomMargin": {
+      "description": "Bottom margin configuration to keep prompt away from terminal bottom.\n\nControls how much space to reserve at the bottom of the terminal.",
+      "default": "disabled",
+      "oneOf": [
+        {
+          "description": "Disabled (default) - no bottom margin",
+          "type": "string",
+          "enum": [
+            "disabled"
+          ]
+        },
+        {
+          "description": "Fixed number of lines to reserve at bottom",
+          "type": "object",
+          "properties": {
+            "fixed": {
+              "description": "Number of lines to reserve at bottom (0 to terminal height)",
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "fixed"
+          ]
+        },
+        {
+          "description": "Fraction of terminal height to reserve",
+          "type": "object",
+          "properties": {
+            "proportional": {
+              "description": "Fraction of terminal height (0.0 = top, 1.0 = bottom/disabled)",
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "proportional"
           ]
         }
       ]
@@ -1502,6 +1547,11 @@
           "description": "History-based autosuggestions mode (fish/nushell style).\n\nString values: `\"none\"`, `\"all\"`, `\"cwd\"`\nBoolean values: `false` (= none), `true` (= all)\n\n- `none`: Disable suggestions\n- `all`: Show suggestions from all history (default)\n- `cwd`: Show suggestions only from current directory history\n\nSuggestions appear grayed out and can be accepted with right arrow.",
           "$ref": "#/$defs/AutoSuggestions",
           "default": "all"
+        },
+        "bottom_margin": {
+          "description": "Bottom margin to keep prompt away from terminal bottom.\n\n- `disabled`: No margin (default)\n- `{ fixed = 10 }`: Reserve 10 lines at bottom\n- `{ proportional = 0.5 }`: Reserve bottom 50% of terminal",
+          "$ref": "#/$defs/BottomMargin",
+          "default": "disabled"
         },
         "highlight_matching_bracket": {
           "description": "Highlight matching bracket when cursor is on a bracket.",

--- a/crates/arf-console/src/config/editor.rs
+++ b/crates/arf-console/src/config/editor.rs
@@ -132,6 +132,167 @@ impl<'de> Deserialize<'de> for AutoSuggestions {
     }
 }
 
+/// Bottom margin configuration to keep prompt away from terminal bottom.
+///
+/// Controls how much space to reserve at the bottom of the terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Default, JsonSchema)]
+#[schemars(schema_with = "bottom_margin_schema")]
+pub enum BottomMargin {
+    /// Fixed number of lines to reserve at bottom.
+    Fixed(u16),
+    /// Fraction of terminal height (0.0-1.0).
+    Proportional(f32),
+    /// Disabled (default) - no bottom margin.
+    #[default]
+    Disabled,
+}
+
+impl fmt::Display for BottomMargin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BottomMargin::Fixed(n) => write!(f, "fixed({})", n),
+            BottomMargin::Proportional(v) => write!(f, "proportional({})", v),
+            BottomMargin::Disabled => write!(f, "disabled"),
+        }
+    }
+}
+
+/// Custom JSON schema for BottomMargin.
+fn bottom_margin_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "description": "Bottom margin to keep prompt away from terminal bottom. Can be a string \"disabled\" or an object with type and value.",
+        "oneOf": [
+            {
+                "type": "string",
+                "enum": ["disabled"],
+                "description": "Disabled (default) - no bottom margin"
+            },
+            {
+                "type": "object",
+                "description": "Fixed number of lines to reserve at bottom",
+                "properties": {
+                    "fixed": {
+                        "type": "integer",
+                        "description": "Number of lines to reserve at bottom (0 to terminal height)",
+                        "minimum": 0
+                    }
+                },
+                "required": ["fixed"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "description": "Fraction of terminal height to reserve",
+                "properties": {
+                    "proportional": {
+                        "type": "number",
+                        "description": "Fraction of terminal height (0.0 = top, 1.0 = bottom/disabled)",
+                        "minimum": 0.0,
+                        "maximum": 1.0
+                    }
+                },
+                "required": ["proportional"],
+                "additionalProperties": false
+            }
+        ],
+        "default": "disabled"
+    })
+}
+
+// Serialize BottomMargin - can be string "disabled" or object with fixed/proportional.
+impl Serialize for BottomMargin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeMap;
+        match self {
+            BottomMargin::Disabled => serializer.serialize_str("disabled"),
+            BottomMargin::Fixed(n) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("fixed", n)?;
+                map.end()
+            }
+            BottomMargin::Proportional(v) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("proportional", v)?;
+                map.end()
+            }
+        }
+    }
+}
+
+// Deserialize BottomMargin - accepts "disabled" string or object with fixed/proportional.
+impl<'de> Deserialize<'de> for BottomMargin {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, MapAccess, Visitor};
+
+        struct BottomMarginVisitor;
+
+        impl<'de> Visitor<'de> for BottomMarginVisitor {
+            type Value = BottomMargin;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str(
+                    "a string \"disabled\" or an object with \"fixed\" or \"proportional\" key",
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<BottomMargin, E>
+            where
+                E: de::Error,
+            {
+                match value.to_lowercase().as_str() {
+                    "disabled" => Ok(BottomMargin::Disabled),
+                    _ => Err(de::Error::unknown_variant(value, &["disabled"])),
+                }
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<BottomMargin, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut fixed: Option<u16> = None;
+                let mut proportional: Option<f32> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "fixed" => {
+                            if fixed.is_some() {
+                                return Err(de::Error::duplicate_field("fixed"));
+                            }
+                            fixed = Some(map.next_value()?);
+                        }
+                        "proportional" => {
+                            if proportional.is_some() {
+                                return Err(de::Error::duplicate_field("proportional"));
+                            }
+                            proportional = Some(map.next_value()?);
+                        }
+                        _ => {
+                            return Err(de::Error::unknown_field(&key, &["fixed", "proportional"]));
+                        }
+                    }
+                }
+
+                match (fixed, proportional) {
+                    (Some(n), None) => Ok(BottomMargin::Fixed(n)),
+                    (None, Some(v)) => Ok(BottomMargin::Proportional(v)),
+                    (None, None) => Err(de::Error::missing_field("fixed or proportional")),
+                    (Some(_), Some(_)) => Err(de::Error::custom(
+                        "cannot specify both fixed and proportional",
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(BottomMarginVisitor)
+    }
+}
+
 /// Editor configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
@@ -159,6 +320,13 @@ pub struct EditorConfig {
     #[serde(default = "default_key_map")]
     #[schemars(schema_with = "key_map_schema")]
     pub key_map: BTreeMap<KeyCombination, String>,
+    /// Bottom margin to keep prompt away from terminal bottom.
+    ///
+    /// - `disabled`: No margin (default)
+    /// - `{ fixed = 10 }`: Reserve 10 lines at bottom
+    /// - `{ proportional = 0.5 }`: Reserve bottom 50% of terminal
+    #[serde(default)]
+    pub bottom_margin: BottomMargin,
 }
 
 fn default_key_map() -> BTreeMap<KeyCombination, String> {
@@ -196,6 +364,7 @@ impl Default for EditorConfig {
             highlight_matching_bracket: false,
             auto_suggestions: AutoSuggestions::All,
             key_map: default_key_map(),
+            bottom_margin: BottomMargin::default(),
         }
     }
 }

--- a/crates/arf-console/src/config/mod.rs
+++ b/crates/arf-console/src/config/mod.rs
@@ -12,7 +12,7 @@ mod startup;
 
 pub use colors::{ColorsConfig, MetaColorConfig, RColorConfig, StatusColorConfig, ViColorConfig};
 pub use completion::CompletionConfig;
-pub use editor::{AutoSuggestions, EditorConfig, EditorMode};
+pub use editor::{AutoSuggestions, BottomMargin, EditorConfig, EditorMode};
 pub use experimental::{
     ExperimentalConfig, HistoryForgetConfig, PromptDurationConfig, SpinnerConfig,
 };
@@ -985,5 +985,41 @@ auto_match = false
 
         // Restore permissions so tempdir cleanup succeeds
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    #[test]
+    fn test_default_bottom_margin() {
+        let config = Config::default();
+        assert_eq!(config.editor.bottom_margin, BottomMargin::Disabled);
+    }
+
+    #[test]
+    fn test_parse_bottom_margin_fixed() {
+        let toml_str = r#"
+[editor]
+bottom_margin = { fixed = 10 }
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.editor.bottom_margin, BottomMargin::Fixed(10));
+    }
+
+    #[test]
+    fn test_parse_bottom_margin_proportional() {
+        let toml_str = r#"
+[editor]
+bottom_margin = { proportional = 0.5 }
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.editor.bottom_margin, BottomMargin::Proportional(0.5));
+    }
+
+    #[test]
+    fn test_parse_bottom_margin_disabled() {
+        let toml_str = r#"
+[editor]
+bottom_margin = "disabled"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.editor.bottom_margin, BottomMargin::Disabled);
     }
 }

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -58,6 +58,7 @@ expression: schema
       "default": {
         "auto_match": true,
         "auto_suggestions": "all",
+        "bottom_margin": "disabled",
         "highlight_matching_bracket": false,
         "key_map": {
           "Alt-Hyphen": " <- ",
@@ -171,6 +172,50 @@ expression: schema
             "none",
             "all",
             "cwd"
+          ]
+        }
+      ]
+    },
+    "BottomMargin": {
+      "description": "Bottom margin configuration to keep prompt away from terminal bottom.\n\nControls how much space to reserve at the bottom of the terminal.",
+      "default": "disabled",
+      "oneOf": [
+        {
+          "description": "Disabled (default) - no bottom margin",
+          "type": "string",
+          "enum": [
+            "disabled"
+          ]
+        },
+        {
+          "description": "Fixed number of lines to reserve at bottom",
+          "type": "object",
+          "properties": {
+            "fixed": {
+              "description": "Number of lines to reserve at bottom (0 to terminal height)",
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "fixed"
+          ]
+        },
+        {
+          "description": "Fraction of terminal height to reserve",
+          "type": "object",
+          "properties": {
+            "proportional": {
+              "description": "Fraction of terminal height (0.0 = top, 1.0 = bottom/disabled)",
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "proportional"
           ]
         }
       ]
@@ -1506,6 +1551,11 @@ expression: schema
           "description": "History-based autosuggestions mode (fish/nushell style).\n\nString values: `\"none\"`, `\"all\"`, `\"cwd\"`\nBoolean values: `false` (= none), `true` (= all)\n\n- `none`: Disable suggestions\n- `all`: Show suggestions from all history (default)\n- `cwd`: Show suggestions only from current directory history\n\nSuggestions appear grayed out and can be accepted with right arrow.",
           "$ref": "#/$defs/AutoSuggestions",
           "default": "all"
+        },
+        "bottom_margin": {
+          "description": "Bottom margin to keep prompt away from terminal bottom.\n\n- `disabled`: No margin (default)\n- `{ fixed = 10 }`: Reserve 10 lines at bottom\n- `{ proportional = 0.5 }`: Reserve bottom 50% of terminal",
+          "$ref": "#/$defs/BottomMargin",
+          "default": "disabled"
         },
         "highlight_matching_bracket": {
           "description": "Highlight matching bracket when cursor is on a bracket.",

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
@@ -20,6 +20,7 @@ mode = "emacs"
 auto_match = true
 highlight_matching_bracket = false
 auto_suggestions = "all"
+bottom_margin = "disabled"
 
 [editor.key_map]
 Alt-Hyphen = " <- "

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -10,8 +10,8 @@ pub(crate) mod state;
 use crate::completion::completer::{CombinedCompleter, MetaCommandCompleter};
 use crate::completion::menu::{FunctionAwareMenu, StateSyncHistoryMenu};
 use crate::config::{
-    AutoSuggestions, Config, ConfigStatus, EditorMode, ModeIndicatorPosition, RSourceStatus,
-    history_dir,
+    AutoSuggestions, BottomMargin, Config, ConfigStatus, EditorMode, ModeIndicatorPosition,
+    RSourceStatus, history_dir,
 };
 use crate::editor::hinter::RLanguageHinter;
 use crate::editor::mode::new_editor_state_ref;
@@ -20,7 +20,7 @@ use crate::highlighter::{CombinedHighlighter, MetaCommandHighlighter};
 use crate::history::FuzzyHistory;
 use anyhow::Result;
 use crossterm::{
-    ExecutableCommand,
+    ExecutableCommand, cursor,
     style::Stylize,
     terminal::{self, ClearType},
 };
@@ -32,6 +32,7 @@ use reedline::{
 };
 use std::cell::RefCell;
 use std::io;
+use std::io::Write;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::editor::keybindings::{
@@ -99,6 +100,53 @@ fn sync_r_width() {
             }
             Err(e) => log::debug!("Failed to set R width option: {:?}", e),
         }
+    }
+}
+
+/// Ensure the prompt maintains a margin from the bottom of the terminal.
+///
+/// Supports fixed lines or proportional fraction of terminal height.
+///
+/// - `BottomMargin::Disabled`: No margin (default)
+/// - `BottomMargin::Fixed(n)`: Reserve n lines at bottom
+/// - `BottomMargin::Proportional(f)`: Reserve bottom f fraction (0.0-1.0)
+fn ensure_bottom_margin(margin: BottomMargin) {
+    let Ok((_, term_rows)) = terminal::size() else {
+        return;
+    };
+
+    let target_row = match margin {
+        BottomMargin::Disabled => return,
+        BottomMargin::Fixed(lines) => {
+            if lines == 0 {
+                return;
+            }
+            term_rows.saturating_sub(lines.clamp(0, term_rows))
+        }
+        BottomMargin::Proportional(fraction) => {
+            if fraction >= 1.0 {
+                return;
+            }
+            (term_rows as f32 * fraction.clamp(0.0, 1.0)) as u16
+        }
+    };
+
+    let Ok((_, cursor_row)) = cursor::position() else {
+        return;
+    };
+
+    // If cursor is at or below the target row, we need to scroll up and move cursor
+    if cursor_row >= target_row {
+        let lines_to_scroll = cursor_row.saturating_sub(target_row) + 1;
+
+        // Scroll terminal up to create space, then move cursor to target row
+        let mut stdout = io::stdout();
+        if lines_to_scroll > 0 {
+            let _ = stdout.execute(terminal::ScrollUp(lines_to_scroll));
+        }
+        // Move cursor to the target row (column 0)
+        let _ = stdout.execute(cursor::MoveTo(0, target_row));
+        let _ = stdout.flush();
     }
 }
 
@@ -429,6 +477,7 @@ impl Repl {
                 forget_config: self.config.experimental.history_forget.clone(),
                 sponge_queue: state::SpongeQueue::new(),
                 dir_stack: Vec::new(),
+                bottom_margin: self.config.editor.bottom_margin,
             });
         });
 
@@ -598,6 +647,9 @@ impl Repl {
         let mut dir_stack: Vec<std::path::PathBuf> = Vec::new();
 
         loop {
+            // Apply bottom margin to keep prompt away from terminal bottom
+            ensure_bottom_margin(self.config.editor.bottom_margin);
+
             match line_editor.read_line(&prompt) {
                 Ok(Signal::Success(line)) => {
                     let trimmed = line.trim();
@@ -878,6 +930,12 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
             // The idle callback will continue processing events at ~30fps while waiting for input,
             // keeping graphics windows (plot(), help browser) responsive.
             arf_libr::process_r_events();
+
+            // Apply bottom margin to keep prompt away from terminal bottom
+            // Only for command prompts, not continuation or menu prompts
+            if is_r_command_prompt(r_prompt) {
+                ensure_bottom_margin(state.bottom_margin);
+            }
 
             // Track whether we're in a non-standard prompt mode (menu selection, etc.)
             let is_menu_prompt = !is_r_command_prompt(r_prompt) && !r_prompt.starts_with('+');

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -122,6 +122,8 @@ pub struct ReplState {
     pub sponge_queue: SpongeQueue,
     /// Directory stack for :pushd/:popd navigation.
     pub dir_stack: Vec<PathBuf>,
+    /// Bottom margin to keep prompt away from terminal bottom.
+    pub bottom_margin: crate::config::BottomMargin,
 }
 
 /// Runtime configuration for prompts that can be modified during the session.

--- a/crates/arf-console/tests/pty_bottom_margin_tests.rs
+++ b/crates/arf-console/tests/pty_bottom_margin_tests.rs
@@ -1,0 +1,502 @@
+//! Bottom margin PTY integration tests for arf.
+//!
+//! These tests verify the bottom margin feature keeps the prompt at the
+//! configured distance from the terminal bottom.
+//!
+//! The bottom margin feature is useful for keeping the prompt visible when
+//! there's a lot of output, similar to radian's behavior. Without it, the
+//! prompt quickly reaches the bottom of the terminal and stays there.
+
+mod common;
+
+#[cfg(unix)]
+use common::Terminal;
+
+/// Test proportional margin (0.5) keeps prompt in upper half.
+///
+/// Verifies that with `bottom_margin = { proportional = 0.5 }`, the prompt
+/// stays in the upper half of a 24-row terminal (at or above row 12).
+/// Tests multiple commands to ensure consistency.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_proportional_half() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ proportional = 0.5 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With 0.5 margin in 24-row terminal, prompt should be at or above row 12
+    // Allow ±1 row tolerance for rounding
+    assert!(
+        row <= 13,
+        "Prompt should be in upper half (row <= 13), got row {}",
+        row
+    );
+
+    // Run several commands to verify consistency
+    for i in 1..=5 {
+        terminal
+            .send_line(&format!("print({})", i))
+            .expect("Should send command");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after command");
+
+        let (row, _) = terminal
+            .cursor_position()
+            .expect("Should get cursor position");
+        assert!(
+            row <= 13,
+            "Prompt should stay in upper half after command {}, got row {}",
+            i,
+            row
+        );
+    }
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test fixed margin reserves exact line count.
+///
+/// Verifies that with `bottom_margin = { fixed = 5 }`, the prompt stays
+/// at least 5 lines from the bottom of the terminal.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_fixed_lines() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ fixed = 5 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Fill screen with output to push cursor down
+    for _ in 1..=20 {
+        terminal
+            .send_line("cat('\\n')")
+            .expect("Should send command");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With fixed=5 in 24-row terminal, prompt should be at or above row 19
+    // (24 - 5 = 19, allowing 1 row tolerance)
+    assert!(
+        row >= 18,
+        "Prompt should be at least 5 rows from bottom (row >= 18), got row {}",
+        row
+    );
+
+    // Run more commands to verify margin maintained consistently
+    for _ in 1..=3 {
+        terminal
+            .send_line("cat('\\n')")
+            .expect("Should send command");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    assert!(
+        row >= 18,
+        "Prompt should maintain 5-line margin after output, got row {}",
+        row
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test disabled margin allows prompt at bottom.
+///
+/// Verifies that with `bottom_margin = "disabled"`, the prompt can reach
+/// the bottom of the terminal (normal behavior).
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_disabled() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = "disabled"
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Fill the screen with output
+    for _ in 1..=30 {
+        terminal
+            .send_line("cat('\\n')")
+            .expect("Should send command");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With disabled margin, prompt should be able to reach near bottom
+    // (allowing for some scrollback, row should be >= 20 in 24-row terminal)
+    assert!(
+        row >= 20,
+        "With disabled margin, prompt should reach near bottom (row >= 20), got row {}",
+        row
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test proportional = 0.0 pins prompt to top.
+///
+/// Verifies that with `bottom_margin = { proportional = 0.0 }`, the
+/// prompt stays at the top of the terminal (row 0 or 1).
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_proportional_top() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ proportional = 0.0 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With 0.0 margin, prompt should be at top (row 0 or 1)
+    assert!(
+        row <= 2,
+        "With proportional = 0.0, prompt should be at top (row <= 2), got row {}",
+        row
+    );
+
+    // Run multiple commands and verify it stays at top
+    for i in 1..=5 {
+        terminal
+            .send_line(&format!("print({})", i))
+            .expect("Should send command");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after command");
+
+        let (row, _) = terminal
+            .cursor_position()
+            .expect("Should get cursor position");
+        assert!(
+            row <= 2,
+            "Prompt should stay at top after command {}, got row {}",
+            i,
+            row
+        );
+    }
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test fixed = 0 behaves like disabled (zero-cost).
+///
+/// Verifies that `bottom_margin = { fixed = 0 }` behaves the same as
+/// disabled - no margin, prompt reaches bottom.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_fixed_zero() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ fixed = 0 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Fill the screen with output
+    for _ in 1..=30 {
+        terminal
+            .send_line("cat('\\n')")
+            .expect("Should send command");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With fixed = 0, should behave like disabled
+    assert!(
+        row >= 20,
+        "With fixed = 0, prompt should reach near bottom (row >= 20), got row {}",
+        row
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test large fixed value clamps to terminal height.
+///
+/// Verifies that `bottom_margin = { fixed = 100 }` in a 24-row terminal
+/// clamps to 24 lines, resulting in prompt at top.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_large_fixed() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ fixed = 100 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With fixed=100 in 24-row terminal, should clamp to 24
+    // resulting in target_row = 0 (top of screen)
+    assert!(
+        row <= 2,
+        "With large fixed value, prompt should be at top (row <= 2), got row {}",
+        row
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test high proportional value (0.95) keeps prompt near top.
+///
+/// Verifies that `bottom_margin = { proportional = 0.95 }` keeps the
+/// prompt near the top by reserving only the bottom 5% of the terminal.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_high_proportional() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ proportional = 0.95 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--no-auto-match",
+        "--config",
+        &config_path.to_string_lossy(),
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    // With 0.95 margin in 24-row terminal, only bottom 5% is reserved
+    // So prompt should be at or above row 22 (allowing ±1 tolerance)
+    assert!(
+        row <= 23,
+        "With proportional = 0.95, prompt should be near top (row <= 23), got row {}",
+        row
+    );
+
+    // Run commands and verify it stays near top
+    for _ in 1..=3 {
+        terminal
+            .send_line("cat('\\n')")
+            .expect("Should send command");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let (row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    assert!(
+        row <= 23,
+        "Prompt should stay near top with high proportional, got row {}",
+        row
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test window resize adjusts margin correctly.
+///
+/// Verifies that with `bottom_margin = { proportional = 0.5 }` in a 24-row
+/// terminal, the prompt starts in the upper half. While we cannot actually
+/// resize the PTY during the test, we verify the margin is consistently
+/// recalculated across multiple prompts.
+#[test]
+#[cfg(unix)]
+fn test_pty_bottom_margin_resize_window() {
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("arf.toml");
+    let mut config_file =
+        std::fs::File::create(&config_path).expect("Failed to create config file");
+    writeln!(
+        config_file,
+        r#"
+[editor]
+bottom_margin = {{ proportional = 0.5 }}
+"#
+    )
+    .expect("Failed to write config");
+
+    // Start with 24-row terminal
+    let mut terminal = Terminal::spawn_with_size(
+        &[
+            "--no-auto-match",
+            "--config",
+            &config_path.to_string_lossy(),
+        ],
+        24,
+        80,
+    )
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Check initial position in 24-row terminal (should be <= row 12)
+    let (initial_row, _) = terminal
+        .cursor_position()
+        .expect("Should get cursor position");
+    assert!(
+        initial_row <= 13,
+        "Initial prompt should be in upper half of 24-row terminal (row <= 13), got row {}",
+        initial_row
+    );
+
+    // For a more robust test, we verify the margin is consistent across multiple prompts
+    for i in 1..=5 {
+        terminal
+            .send_line(&format!("print({})", i))
+            .expect("Should send command");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after command");
+
+        let (row, _) = terminal
+            .cursor_position()
+            .expect("Should get cursor position");
+        // Verify the margin is recalculated each prompt
+        assert!(
+            row <= 13,
+            "Prompt should maintain upper half position after command {}, got row {}",
+            i,
+            row
+        );
+    }
+
+    terminal.quit().expect("Should quit cleanly");
+}


### PR DESCRIPTION
- adds BottomMargin enum with Fixed, Proportional, and Disabled variants
- places config in [editor] section (not [prompt]) for terminal positioning control
- implements ensure_bottom_margin() with single ScrollUp call (not loop)
- early returns for disabled states: Fixed(0) and Proportional(>=1.0)
- clamps Fixed to terminal height and Proportional to 0.0-1.0 range
- derives Default trait idiomatically with #[default] attribute
- adds 4 unit tests for config parsing
- adds 8 PTY integration tests for cursor positioning verification
- updates JSON schema and snapshots

```toml
[editor]
# Proportional: reserve bottom fraction (0.0 = top, 1.0 = disabled)
bottom_margin = { proportional = 0.5 }
# Fixed: reserve exact line count
bottom_margin = { fixed = 10 }
# Disabled (default): no margin
bottom_margin = "disabled"
```

Implements #114 