### PR TITLE
refactor: separate pager side effects from `process_meta_command`

### DIFF
--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -468,6 +468,7 @@ mod tests {
         let config = default_prompt_config();
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let path = temp_file.path().to_path_buf();
+        let masked = mask_home_path(&path);
         let lines = generate_info_lines(
             &config,
             &Some(path),
@@ -480,6 +481,11 @@ mod tests {
             .iter()
             .find(|l| l.starts_with("Config file:"))
             .unwrap();
+        assert!(
+            config_line.contains(&masked),
+            "Existing path should contain the file path: {}",
+            config_line
+        );
         assert!(
             !config_line.contains("not found"),
             "Existing path should not say 'not found': {}",

--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -431,4 +431,136 @@ mod tests {
         let content = SessionInfoContent::new(lines);
         assert_eq!(content.line_count(), 2);
     }
+
+    // --- generate_info_lines config_path tests ---
+
+    use crate::editor::prompt::PromptFormatter;
+    use crate::repl::state::PromptRuntimeConfig;
+
+    fn default_prompt_config() -> PromptRuntimeConfig {
+        PromptRuntimeConfig::builder(PromptFormatter::default(), "r> ", "+  ", "[bash] $ ").build()
+    }
+
+    #[test]
+    fn test_generate_info_lines_config_path_none() {
+        let config = default_prompt_config();
+        let lines = generate_info_lines(
+            &config,
+            &None,
+            ConfigStatus::Ok,
+            &None,
+            &None,
+            &RSourceStatus::Path,
+        );
+        let config_line = lines
+            .iter()
+            .find(|l| l.starts_with("Config file:"))
+            .unwrap();
+        assert!(
+            config_line.contains("using defaults"),
+            "None path should show defaults: {}",
+            config_line
+        );
+    }
+
+    #[test]
+    fn test_generate_info_lines_config_path_existing() {
+        let config = default_prompt_config();
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        let lines = generate_info_lines(
+            &config,
+            &Some(path),
+            ConfigStatus::Ok,
+            &None,
+            &None,
+            &RSourceStatus::Path,
+        );
+        let config_line = lines
+            .iter()
+            .find(|l| l.starts_with("Config file:"))
+            .unwrap();
+        assert!(
+            !config_line.contains("not found"),
+            "Existing path should not say 'not found': {}",
+            config_line
+        );
+        assert!(
+            !config_line.contains("using defaults"),
+            "Existing path should not say 'using defaults': {}",
+            config_line
+        );
+    }
+
+    #[test]
+    fn test_generate_info_lines_config_path_nonexistent() {
+        let config = default_prompt_config();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("nonexistent_config.toml");
+        let lines = generate_info_lines(
+            &config,
+            &Some(path),
+            ConfigStatus::Ok,
+            &None,
+            &None,
+            &RSourceStatus::Path,
+        );
+        let config_line = lines
+            .iter()
+            .find(|l| l.starts_with("Config file:"))
+            .unwrap();
+        assert!(
+            config_line.contains("not found"),
+            "Non-existing path should say 'not found': {}",
+            config_line
+        );
+    }
+
+    #[test]
+    fn test_generate_info_lines_config_parse_error() {
+        let config = default_prompt_config();
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        let lines = generate_info_lines(
+            &config,
+            &Some(path),
+            ConfigStatus::ParseError,
+            &None,
+            &None,
+            &RSourceStatus::Path,
+        );
+        let config_line = lines
+            .iter()
+            .find(|l| l.starts_with("Config file:"))
+            .unwrap();
+        assert!(
+            config_line.contains("parse error"),
+            "Parse error should be shown: {}",
+            config_line
+        );
+    }
+
+    #[test]
+    fn test_generate_info_lines_config_read_error() {
+        let config = default_prompt_config();
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        let lines = generate_info_lines(
+            &config,
+            &Some(path),
+            ConfigStatus::ReadError,
+            &None,
+            &None,
+            &RSourceStatus::Path,
+        );
+        let config_line = lines
+            .iter()
+            .find(|l| l.starts_with("Config file:"))
+            .unwrap();
+        assert!(
+            config_line.contains("read error"),
+            "Read error should be shown: {}",
+            config_line
+        );
+    }
 }

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -1,12 +1,9 @@
 //! Meta command processing.
 
 use crate::completion::path::expand_tilde;
-use crate::config::{ConfigStatus, RSourceStatus};
+use crate::config::RSourceStatus;
 use crate::external::formatter;
-use crate::pager::{
-    HistoryBrowserResult, HistoryDbMode, display_changelog, display_session_info, run_help_browser,
-    run_history_browser, text_utils,
-};
+use crate::pager::HistoryDbMode;
 use reedline::{History, SqliteBackedHistory};
 use std::path::PathBuf;
 
@@ -26,6 +23,16 @@ pub enum MetaCommandResult {
     ShellExecuted,
     /// Restart the process with optional R version
     Restart(Option<String>),
+    /// Open the help browser with the given query (caller runs pager)
+    ShowHelpBrowser(String),
+    /// Display session info (caller runs pager)
+    ShowSessionInfo,
+    /// Display changelog (caller runs pager)
+    ShowChangelog,
+    /// Open the history browser (caller runs pager)
+    ShowHistoryBrowser { path: PathBuf, mode: HistoryDbMode },
+    /// Display history schema (caller runs pager)
+    ShowHistorySchema,
 }
 
 /// Process a meta command (starting with `:`) and return the result.
@@ -33,8 +40,6 @@ pub enum MetaCommandResult {
 pub fn process_meta_command(
     input: &str,
     prompt_config: &mut PromptRuntimeConfig,
-    config_path: &Option<PathBuf>,
-    config_status: ConfigStatus,
     r_history_path: &Option<PathBuf>,
     shell_history_path: &Option<PathBuf>,
     r_source_status: &RSourceStatus,
@@ -182,12 +187,7 @@ pub fn process_meta_command(
                         prompt_config.is_shell_enabled(),
                     )
                 }
-                "schema" => {
-                    if let Err(e) = crate::pager::history_schema::show_schema_pager() {
-                        arf_println!("Error: {}", e);
-                    }
-                    Some(MetaCommandResult::Handled)
-                }
+                "schema" => Some(MetaCommandResult::ShowHistorySchema),
                 "" => {
                     arf_println!("Usage: :history <subcommand>");
                     println!("#   browse - Browse and manage command history");
@@ -208,34 +208,10 @@ pub fn process_meta_command(
             // Fuzzy help search for R documentation
             // Inspired by the felp package: https://github.com/atusy/felp
             let query = parts.get(1..).map(|p| p.join(" ")).unwrap_or_default();
-            // Mark alternate mode so IPC requests are rejected immediately
-            // instead of hanging. Save and restore the previous state so that
-            // nested alternate modes (e.g., help inside shell mode) are not
-            // clobbered. No RAII guard: a panic here aborts the process.
-            let was_alternate = crate::ipc::is_in_alternate_mode();
-            crate::ipc::set_in_alternate_mode(true);
-            let help_result = run_help_browser(&query);
-            crate::ipc::set_in_alternate_mode(was_alternate);
-            if let Err(e) = help_result {
-                arf_println!("Error in help browser: {}", e);
-            }
-            Some(MetaCommandResult::Handled)
+            Some(MetaCommandResult::ShowHelpBrowser(query))
         }
-        "info" | "session" => {
-            display_session_info(
-                prompt_config,
-                config_path,
-                config_status,
-                r_history_path,
-                shell_history_path,
-                r_source_status,
-            );
-            Some(MetaCommandResult::Handled)
-        }
-        "changelog" => {
-            display_changelog();
-            Some(MetaCommandResult::Handled)
-        }
+        "info" | "session" => Some(MetaCommandResult::ShowSessionInfo),
+        "changelog" => Some(MetaCommandResult::ShowChangelog),
         "cd" => {
             let path_arg = trimmed[1..].strip_prefix("cd").unwrap_or("").trim();
             match meta_cd(path_arg) {
@@ -357,28 +333,10 @@ fn process_history_browse(
         return Some(MetaCommandResult::Handled);
     };
 
-    // Mark alternate mode so IPC requests are rejected immediately
-    // instead of hanging. Save and restore the previous state so that
-    // nested alternate modes (e.g., history inside shell mode) are not
-    // clobbered. No RAII guard: a panic here aborts the process.
-    let was_alternate = crate::ipc::is_in_alternate_mode();
-    crate::ipc::set_in_alternate_mode(true);
-    let browser_result = run_history_browser(db_path, mode);
-    crate::ipc::set_in_alternate_mode(was_alternate);
-
-    match browser_result {
-        Ok(HistoryBrowserResult::Copied(cmd)) => {
-            // Truncate long commands for display (display-width aware)
-            let display = text_utils::truncate_to_width(&cmd, 60);
-            arf_println!("Copied: {}", display);
-            Some(MetaCommandResult::Handled)
-        }
-        Ok(HistoryBrowserResult::Cancelled) => Some(MetaCommandResult::Handled),
-        Err(e) => {
-            arf_println!("Error: {}", e);
-            Some(MetaCommandResult::Handled)
-        }
-    }
+    Some(MetaCommandResult::ShowHistoryBrowser {
+        path: db_path.clone(),
+        mode,
+    })
 }
 
 /// Process :history clear command.
@@ -566,7 +524,6 @@ mod tests {
     fn call_meta(
         input: &str,
         config: &mut PromptRuntimeConfig,
-        config_path: &Option<PathBuf>,
         r_history_path: &Option<PathBuf>,
         shell_history_path: &Option<PathBuf>,
         status: &RSourceStatus,
@@ -575,8 +532,6 @@ mod tests {
         process_meta_command(
             input,
             config,
-            config_path,
-            ConfigStatus::Ok,
             r_history_path,
             shell_history_path,
             status,
@@ -589,7 +544,7 @@ mod tests {
     fn test_process_meta_command_not_meta() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta("print(x)", &mut config, &None, &None, &None, &status);
+        let result = call_meta("print(x)", &mut config, &None, &None, &status);
         assert!(result.is_none());
     }
 
@@ -599,11 +554,11 @@ mod tests {
         let status = default_r_source_status();
         assert!(!config.is_reprex_enabled());
 
-        let result = call_meta(":reprex", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":reprex", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(config.is_reprex_enabled());
 
-        let result = call_meta(":reprex", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":reprex", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(!config.is_reprex_enabled());
     }
@@ -612,72 +567,34 @@ mod tests {
     fn test_process_meta_command_commands() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":commands", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":commands", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
 
         // Test alias
-        let result = call_meta(":cmds", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":cmds", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
     }
 
     #[test]
-    #[cfg_attr(windows, ignore)] // Windows CI lacks terminal for interactive pager
     fn test_process_meta_command_info() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":info", &mut config, &None, &None, &None, &status);
-        assert!(matches!(result, Some(MetaCommandResult::Handled)));
+        let result = call_meta(":info", &mut config, &None, &None, &status);
+        assert!(matches!(result, Some(MetaCommandResult::ShowSessionInfo)));
 
         // Test alias
-        let result = call_meta(":session", &mut config, &None, &None, &None, &status);
-        assert!(matches!(result, Some(MetaCommandResult::Handled)));
-    }
-
-    #[test]
-    #[cfg_attr(windows, ignore)] // Windows CI lacks terminal for interactive pager
-    fn test_process_meta_command_info_with_config_path() {
-        let mut config = create_test_prompt_config();
-        let status = default_r_source_status();
-
-        // Test with existing config path (using tempfile)
-        let temp_file = tempfile::NamedTempFile::new().unwrap();
-        let existing_path = temp_file.path().to_path_buf();
-        let result = call_meta(
-            ":info",
-            &mut config,
-            &Some(existing_path),
-            &None,
-            &None,
-            &status,
-        );
-        assert!(matches!(result, Some(MetaCommandResult::Handled)));
-
-        // Test with non-existing config path (using tempfile directory with fake filename)
-        let temp_dir = tempfile::tempdir().unwrap();
-        let non_existing_path = temp_dir.path().join("nonexistent_config.toml");
-        let result = call_meta(
-            ":info",
-            &mut config,
-            &Some(non_existing_path),
-            &None,
-            &None,
-            &status,
-        );
-        assert!(matches!(result, Some(MetaCommandResult::Handled)));
-
-        // Test with None config path (using defaults)
-        let result = call_meta(":info", &mut config, &None, &None, &None, &status);
-        assert!(matches!(result, Some(MetaCommandResult::Handled)));
+        let result = call_meta(":session", &mut config, &None, &None, &status);
+        assert!(matches!(result, Some(MetaCommandResult::ShowSessionInfo)));
     }
 
     #[test]
     fn test_process_meta_command_quit() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":quit", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":quit", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Exit)));
 
-        let result = call_meta(":exit", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":exit", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Exit)));
     }
 
@@ -685,7 +602,7 @@ mod tests {
     fn test_process_meta_command_unknown() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":unknown", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":unknown", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Unknown(_))));
     }
 
@@ -693,7 +610,7 @@ mod tests {
     fn test_process_meta_command_empty_colon() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
     }
 
@@ -701,7 +618,7 @@ mod tests {
     fn test_process_meta_command_with_whitespace() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta("  :reprex  ", &mut config, &None, &None, &None, &status);
+        let result = call_meta("  :reprex  ", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(config.is_reprex_enabled());
     }
@@ -712,7 +629,7 @@ mod tests {
         let status = default_r_source_status();
         assert!(!config.is_shell_enabled());
 
-        let result = call_meta(":shell", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":shell", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(config.is_shell_enabled());
     }
@@ -724,7 +641,7 @@ mod tests {
         config.set_shell(true);
         assert!(config.is_shell_enabled());
 
-        let result = call_meta(":r", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":r", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(!config.is_shell_enabled());
     }
@@ -736,7 +653,7 @@ mod tests {
         config.set_shell(true);
         assert!(config.is_shell_enabled());
 
-        let result = call_meta(":R", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":R", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(!config.is_shell_enabled());
     }
@@ -747,7 +664,7 @@ mod tests {
         let status = default_r_source_status();
         assert!(!config.is_shell_enabled());
 
-        let result = call_meta(":r", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":r", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert!(!config.is_shell_enabled()); // Still not in shell
     }
@@ -756,14 +673,7 @@ mod tests {
     fn test_process_meta_command_system() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(
-            ":system echo hello",
-            &mut config,
-            &None,
-            &None,
-            &None,
-            &status,
-        );
+        let result = call_meta(":system echo hello", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::ShellExecuted)));
     }
 
@@ -771,7 +681,7 @@ mod tests {
     fn test_process_meta_command_system_empty() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta(":system", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":system", &mut config, &None, &None, &status);
         // Empty :system should still be handled
         assert!(matches!(result, Some(MetaCommandResult::ShellExecuted)));
     }
@@ -782,14 +692,7 @@ mod tests {
 
         // With PATH mode (rig not enabled), :switch should show error
         let status_path = RSourceStatus::Path;
-        let result = call_meta(
-            ":switch 4.4",
-            &mut config,
-            &None,
-            &None,
-            &None,
-            &status_path,
-        );
+        let result = call_meta(":switch 4.4", &mut config, &None, &None, &status_path);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
 
         // With Rig mode (rig enabled), :switch should work (but needs confirmation which we can't test here)
@@ -799,7 +702,7 @@ mod tests {
         };
         // Note: This will prompt for confirmation, so we can't fully test it in unit tests
         // Just testing the setup path here
-        let result = call_meta(":switch", &mut config, &None, &None, &None, &status_rig);
+        let result = call_meta(":switch", &mut config, &None, &None, &status_rig);
         // Without version argument, it should show usage
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
     }
@@ -940,8 +843,6 @@ mod tests {
             &format!(":cd {}", tmp.path().display()),
             &mut config,
             &None,
-            ConfigStatus::Ok,
-            &None,
             &None,
             &status,
             &mut dir_stack,
@@ -962,8 +863,6 @@ mod tests {
             &format!(":pushd {}", tmp.path().display()),
             &mut config,
             &None,
-            ConfigStatus::Ok,
-            &None,
             &None,
             &status,
             &mut dir_stack,
@@ -975,8 +874,6 @@ mod tests {
         let result = process_meta_command(
             ":popd",
             &mut config,
-            &None,
-            ConfigStatus::Ok,
             &None,
             &None,
             &status,
@@ -1022,7 +919,7 @@ mod tests {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         // :restart! should skip confirmation and return Restart directly
-        let result = call_meta(":restart!", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":restart!", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Restart(None))));
     }
 
@@ -1030,7 +927,7 @@ mod tests {
     fn test_process_meta_command_restart_force_with_whitespace() {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
-        let result = call_meta("  :restart!  ", &mut config, &None, &None, &None, &status);
+        let result = call_meta("  :restart!  ", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Restart(None))));
     }
 
@@ -1040,14 +937,7 @@ mod tests {
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
         };
-        let result = call_meta(
-            ":switch! 4.4",
-            &mut config,
-            &None,
-            &None,
-            &None,
-            &status_rig,
-        );
+        let result = call_meta(":switch! 4.4", &mut config, &None, &None, &status_rig);
         assert!(matches!(result, Some(MetaCommandResult::Restart(Some(ref v))) if v == "4.4"));
     }
 
@@ -1058,7 +948,7 @@ mod tests {
             version: "4.4.0".to_string(),
         };
         // :switch! without version should still show usage
-        let result = call_meta(":switch!", &mut config, &None, &None, &None, &status_rig);
+        let result = call_meta(":switch!", &mut config, &None, &None, &status_rig);
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
     }
 
@@ -1067,7 +957,7 @@ mod tests {
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         // :shell! is not a valid command (! only supported on restart/switch)
-        let result = call_meta(":shell!", &mut config, &None, &None, &None, &status);
+        let result = call_meta(":shell!", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Unknown(_))));
     }
 }

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -699,18 +699,20 @@ impl Repl {
                                 continue;
                             }
                             MetaCommandResult::ShowSessionInfo => {
-                                crate::pager::display_session_info(
-                                    &prompt_config,
-                                    &self.config_path,
-                                    self.config_status,
-                                    &r_history_path,
-                                    &shell_history_path,
-                                    &self.r_source_status,
-                                );
+                                with_ipc_alternate_guard(|| {
+                                    crate::pager::display_session_info(
+                                        &prompt_config,
+                                        &self.config_path,
+                                        self.config_status,
+                                        &r_history_path,
+                                        &shell_history_path,
+                                        &self.r_source_status,
+                                    );
+                                });
                                 continue;
                             }
                             MetaCommandResult::ShowChangelog => {
-                                crate::pager::display_changelog();
+                                with_ipc_alternate_guard(crate::pager::display_changelog);
                                 continue;
                             }
                             MetaCommandResult::ShowHistoryBrowser { path, mode } => {
@@ -718,7 +720,9 @@ impl Repl {
                                 continue;
                             }
                             MetaCommandResult::ShowHistorySchema => {
-                                if let Err(e) = crate::pager::history_schema::show_schema_pager() {
+                                if let Err(e) = with_ipc_alternate_guard(
+                                    crate::pager::history_schema::show_schema_pager,
+                                ) {
                                     arf_println!("Error: {}", e);
                                 }
                                 continue;
@@ -1069,18 +1073,20 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                                 continue;
                             }
                             MetaCommandResult::ShowSessionInfo => {
-                                crate::pager::display_session_info(
-                                    &state.prompt_config,
-                                    &state.config_path,
-                                    state.config_status,
-                                    &state.r_history_path,
-                                    &state.shell_history_path,
-                                    &state.r_source_status,
-                                );
+                                with_ipc_alternate_guard(|| {
+                                    crate::pager::display_session_info(
+                                        &state.prompt_config,
+                                        &state.config_path,
+                                        state.config_status,
+                                        &state.r_history_path,
+                                        &state.shell_history_path,
+                                        &state.r_source_status,
+                                    );
+                                });
                                 continue;
                             }
                             MetaCommandResult::ShowChangelog => {
-                                crate::pager::display_changelog();
+                                with_ipc_alternate_guard(crate::pager::display_changelog);
                                 continue;
                             }
                             MetaCommandResult::ShowHistoryBrowser { path, mode } => {
@@ -1088,7 +1094,9 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                                 continue;
                             }
                             MetaCommandResult::ShowHistorySchema => {
-                                if let Err(e) = crate::pager::history_schema::show_schema_pager() {
+                                if let Err(e) = with_ipc_alternate_guard(
+                                    crate::pager::history_schema::show_schema_pager,
+                                ) {
                                     arf_println!("Error: {}", e);
                                 }
                                 continue;
@@ -1266,12 +1274,21 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
     })
 }
 
-/// Run the help browser pager, wrapping with IPC alternate mode.
-fn run_pager_help_browser(query: &str) {
+/// Run a closure with IPC alternate mode enabled, restoring the previous state afterward.
+///
+/// Pagers that enter crossterm's alternate screen must be wrapped with this guard
+/// so that IPC requests are rejected immediately instead of hanging.
+fn with_ipc_alternate_guard<R>(f: impl FnOnce() -> R) -> R {
     let was_alternate = crate::ipc::is_in_alternate_mode();
     crate::ipc::set_in_alternate_mode(true);
-    let help_result = crate::pager::run_help_browser(query);
+    let result = f();
     crate::ipc::set_in_alternate_mode(was_alternate);
+    result
+}
+
+/// Run the help browser pager, wrapping with IPC alternate mode.
+fn run_pager_help_browser(query: &str) {
+    let help_result = with_ipc_alternate_guard(|| crate::pager::run_help_browser(query));
     if let Err(e) = help_result {
         arf_println!("Error in help browser: {}", e);
     }
@@ -1279,10 +1296,7 @@ fn run_pager_help_browser(query: &str) {
 
 /// Run the history browser pager, wrapping with IPC alternate mode.
 fn run_pager_history_browser(path: &std::path::Path, mode: crate::pager::HistoryDbMode) {
-    let was_alternate = crate::ipc::is_in_alternate_mode();
-    crate::ipc::set_in_alternate_mode(true);
-    let browser_result = crate::pager::run_history_browser(path, mode);
-    crate::ipc::set_in_alternate_mode(was_alternate);
+    let browser_result = with_ipc_alternate_guard(|| crate::pager::run_history_browser(path, mode));
 
     match browser_result {
         Ok(crate::pager::HistoryBrowserResult::Copied(cmd)) => {

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1278,7 +1278,7 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
 ///
 /// Pagers that enter crossterm's alternate screen must be wrapped with this guard
 /// so that IPC requests are rejected immediately instead of hanging.
-/// Using a drop guard ensures the state is restored even if the closure panics.
+/// The drop guard also restores the state on panic unwind (where the panic strategy permits it).
 struct IpcAlternateGuard {
     was_alternate: bool,
 }

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1274,16 +1274,33 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
     })
 }
 
-/// Run a closure with IPC alternate mode enabled, restoring the previous state afterward.
+/// RAII guard that sets IPC alternate mode on creation and restores the previous state on drop.
 ///
 /// Pagers that enter crossterm's alternate screen must be wrapped with this guard
 /// so that IPC requests are rejected immediately instead of hanging.
+/// Using a drop guard ensures the state is restored even if the closure panics.
+struct IpcAlternateGuard {
+    was_alternate: bool,
+}
+
+impl IpcAlternateGuard {
+    fn new() -> Self {
+        let was_alternate = crate::ipc::is_in_alternate_mode();
+        crate::ipc::set_in_alternate_mode(true);
+        Self { was_alternate }
+    }
+}
+
+impl Drop for IpcAlternateGuard {
+    fn drop(&mut self) {
+        crate::ipc::set_in_alternate_mode(self.was_alternate);
+    }
+}
+
+/// Run a closure with IPC alternate mode enabled, restoring the previous state afterward.
 fn with_ipc_alternate_guard<R>(f: impl FnOnce() -> R) -> R {
-    let was_alternate = crate::ipc::is_in_alternate_mode();
-    crate::ipc::set_in_alternate_mode(true);
-    let result = f();
-    crate::ipc::set_in_alternate_mode(was_alternate);
-    result
+    let _guard = IpcAlternateGuard::new();
+    f()
 }
 
 /// Run the help browser pager, wrapping with IPC alternate mode.

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -663,8 +663,6 @@ impl Repl {
                     if let Some(result) = process_meta_command(
                         &line,
                         &mut prompt_config,
-                        &self.config_path,
-                        self.config_status,
                         &r_history_path,
                         &shell_history_path,
                         &self.r_source_status,
@@ -694,6 +692,35 @@ impl Repl {
                             }
                             MetaCommandResult::Restart(version) => {
                                 restart_process(version.as_deref());
+                                continue;
+                            }
+                            MetaCommandResult::ShowHelpBrowser(query) => {
+                                run_pager_help_browser(&query);
+                                continue;
+                            }
+                            MetaCommandResult::ShowSessionInfo => {
+                                crate::pager::display_session_info(
+                                    &prompt_config,
+                                    &self.config_path,
+                                    self.config_status,
+                                    &r_history_path,
+                                    &shell_history_path,
+                                    &self.r_source_status,
+                                );
+                                continue;
+                            }
+                            MetaCommandResult::ShowChangelog => {
+                                crate::pager::display_changelog();
+                                continue;
+                            }
+                            MetaCommandResult::ShowHistoryBrowser { path, mode } => {
+                                run_pager_history_browser(&path, mode);
+                                continue;
+                            }
+                            MetaCommandResult::ShowHistorySchema => {
+                                if let Err(e) = crate::pager::history_schema::show_schema_pager() {
+                                    arf_println!("Error: {}", e);
+                                }
                                 continue;
                             }
                         }
@@ -1001,8 +1028,6 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                     if let Some(result) = process_meta_command(
                         &line,
                         &mut state.prompt_config,
-                        &state.config_path,
-                        state.config_status,
                         &state.r_history_path,
                         &state.shell_history_path,
                         &state.r_source_status,
@@ -1037,6 +1062,35 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                                 restart_process(version.as_deref());
                                 // If restart_process returns, it means exec failed
                                 // Continue with the current session
+                                continue;
+                            }
+                            MetaCommandResult::ShowHelpBrowser(query) => {
+                                run_pager_help_browser(&query);
+                                continue;
+                            }
+                            MetaCommandResult::ShowSessionInfo => {
+                                crate::pager::display_session_info(
+                                    &state.prompt_config,
+                                    &state.config_path,
+                                    state.config_status,
+                                    &state.r_history_path,
+                                    &state.shell_history_path,
+                                    &state.r_source_status,
+                                );
+                                continue;
+                            }
+                            MetaCommandResult::ShowChangelog => {
+                                crate::pager::display_changelog();
+                                continue;
+                            }
+                            MetaCommandResult::ShowHistoryBrowser { path, mode } => {
+                                run_pager_history_browser(&path, mode);
+                                continue;
+                            }
+                            MetaCommandResult::ShowHistorySchema => {
+                                if let Err(e) = crate::pager::history_schema::show_schema_pager() {
+                                    arf_println!("Error: {}", e);
+                                }
                                 continue;
                             }
                         }
@@ -1210,6 +1264,36 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
             }
         }
     })
+}
+
+/// Run the help browser pager, wrapping with IPC alternate mode.
+fn run_pager_help_browser(query: &str) {
+    let was_alternate = crate::ipc::is_in_alternate_mode();
+    crate::ipc::set_in_alternate_mode(true);
+    let help_result = crate::pager::run_help_browser(query);
+    crate::ipc::set_in_alternate_mode(was_alternate);
+    if let Err(e) = help_result {
+        arf_println!("Error in help browser: {}", e);
+    }
+}
+
+/// Run the history browser pager, wrapping with IPC alternate mode.
+fn run_pager_history_browser(path: &std::path::Path, mode: crate::pager::HistoryDbMode) {
+    let was_alternate = crate::ipc::is_in_alternate_mode();
+    crate::ipc::set_in_alternate_mode(true);
+    let browser_result = crate::pager::run_history_browser(path, mode);
+    crate::ipc::set_in_alternate_mode(was_alternate);
+
+    match browser_result {
+        Ok(crate::pager::HistoryBrowserResult::Copied(cmd)) => {
+            let display = crate::pager::text_utils::truncate_to_width(&cmd, 60);
+            arf_println!("Copied: {}", display);
+        }
+        Ok(crate::pager::HistoryBrowserResult::Cancelled) => {}
+        Err(e) => {
+            arf_println!("Error: {}", e);
+        }
+    }
 }
 
 /// Check if the prompt is R's standard command prompt (top-level).


### PR DESCRIPTION
## Summary
- Move interactive pager invocations (help browser, session info, changelog, history browser/schema) out of `process_meta_command` into the REPL caller via new `MetaCommandResult` variants
- Fixes `cargo test` hanging when meta-command tests (`:info`, `:session`, etc.) trigger crossterm pagers that open `/dev/tty` directly for keyboard input
- Add RAII `IpcAlternateGuard` to ensure all pager calls are wrapped with IPC alternate-mode protection (panic-safe)
- Add unit tests for `generate_info_lines` config-path branches to restore deleted coverage

## Known issue / Follow-up
- The `MetaCommandResult` match arms are duplicated across `Repl::run` and `read_console_callback`. Extracting a shared helper is planned as a follow-up to keep this PR focused on the test-hang fix.

## Test plan
- [x] `cargo test -p arf-console --bin arf -- meta_command` — 65 tests pass in 0.10s (no hang)
- [x] `cargo test -p arf-console --bin arf -- session_info` — 16 tests pass including 5 new config-path tests
- [x] `cargo fmt` and `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)