### PR TITLE
feat!: remove positional script argument, keep -f/--file only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- **Breaking:** Positional script argument (`arf file.R`) has been removed. Use `-f`/`--file` instead: `arf -f file.R`
+
 ### Fixed
 
 - **Experimental:** Place IPC Unix socket in `$XDG_RUNTIME_DIR/arf/` instead of `~/.cache/arf/sessions/`, which is the correct XDG location for runtime sockets. Falls back to a randomized temporary directory when `XDG_RUNTIME_DIR` is not set (e.g. macOS). The socket directory is now validated for safe ownership and permissions

--- a/crates/arf-console/src/cli.rs
+++ b/crates/arf-console/src/cli.rs
@@ -13,16 +13,12 @@ use std::path::PathBuf;
 #[command(name = "arf")]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// R script file to execute (non-interactive mode)
-    #[arg(value_hint = ValueHint::FilePath, conflicts_with = "file")]
-    pub script: Option<PathBuf>,
-
     /// Evaluate R expression and exit
     #[arg(short = 'e', long = "eval")]
     pub eval: Option<String>,
 
-    /// [R] Take input from FILE (same as positional SCRIPT argument)
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath, conflicts_with = "script", hide_short_help = true)]
+    /// [R] Take input from FILE
+    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath, hide_short_help = true)]
     pub file: Option<PathBuf>,
 
     /// Enable reprex mode (no prompt, output prefixed with #>)
@@ -792,9 +788,9 @@ impl Cli {
         Some(values)
     }
 
-    /// Returns the script file path from either `-f`/`--file` or the positional argument.
+    /// Returns the script file path from `-f`/`--file`.
     pub fn script_file(&self) -> Option<&PathBuf> {
-        self.script.as_ref().or(self.file.as_ref())
+        self.file.as_ref()
     }
 
     /// Generate R initialization arguments based on CLI flags.

--- a/crates/arf-console/src/cli.rs
+++ b/crates/arf-console/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     pub eval: Option<String>,
 
     /// [R] Take input from FILE
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath, hide_short_help = true)]
+    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath, conflicts_with = "eval", hide_short_help = true)]
     pub file: Option<PathBuf>,
 
     /// Enable reprex mode (no prompt, output prefixed with #>)

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -278,6 +278,22 @@ fn run() -> Result<()> {
     // detection that could miss global options before the subcommand.
     let cli = Cli::parse();
 
+    // Reject combinations of -f/--file or -e/--eval with a subcommand.
+    // clap cannot enforce this via conflicts_with because subcommand fields are
+    // not referenceable as argument IDs in the derive API.
+    if (cli.eval.is_some() || cli.file.is_some()) && cli.command.is_some() {
+        let flag = if cli.eval.is_some() {
+            "--eval"
+        } else {
+            "--file"
+        };
+        let err = clap::Command::new("arf").error(
+            clap::error::ErrorKind::ArgumentConflict,
+            format!("the argument '{flag}' cannot be used with a subcommand"),
+        );
+        err.exit();
+    }
+
     // Extract log_file from headless command (if applicable) and initialize
     // the logger once. Non-headless modes use the default stderr target.
     // In headless mode, also redirect stderr to the log file so that all

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -18,7 +18,7 @@ mod traps;
 mod test_utils;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use cli::{Cli, Commands, ConfigAction, HistoryAction, ImportSource, IpcAction, RArgsBuilder};
 use config::{
     Config, ConfigLoadError, ConfigStatus, RSource, RSourceMode, RSourceStatus, config_file_path,
@@ -287,11 +287,12 @@ fn run() -> Result<()> {
         } else {
             "--file"
         };
-        let err = clap::Command::new("arf").error(
-            clap::error::ErrorKind::ArgumentConflict,
-            format!("the argument '{flag}' cannot be used with a subcommand"),
-        );
-        err.exit();
+        Cli::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                format!("the argument '{flag}' cannot be used with a subcommand"),
+            )
+            .exit();
     }
 
     // Extract log_file from headless command (if applicable) and initialize

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -287,10 +287,18 @@ fn run() -> Result<()> {
         } else {
             "--file"
         };
+        let subcommand = match &cli.command {
+            Some(Commands::Completions { .. }) => "completions",
+            Some(Commands::Config { .. }) => "config",
+            Some(Commands::History { .. }) => "history",
+            Some(Commands::Ipc { .. }) => "ipc",
+            Some(Commands::Headless { .. }) => "headless",
+            None => unreachable!(),
+        };
         Cli::command()
             .error(
                 clap::error::ErrorKind::ArgumentConflict,
-                format!("the argument '{flag}' cannot be used with a subcommand"),
+                format!("the argument '{flag}' cannot be used with subcommand '{subcommand}'"),
             )
             .exit();
     }

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -180,7 +180,7 @@ _arf() {
 
     case "${cmd}" in
         arf)
