### PR TITLE
fix: do not use prefix cache when token extends by structural operator

### DIFF
--- a/crates/arf-console/src/completion/r_completer.rs
+++ b/crates/arf-console/src/completion/r_completer.rs
@@ -1387,6 +1387,20 @@ mod tests {
     }
 
     #[test]
+    fn test_is_prefix_extension_bracket_not_extension() {
+        // "l[" extends "l" by "[" — bracket access changes completion context
+        let c = completer_with_cache("l", vec!["list".to_string()]);
+        assert!(!c.is_prefix_extension("l["));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_colon_not_extension() {
+        // "pkg::foo" extends "pkg:" by ":foo" — namespace operator, fresh fetch needed
+        let c = completer_with_cache("pkg:", vec!["pkg::foo".to_string()]);
+        assert!(!c.is_prefix_extension("pkg::foo"));
+    }
+
+    #[test]
     fn test_is_prefix_extension_no_cache() {
         let c = RCompleter::new();
         assert!(!c.is_prefix_extension("pri"));

--- a/crates/arf-console/src/completion/r_completer.rs
+++ b/crates/arf-console/src/completion/r_completer.rs
@@ -344,21 +344,19 @@ impl RCompleter {
     /// Check if the new token extends the cached token (prefix extension).
     fn is_prefix_extension(&self, new_token: &str) -> bool {
         if let Some(cache) = &self.cache {
-            // New token must start with the cached token
-            // e.g., "pri" extends "pr", but "po" does not
-            if !new_token.starts_with(&cache.token) || new_token == cache.token {
-                return false;
-            }
             // Only reuse the cache when the extension consists solely of identifier
             // characters (alphanumeric, `.`, `_`).  Structural operators such as `$`,
             // `@`, `[`, or `:` change the completion context entirely, so a fresh
             // fetch is required.
             // Example: "l$a$" extends "l$" by "a$" — the `$` means we are now
             // completing inside a nested list and the old completions are irrelevant.
-            let extension = &new_token[cache.token.len()..];
-            extension
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '.' || c == '_')
+            let Some(extension) = new_token.strip_prefix(cache.token.as_str()) else {
+                return false;
+            };
+            !extension.is_empty()
+                && extension
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '.' || c == '_')
         } else {
             false
         }

--- a/crates/arf-console/src/completion/r_completer.rs
+++ b/crates/arf-console/src/completion/r_completer.rs
@@ -346,7 +346,19 @@ impl RCompleter {
         if let Some(cache) = &self.cache {
             // New token must start with the cached token
             // e.g., "pri" extends "pr", but "po" does not
-            new_token.starts_with(&cache.token) && new_token != cache.token
+            if !new_token.starts_with(&cache.token) || new_token == cache.token {
+                return false;
+            }
+            // Only reuse the cache when the extension consists solely of identifier
+            // characters (alphanumeric, `.`, `_`).  Structural operators such as `$`,
+            // `@`, `[`, or `:` change the completion context entirely, so a fresh
+            // fetch is required.
+            // Example: "l$a$" extends "l$" by "a$" — the `$` means we are now
+            // completing inside a nested list and the old completions are irrelevant.
+            let extension = &new_token[cache.token.len()..];
+            extension
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '.' || c == '_')
         } else {
             false
         }
@@ -1320,5 +1332,63 @@ mod tests {
                 start_pos: 8,
             })
         );
+    }
+
+    // --- Prefix extension cache tests ---
+
+    fn completer_with_cache(token: &str, completions: Vec<String>) -> RCompleter {
+        let mut c = RCompleter::new();
+        c.cache = Some(CompletionCache {
+            token: token.to_string(),
+            completions,
+            timestamp: Instant::now(),
+        });
+        c
+    }
+
+    #[test]
+    fn test_is_prefix_extension_identifier_only() {
+        // "pri" extends "pr" — pure identifier extension, cache is valid
+        let c = completer_with_cache("pr", vec!["print".to_string()]);
+        assert!(c.is_prefix_extension("pri"));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_dot_underscore() {
+        // "my_f" extends "my_" and "st.g" extends "st." — dots/underscores are ok
+        let c = completer_with_cache("my_", vec!["my_func".to_string()]);
+        assert!(c.is_prefix_extension("my_f"));
+
+        let c = completer_with_cache("st.", vec!["st.geo".to_string()]);
+        assert!(c.is_prefix_extension("st.g"));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_dollar_sign_not_extension() {
+        // "l$a$" extends "l$" by "a$" — the `$` means a new $ access context;
+        // cached completions for "l$" ([l$a, l$b]) are irrelevant for "l$a$".
+        // This is the nested-list completion bug: must return false so fresh
+        // completions are fetched.
+        let c = completer_with_cache("l$", vec!["l$a".to_string(), "l$b".to_string()]);
+        assert!(!c.is_prefix_extension("l$a$"));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_at_sign_not_extension() {
+        // "obj@field$" extends "obj@" by "field$" — structural operator
+        let c = completer_with_cache("obj@", vec!["obj@slot".to_string()]);
+        assert!(!c.is_prefix_extension("obj@slot$"));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_same_token_not_extension() {
+        let c = completer_with_cache("pri", vec!["print".to_string()]);
+        assert!(!c.is_prefix_extension("pri"));
+    }
+
+    #[test]
+    fn test_is_prefix_extension_no_cache() {
+        let c = RCompleter::new();
+        assert!(!c.is_prefix_extension("pri"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #149: nested list autocomplete (`l$a$`) returning "NO RECORDS FOUND".

- After completing `l$` (cache: token=`"l$"`, completions=`["l$a","l$b"]`), typing `$` to form `l$a$` caused `is_prefix_extension` to return `true` because `"l$a$".starts_with("l$")`. The subsequent `filter_cached("l$a$")` found no matches and returned empty → NO RECORDS FOUND.
- **Fix**: `is_prefix_extension` now only returns `true` when every character added beyond the cached token is an identifier character (alphanumeric, `.`, `_`). Structural operators (`$`, `@`, `[`, `:`) indicate a new completion context and require a fresh R fetch.

## Test plan

- [x] New unit tests: `test_is_prefix_extension_{dollar_sign,at_sign,bracket,colon}_not_extension`
- [x] All existing tests pass (`cargo test -p arf-console`)
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Manual: assign `l <- list(a = list(d=1, e=4), b=list(f=3, g=4))`, type `l$` + Tab, select `l$a`, type `$` + Tab → should show `d` and `e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)