-            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --no-banner --with-r-version --r-home --vanilla --quiet --no-save --save --no-restore --no-restore-data --restore-data --no-environ --no-site-file --no-init-file --interactive --no-echo --slave --restore --verbose --encoding --max-connections --max-ppsize --min-nsize --min-vsize --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --no-auto-match --no-completion --history-dir --no-history --help --version [SCRIPT] completions config history ipc headless help"
+            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --no-banner --with-r-version --r-home --vanilla --quiet --no-save --save --no-restore --no-restore-data --restore-data --no-environ --no-site-file --no-init-file --interactive --no-echo --slave --restore --verbose --encoding --max-connections --max-ppsize --min-nsize --min-vsize --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --no-auto-match --no-completion --history-dir --no-history --help --version completions config history ipc headless help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
@@ -29,7 +29,7 @@ function __fish_arf_using_subcommand
 end
 
 complete -c arf -n "__fish_arf_needs_command" -s e -l eval -d 'Evaluate R expression and exit' -r
-complete -c arf -n "__fish_arf_needs_command" -s f -l file -d '[R] Take input from FILE (same as positional SCRIPT argument)' -r -F
+complete -c arf -n "__fish_arf_needs_command" -s f -l file -d '[R] Take input from FILE' -r -F
 complete -c arf -n "__fish_arf_needs_command" -s c -l config -d 'Path to configuration file' -r -F
 complete -c arf -n "__fish_arf_needs_command" -l with-r-version -d 'R version to use via rig (overrides r_source config)' -r
 complete -c arf -n "__fish_arf_needs_command" -l r-home -d 'Explicit R_HOME path (overrides r_source config)' -r -f -a "(__fish_complete_directories)"
@@ -70,12 +70,12 @@ complete -c arf -n "__fish_arf_needs_command" -l no-completion -d 'Disable compl
 complete -c arf -n "__fish_arf_needs_command" -l no-history -d 'Disable history (no history saved or loaded)'
 complete -c arf -n "__fish_arf_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_needs_command" -s V -l version -d 'Print version'
-complete -c arf -n "__fish_arf_needs_command" -a "completions" -d 'Generate shell completion scripts'
-complete -c arf -n "__fish_arf_needs_command" -a "config" -d 'Configuration management'
-complete -c arf -n "__fish_arf_needs_command" -a "history" -d 'History management'
-complete -c arf -n "__fish_arf_needs_command" -a "ipc" -d 'Interact with a running arf session via IPC'
-complete -c arf -n "__fish_arf_needs_command" -a "headless" -d 'Run R with IPC server only (no interactive REPL)'
-complete -c arf -n "__fish_arf_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c arf -n "__fish_arf_needs_command" -f -a "completions" -d 'Generate shell completion scripts'
+complete -c arf -n "__fish_arf_needs_command" -f -a "config" -d 'Configuration management'
+complete -c arf -n "__fish_arf_needs_command" -f -a "history" -d 'History management'
+complete -c arf -n "__fish_arf_needs_command" -f -a "ipc" -d 'Interact with a running arf session via IPC'
+complete -c arf -n "__fish_arf_needs_command" -f -a "headless" -d 'Run R with IPC server only (no interactive REPL)'
+complete -c arf -n "__fish_arf_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c arf -n "__fish_arf_using_subcommand completions" -s h -l help -d 'Print help'
 complete -c arf -n "__fish_arf_using_subcommand config; and not __fish_seen_subcommand_from init check help" -s h -l help -d 'Print help'
 complete -c arf -n "__fish_arf_using_subcommand config; and not __fish_seen_subcommand_from init check help" -f -a "init" -d 'Generate a default configuration file'

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
@@ -27,8 +27,8 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
         'arf' {
             [CompletionResult]::new('-e', '-e', [CompletionResultType]::ParameterName, 'Evaluate R expression and exit')
             [CompletionResult]::new('--eval', '--eval', [CompletionResultType]::ParameterName, 'Evaluate R expression and exit')
-            [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, '[R] Take input from FILE (same as positional SCRIPT argument)')
-            [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, '[R] Take input from FILE (same as positional SCRIPT argument)')
+            [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, '[R] Take input from FILE')
+            [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, '[R] Take input from FILE')
             [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Path to configuration file')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to configuration file')
             [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'R version to use via rig (overrides r_source config)')

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -21,8 +21,8 @@ _arf() {
     _arguments "${_arguments_options[@]}" : \
 '-e+[Evaluate R expression and exit]:EVAL:_default' \
 '--eval=[Evaluate R expression and exit]:EVAL:_default' \
-'()-f+[\[R\] Take input from FILE (same as positional SCRIPT argument)]:FILE:_files' \
-'()--file=[\[R\] Take input from FILE (same as positional SCRIPT argument)]:FILE:_files' \
+'-f+[\[R\] Take input from FILE]:FILE:_files' \
+'--file=[\[R\] Take input from FILE]:FILE:_files' \
 '-c+[Path to configuration file]:CONFIG:_files' \
 '--config=[Path to configuration file]:CONFIG:_files' \
 '(--r-home)--with-r-version=[R version to use via rig (overrides r_source config)]:R_VERSION:_default' \
@@ -69,16 +69,15 @@ _arf() {
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'::script -- R script file to execute (non-interactive mode):_files' \
 ":: :_arf_commands" \
 "*::: :->arf" \
 && ret=0
     case $state in
     (arf)
-        words=($line[2] "${words[@]}")
+        words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:arf-command-$line[2]:"
-        case $line[2] in
+        curcontext="${curcontext%:*:*}:arf-command-$line[1]:"
+        case $line[1] in
             (completions)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -21,8 +21,8 @@ _arf() {
     _arguments "${_arguments_options[@]}" : \
 '-e+[Evaluate R expression and exit]:EVAL:_default' \
 '--eval=[Evaluate R expression and exit]:EVAL:_default' \
-'-f+[\[R\] Take input from FILE]:FILE:_files' \
-'--file=[\[R\] Take input from FILE]:FILE:_files' \
+'(-e --eval)-f+[\[R\] Take input from FILE]:FILE:_files' \
+'(-e --eval)--file=[\[R\] Take input from FILE]:FILE:_files' \
 '-c+[Path to configuration file]:CONFIG:_files' \
 '--config=[Path to configuration file]:CONFIG:_files' \
 '(--r-home)--with-r-version=[R version to use via rig (overrides r_source config)]:R_VERSION:_default' \

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
@@ -4,7 +4,7 @@ expression: help
 ---
 A cross-platform R console written in Rust
 
-Usage: arf [OPTIONS] [SCRIPT] [COMMAND]
+Usage: arf [OPTIONS] [COMMAND]
 
 Commands:
   completions  Generate shell completion scripts
@@ -14,16 +14,12 @@ Commands:
   headless     Run R with IPC server only (no interactive REPL)
   help         Print this message or the help of the given subcommand(s)
 
-Arguments:
-  [SCRIPT]
-          R script file to execute (non-interactive mode)
-
 Options:
   -e, --eval <EVAL>
           Evaluate R expression and exit
 
   -f, --file <FILE>
-          [R] Take input from FILE (same as positional SCRIPT argument)
+          [R] Take input from FILE
 
       --reprex
           Enable reprex mode (no prompt, output prefixed with #>)

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -594,6 +594,21 @@ fn test_script_file_not_found() {
     );
 }
 
+/// Test that positional script argument is rejected (regression test).
+/// The old `arf file.R` syntax was removed; clap now treats it as an unknown subcommand.
+#[test]
+fn test_positional_script_rejected() {
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .arg("some_script.R")
+        .output()
+        .expect("Failed to run arf");
+
+    assert!(
+        !output.status.success(),
+        "positional script arg should be rejected"
+    );
+}
+
 // ============================================================================
 // R Completion Tests (using R's internal completion functions)
 // ============================================================================

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -528,7 +528,7 @@ fn test_script_file_function() {
         .output()
         .expect("Failed to run arf with script file");
 
-    assert!(output.status.success(), "arf script.R should succeed");
+    assert!(output.status.success(), "arf -f script.R should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -606,6 +606,23 @@ fn test_positional_script_rejected() {
     assert!(
         !output.status.success(),
         "positional script arg should be rejected"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        (stderr.contains("unrecognized subcommand")
+            || stderr.contains("unexpected argument")
+            || stderr.contains("unknown argument"))
+            && stderr.contains("some_script.R"),
+        "Should show a clap parse error for the positional script arg: {}",
+        stderr
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "positional script rejection should use clap's parse error exit code: stderr={}",
+        stderr
     );
 }
 

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -626,6 +626,60 @@ fn test_positional_script_rejected() {
     );
 }
 
+/// Test that -e/--eval combined with a subcommand is rejected with exit code 2.
+#[test]
+fn test_eval_with_subcommand_rejected() {
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["-e", "1+1", "completions", "bash"])
+        .output()
+        .expect("Failed to run arf");
+
+    assert!(
+        !output.status.success(),
+        "--eval with subcommand should be rejected"
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "--eval with subcommand should exit with code 2"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--eval") && stderr.contains("cannot be used"),
+        "Should show conflict error mentioning --eval: {}",
+        stderr
+    );
+}
+
+/// Test that -f/--file combined with a subcommand is rejected with exit code 2.
+#[test]
+fn test_file_with_subcommand_rejected() {
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["-f", "some.R", "completions", "bash"])
+        .output()
+        .expect("Failed to run arf");
+
+    assert!(
+        !output.status.success(),
+        "--file with subcommand should be rejected"
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "--file with subcommand should exit with code 2"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--file") && stderr.contains("cannot be used"),
+        "Should show conflict error mentioning --file: {}",
+        stderr
+    );
+}
+
 // ============================================================================
 // R Completion Tests (using R's internal completion functions)
 // ============================================================================

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -595,7 +595,7 @@ fn test_script_file_not_found() {
 }
 
 /// Test that positional script argument is rejected (regression test).
-/// The old `arf file.R` syntax was removed; clap now treats it as an unknown subcommand.
+/// The old `arf file.R` syntax was removed; clap now rejects it as an unknown subcommand/argument.
 #[test]
 fn test_positional_script_rejected() {
     let output = Command::new(env!("CARGO_BIN_EXE_arf"))

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -608,20 +608,16 @@ fn test_positional_script_rejected() {
         "positional script arg should be rejected"
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        (stderr.contains("unrecognized subcommand")
-            || stderr.contains("unexpected argument")
-            || stderr.contains("unknown argument"))
-            && stderr.contains("some_script.R"),
-        "Should show a clap parse error for the positional script arg: {}",
-        stderr
-    );
-
     assert_eq!(
         output.status.code(),
         Some(2),
-        "positional script rejection should use clap's parse error exit code: stderr={}",
+        "positional script rejection should use clap's parse error exit code"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("some_script.R"),
+        "Error should mention the offending token: {}",
         stderr
     );
 }
@@ -647,8 +643,10 @@ fn test_eval_with_subcommand_rejected() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--eval") && stderr.contains("cannot be used"),
-        "Should show conflict error mentioning --eval: {}",
+        stderr.contains("--eval")
+            && stderr.contains("cannot be used")
+            && stderr.contains("completions"),
+        "Should show conflict error mentioning --eval and the subcommand: {}",
         stderr
     );
 }
@@ -674,8 +672,10 @@ fn test_file_with_subcommand_rejected() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--file") && stderr.contains("cannot be used"),
-        "Should show conflict error mentioning --file: {}",
+        stderr.contains("--file")
+            && stderr.contains("cannot be used")
+            && stderr.contains("completions"),
+        "Should show conflict error mentioning --file and the subcommand: {}",
         stderr
     );
 }

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -498,11 +498,12 @@ fn test_script_file() {
     writeln!(file, "x + y").expect("Failed to write");
 
     let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .arg("-f")
         .arg(file.path())
         .output()
         .expect("Failed to run arf with script file");
 
-    assert!(output.status.success(), "arf script.R should succeed");
+    assert!(output.status.success(), "arf -f script.R should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -522,6 +523,7 @@ fn test_script_file_function() {
     writeln!(file, "f(10)").expect("Failed to write");
 
     let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .arg("-f")
         .arg(file.path())
         .output()
         .expect("Failed to run arf with script file");
@@ -545,13 +547,14 @@ fn test_script_file_reprex() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_arf"))
         .arg("--reprex")
+        .arg("-f")
         .arg(file.path())
         .output()
-        .expect("Failed to run arf --reprex script.R");
+        .expect("Failed to run arf --reprex -f script.R");
 
     assert!(
         output.status.success(),
-        "arf --reprex script.R should succeed"
+        "arf --reprex -f script.R should succeed"
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -573,6 +576,7 @@ fn test_script_file_reprex() {
 #[test]
 fn test_script_file_not_found() {
     let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .arg("-f")
         .arg("/nonexistent/path/to/script.R")
         .output()
         .expect("Failed to run arf");


### PR DESCRIPTION
## Summary

- Remove positional `arf file.R` syntax; script files must now be specified via `-f`/`--file`
- arf has subcommands, so flag-based file specification (like R itself uses) avoids ambiguity
- Breaking change for v0.3.0 — no deprecation period since arf is not yet stable

## Changes

- Remove `script: Option<PathBuf>` field from `Cli` struct and simplify `script_file()` to `self.file.as_ref()`
- Add `conflicts_with = "eval"` on `--file` so combining `-f` and `-e` is rejected at parse time
- Add post-parse validation in `main()` to reject `-f`/`--file` or `-e`/`--eval` combined with a subcommand (clap limitation workaround); error message includes the conflicting subcommand name
- Update existing tests in `cli_tests.rs` to use `-f` flag
- Update shell completion snapshots
- Add Breaking Change entry to `CHANGELOG.md` under `[Unreleased]`

## Test plan

- [x] `cargo test --package arf-console` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `test_positional_script_rejected` — old `arf file.R` syntax rejected (exit 2, token in stderr)
- [x] `test_eval_with_subcommand_rejected` — `arf -e '1+1' completions bash` rejected (exit 2)
- [x] `test_file_with_subcommand_rejected` — `arf -f some.R completions bash` rejected (exit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)