### PR TITLE
chore: prepare release 0.3.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## [Unreleased]
 
+## [0.3.0-rc.1] - 2026-04-11
+
 ### Removed
 
-- **Breaking:** Positional script argument (`arf file.R`) has been removed. Use `-f`/`--file` instead: `arf -f file.R`
+- **Breaking:** Positional script argument (`arf file.R`) has been removed. Use `-f`/`--file` instead: `arf -f file.R` (#151)
 
 ### Fixed
 
-- **Experimental:** Place IPC Unix socket in `$XDG_RUNTIME_DIR/arf/` instead of `~/.cache/arf/sessions/`, which is the correct XDG location for runtime sockets. Falls back to a randomized temporary directory when `XDG_RUNTIME_DIR` is not set (e.g. macOS). The socket directory is now validated for safe ownership and permissions
+- **Experimental:** Place IPC Unix socket in `$XDG_RUNTIME_DIR/arf/` instead of `~/.cache/arf/sessions/`, which is the correct XDG location for runtime sockets. Falls back to a randomized temporary directory when `XDG_RUNTIME_DIR` is not set (e.g. macOS). The socket directory is now validated for safe ownership and permissions (#145)
+- Nested list autocomplete (e.g. `l$a$`) no longer returns "NO RECORDS FOUND" — structural operators (`$`, `@`, `[`, `:`) now correctly trigger a fresh completion fetch instead of filtering the previous cache (#150)
 
 ## [0.2.7] - 2026-04-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arf-console"
-version = "0.2.7"
+version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.2.7"
+version = "0.3.0-rc.1"
 dependencies = [
  "arf-libr",
  "log",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.2.7"
+version = "0.3.0-rc.1"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
 dependencies = [
  "clap",
 ]
@@ -654,9 +654,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fd-lock"
@@ -809,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,12 +888,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -982,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1031,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2145,9 +2151,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2385,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2398,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2408,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2421,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.3.0-rc.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.7
+# arf console v0.3.0-rc.1
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.7
+# arf console v0.3.0-rc.1
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.7
+# arf console v0.3.0-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.7
+# arf console v0.3.0-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.2.7
+# arf console v0.3.0-rc.1
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -21,157 +21,157 @@ _arf() {
                 cmd="arf"
                 ;;
             arf,completions)
-                cmd="arf__completions"
+                cmd="arf__subcmd__completions"
                 ;;
             arf,config)
-                cmd="arf__config"
+                cmd="arf__subcmd__config"
                 ;;
             arf,headless)
-                cmd="arf__headless"
+                cmd="arf__subcmd__headless"
                 ;;
             arf,help)
-                cmd="arf__help"
+                cmd="arf__subcmd__help"
                 ;;
             arf,history)
-                cmd="arf__history"
+                cmd="arf__subcmd__history"
                 ;;
             arf,ipc)
-                cmd="arf__ipc"
+                cmd="arf__subcmd__ipc"
                 ;;
-            arf__config,check)
-                cmd="arf__config__check"
+            arf__subcmd__config,check)
+                cmd="arf__subcmd__config__subcmd__check"
                 ;;
-            arf__config,help)
-                cmd="arf__config__help"
+            arf__subcmd__config,help)
+                cmd="arf__subcmd__config__subcmd__help"
                 ;;
-            arf__config,init)
-                cmd="arf__config__init"
+            arf__subcmd__config,init)
+                cmd="arf__subcmd__config__subcmd__init"
                 ;;
-            arf__config__help,check)
-                cmd="arf__config__help__check"
+            arf__subcmd__config__subcmd__help,check)
+                cmd="arf__subcmd__config__subcmd__help__subcmd__check"
                 ;;
-            arf__config__help,help)
-                cmd="arf__config__help__help"
+            arf__subcmd__config__subcmd__help,help)
+                cmd="arf__subcmd__config__subcmd__help__subcmd__help"
                 ;;
-            arf__config__help,init)
-                cmd="arf__config__help__init"
+            arf__subcmd__config__subcmd__help,init)
+                cmd="arf__subcmd__config__subcmd__help__subcmd__init"
                 ;;
-            arf__help,completions)
-                cmd="arf__help__completions"
+            arf__subcmd__help,completions)
+                cmd="arf__subcmd__help__subcmd__completions"
                 ;;
-            arf__help,config)
-                cmd="arf__help__config"
+            arf__subcmd__help,config)
+                cmd="arf__subcmd__help__subcmd__config"
                 ;;
-            arf__help,headless)
-                cmd="arf__help__headless"
+            arf__subcmd__help,headless)
+                cmd="arf__subcmd__help__subcmd__headless"
                 ;;
-            arf__help,help)
-                cmd="arf__help__help"
+            arf__subcmd__help,help)
+                cmd="arf__subcmd__help__subcmd__help"
                 ;;
-            arf__help,history)
-                cmd="arf__help__history"
+            arf__subcmd__help,history)
+                cmd="arf__subcmd__help__subcmd__history"
                 ;;
-            arf__help,ipc)
-                cmd="arf__help__ipc"
+            arf__subcmd__help,ipc)
+                cmd="arf__subcmd__help__subcmd__ipc"
                 ;;
-            arf__help__config,check)
-                cmd="arf__help__config__check"
+            arf__subcmd__help__subcmd__config,check)
+                cmd="arf__subcmd__help__subcmd__config__subcmd__check"
                 ;;
-            arf__help__config,init)
-                cmd="arf__help__config__init"
+            arf__subcmd__help__subcmd__config,init)
+                cmd="arf__subcmd__help__subcmd__config__subcmd__init"
                 ;;
-            arf__help__history,export)
-                cmd="arf__help__history__export"
+            arf__subcmd__help__subcmd__history,export)
+                cmd="arf__subcmd__help__subcmd__history__subcmd__export"
                 ;;
-            arf__help__history,import)
-                cmd="arf__help__history__import"
+            arf__subcmd__help__subcmd__history,import)
+                cmd="arf__subcmd__help__subcmd__history__subcmd__import"
                 ;;
-            arf__help__history,schema)
-                cmd="arf__help__history__schema"
+            arf__subcmd__help__subcmd__history,schema)
+                cmd="arf__subcmd__help__subcmd__history__subcmd__schema"
                 ;;
-            arf__help__ipc,eval)
-                cmd="arf__help__ipc__eval"
+            arf__subcmd__help__subcmd__ipc,eval)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__eval"
                 ;;
-            arf__help__ipc,history)
-                cmd="arf__help__ipc__history"
+            arf__subcmd__help__subcmd__ipc,history)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__history"
                 ;;
-            arf__help__ipc,list)
-                cmd="arf__help__ipc__list"
+            arf__subcmd__help__subcmd__ipc,list)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__list"
                 ;;
-            arf__help__ipc,send)
-                cmd="arf__help__ipc__send"
+            arf__subcmd__help__subcmd__ipc,send)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__send"
                 ;;
-            arf__help__ipc,session)
-                cmd="arf__help__ipc__session"
+            arf__subcmd__help__subcmd__ipc,session)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__session"
                 ;;
-            arf__help__ipc,shutdown)
-                cmd="arf__help__ipc__shutdown"
+            arf__subcmd__help__subcmd__ipc,shutdown)
+                cmd="arf__subcmd__help__subcmd__ipc__subcmd__shutdown"
                 ;;
-            arf__history,export)
-                cmd="arf__history__export"
+            arf__subcmd__history,export)
+                cmd="arf__subcmd__history__subcmd__export"
                 ;;
-            arf__history,help)
-                cmd="arf__history__help"
+            arf__subcmd__history,help)
+                cmd="arf__subcmd__history__subcmd__help"
                 ;;
-            arf__history,import)
-                cmd="arf__history__import"
+            arf__subcmd__history,import)
+                cmd="arf__subcmd__history__subcmd__import"
                 ;;
-            arf__history,schema)
-                cmd="arf__history__schema"
+            arf__subcmd__history,schema)
+                cmd="arf__subcmd__history__subcmd__schema"
                 ;;
-            arf__history__help,export)
-                cmd="arf__history__help__export"
+            arf__subcmd__history__subcmd__help,export)
+                cmd="arf__subcmd__history__subcmd__help__subcmd__export"
                 ;;
-            arf__history__help,help)
-                cmd="arf__history__help__help"
+            arf__subcmd__history__subcmd__help,help)
+                cmd="arf__subcmd__history__subcmd__help__subcmd__help"
                 ;;
-            arf__history__help,import)
-                cmd="arf__history__help__import"
+            arf__subcmd__history__subcmd__help,import)
+                cmd="arf__subcmd__history__subcmd__help__subcmd__import"
                 ;;
-            arf__history__help,schema)
-                cmd="arf__history__help__schema"
+            arf__subcmd__history__subcmd__help,schema)
+                cmd="arf__subcmd__history__subcmd__help__subcmd__schema"
                 ;;
-            arf__ipc,eval)
-                cmd="arf__ipc__eval"
+            arf__subcmd__ipc,eval)
+                cmd="arf__subcmd__ipc__subcmd__eval"
                 ;;
-            arf__ipc,help)
-                cmd="arf__ipc__help"
+            arf__subcmd__ipc,help)
+                cmd="arf__subcmd__ipc__subcmd__help"
                 ;;
-            arf__ipc,history)
-                cmd="arf__ipc__history"
+            arf__subcmd__ipc,history)
+                cmd="arf__subcmd__ipc__subcmd__history"
                 ;;
-            arf__ipc,list)
-                cmd="arf__ipc__list"
+            arf__subcmd__ipc,list)
+                cmd="arf__subcmd__ipc__subcmd__list"
                 ;;
-            arf__ipc,send)
-                cmd="arf__ipc__send"
+            arf__subcmd__ipc,send)
+                cmd="arf__subcmd__ipc__subcmd__send"
                 ;;
-            arf__ipc,session)
-                cmd="arf__ipc__session"
+            arf__subcmd__ipc,session)
+                cmd="arf__subcmd__ipc__subcmd__session"
                 ;;
-            arf__ipc,shutdown)
-                cmd="arf__ipc__shutdown"
+            arf__subcmd__ipc,shutdown)
+                cmd="arf__subcmd__ipc__subcmd__shutdown"
                 ;;
-            arf__ipc__help,eval)
-                cmd="arf__ipc__help__eval"
+            arf__subcmd__ipc__subcmd__help,eval)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__eval"
                 ;;
-            arf__ipc__help,help)
-                cmd="arf__ipc__help__help"
+            arf__subcmd__ipc__subcmd__help,help)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__help"
                 ;;
-            arf__ipc__help,history)
-                cmd="arf__ipc__help__history"
+            arf__subcmd__ipc__subcmd__help,history)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__history"
                 ;;
-            arf__ipc__help,list)
-                cmd="arf__ipc__help__list"
+            arf__subcmd__ipc__subcmd__help,list)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__list"
                 ;;
-            arf__ipc__help,send)
-                cmd="arf__ipc__help__send"
+            arf__subcmd__ipc__subcmd__help,send)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__send"
                 ;;
-            arf__ipc__help,session)
-                cmd="arf__ipc__help__session"
+            arf__subcmd__ipc__subcmd__help,session)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__session"
                 ;;
-            arf__ipc__help,shutdown)
-                cmd="arf__ipc__help__shutdown"
+            arf__subcmd__ipc__subcmd__help,shutdown)
+                cmd="arf__subcmd__ipc__subcmd__help__subcmd__shutdown"
                 ;;
             *)
                 ;;
@@ -323,7 +323,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__completions)
+        arf__subcmd__completions)
             opts="-h --help bash elvish fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -337,7 +337,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config)
+        arf__subcmd__config)
             opts="-h --help init check help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -351,7 +351,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__check)
+        arf__subcmd__config__subcmd__check)
             opts="-c -h --config --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -395,7 +395,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__help)
+        arf__subcmd__config__subcmd__help)
             opts="init check help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -409,7 +409,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__help__check)
+        arf__subcmd__config__subcmd__help__subcmd__check)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -423,7 +423,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__help__help)
+        arf__subcmd__config__subcmd__help__subcmd__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -437,7 +437,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__help__init)
+        arf__subcmd__config__subcmd__help__subcmd__init)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -451,7 +451,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__config__init)
+        arf__subcmd__config__subcmd__init)
             opts="-f -h --force --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -465,7 +465,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__headless)
+        arf__subcmd__headless)
             opts="-c -h --config --with-r-version --r-home --bind --pid-file --quiet --json --log-file --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --history-dir --no-history --min-nsize --min-vsize --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -588,7 +588,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help)
+        arf__subcmd__help)
             opts="completions config history ipc headless help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -602,7 +602,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__completions)
+        arf__subcmd__help__subcmd__completions)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -616,7 +616,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__config)
+        arf__subcmd__help__subcmd__config)
             opts="init check"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -630,7 +630,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__config__check)
+        arf__subcmd__help__subcmd__config__subcmd__check)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -644,7 +644,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__config__init)
+        arf__subcmd__help__subcmd__config__subcmd__init)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -658,7 +658,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__headless)
+        arf__subcmd__help__subcmd__headless)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -672,7 +672,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__help)
+        arf__subcmd__help__subcmd__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -686,7 +686,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__history)
+        arf__subcmd__help__subcmd__history)
             opts="schema import export"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -700,7 +700,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__history__export)
+        arf__subcmd__help__subcmd__history__subcmd__export)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -714,7 +714,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__history__import)
+        arf__subcmd__help__subcmd__history__subcmd__import)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -728,7 +728,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__history__schema)
+        arf__subcmd__help__subcmd__history__subcmd__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -742,7 +742,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc)
+        arf__subcmd__help__subcmd__ipc)
             opts="list eval send session shutdown history"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -756,7 +756,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__eval)
+        arf__subcmd__help__subcmd__ipc__subcmd__eval)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -770,7 +770,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__history)
+        arf__subcmd__help__subcmd__ipc__subcmd__history)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -784,7 +784,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__list)
+        arf__subcmd__help__subcmd__ipc__subcmd__list)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -798,7 +798,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__send)
+        arf__subcmd__help__subcmd__ipc__subcmd__send)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -812,7 +812,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__session)
+        arf__subcmd__help__subcmd__ipc__subcmd__session)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -826,7 +826,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__help__ipc__shutdown)
+        arf__subcmd__help__subcmd__ipc__subcmd__shutdown)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -840,7 +840,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history)
+        arf__subcmd__history)
             opts="-h --help schema import export help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -854,7 +854,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__export)
+        arf__subcmd__history__subcmd__export)
             opts="-h --file --r-table --shell-table --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -891,7 +891,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__help)
+        arf__subcmd__history__subcmd__help)
             opts="schema import export help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -905,7 +905,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__help__export)
+        arf__subcmd__history__subcmd__help__subcmd__export)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -919,7 +919,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__help__help)
+        arf__subcmd__history__subcmd__help__subcmd__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -933,7 +933,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__help__import)
+        arf__subcmd__history__subcmd__help__subcmd__import)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -947,7 +947,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__help__schema)
+        arf__subcmd__history__subcmd__help__subcmd__schema)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -961,7 +961,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__import)
+        arf__subcmd__history__subcmd__import)
             opts="-h --from --file --hostname --dry-run --import-duplicates --unified --r-table --shell-table --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1006,7 +1006,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__history__schema)
+        arf__subcmd__history__subcmd__schema)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1020,7 +1020,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc)
+        arf__subcmd__ipc)
             opts="-h --help list eval send session shutdown history help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1034,7 +1034,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__eval)
+        arf__subcmd__ipc__subcmd__eval)
             opts="-h --pid --visible --timeout --help <CODE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1056,7 +1056,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help)
+        arf__subcmd__ipc__subcmd__help)
             opts="list eval send session shutdown history help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1070,7 +1070,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__eval)
+        arf__subcmd__ipc__subcmd__help__subcmd__eval)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1084,7 +1084,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__help)
+        arf__subcmd__ipc__subcmd__help__subcmd__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1098,7 +1098,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__history)
+        arf__subcmd__ipc__subcmd__help__subcmd__history)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1112,7 +1112,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__list)
+        arf__subcmd__ipc__subcmd__help__subcmd__list)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1126,7 +1126,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__send)
+        arf__subcmd__ipc__subcmd__help__subcmd__send)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1140,7 +1140,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__session)
+        arf__subcmd__ipc__subcmd__help__subcmd__session)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1154,7 +1154,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__help__shutdown)
+        arf__subcmd__ipc__subcmd__help__subcmd__shutdown)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1168,7 +1168,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__history)
+        arf__subcmd__ipc__subcmd__history)
             opts="-h --limit --all-sessions --cwd --grep --since --pid --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1202,7 +1202,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__list)
+        arf__subcmd__ipc__subcmd__list)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1216,7 +1216,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__send)
+        arf__subcmd__ipc__subcmd__send)
             opts="-h --pid --help <CODE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1234,7 +1234,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__session)
+        arf__subcmd__ipc__subcmd__session)
             opts="-h --pid --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1252,7 +1252,7 @@ _arf() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        arf__ipc__shutdown)
+        arf__subcmd__ipc__subcmd__shutdown)
             opts="-h --pid --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -89,7 +89,7 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_arf__config_commands" \
+":: :_arf__subcmd__config_commands" \
 "*::: :->config" \
 && ret=0
 
@@ -117,7 +117,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__config__help_commands" \
+":: :_arf__subcmd__config__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -151,7 +151,7 @@ esac
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_arf__history_commands" \
+":: :_arf__subcmd__history_commands" \
 "*::: :->history" \
 && ret=0
 
@@ -194,7 +194,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__history__help_commands" \
+":: :_arf__subcmd__history__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -232,7 +232,7 @@ esac
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-":: :_arf__ipc_commands" \
+":: :_arf__subcmd__ipc_commands" \
 "*::: :->ipc" \
 && ret=0
 
@@ -294,7 +294,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__ipc__help_commands" \
+":: :_arf__subcmd__ipc__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -367,7 +367,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__help_commands" \
+":: :_arf__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -383,7 +383,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (config)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__help__config_commands" \
+":: :_arf__subcmd__help__subcmd__config_commands" \
 "*::: :->config" \
 && ret=0
 
@@ -407,7 +407,7 @@ esac
 ;;
 (history)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__help__history_commands" \
+":: :_arf__subcmd__help__subcmd__history_commands" \
 "*::: :->history" \
 && ret=0
 
@@ -435,7 +435,7 @@ esac
 ;;
 (ipc)
 _arguments "${_arguments_options[@]}" : \
-":: :_arf__help__ipc_commands" \
+":: :_arf__subcmd__help__subcmd__ipc_commands" \
 "*::: :->ipc" \
 && ret=0
 
@@ -502,13 +502,13 @@ _arf_commands() {
     )
     _describe -t commands 'arf commands' commands "$@"
 }
-(( $+functions[_arf__completions_commands] )) ||
-_arf__completions_commands() {
+(( $+functions[_arf__subcmd__completions_commands] )) ||
+_arf__subcmd__completions_commands() {
     local commands; commands=()
     _describe -t commands 'arf completions commands' commands "$@"
 }
-(( $+functions[_arf__config_commands] )) ||
-_arf__config_commands() {
+(( $+functions[_arf__subcmd__config_commands] )) ||
+_arf__subcmd__config_commands() {
     local commands; commands=(
 'init:Generate a default configuration file' \
 'check:Validate the configuration file' \
@@ -516,13 +516,13 @@ _arf__config_commands() {
     )
     _describe -t commands 'arf config commands' commands "$@"
 }
-(( $+functions[_arf__config__check_commands] )) ||
-_arf__config__check_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__check_commands] )) ||
+_arf__subcmd__config__subcmd__check_commands() {
     local commands; commands=()
     _describe -t commands 'arf config check commands' commands "$@"
 }
-(( $+functions[_arf__config__help_commands] )) ||
-_arf__config__help_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__help_commands] )) ||
+_arf__subcmd__config__subcmd__help_commands() {
     local commands; commands=(
 'init:Generate a default configuration file' \
 'check:Validate the configuration file' \
@@ -530,33 +530,33 @@ _arf__config__help_commands() {
     )
     _describe -t commands 'arf config help commands' commands "$@"
 }
-(( $+functions[_arf__config__help__check_commands] )) ||
-_arf__config__help__check_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__help__subcmd__check_commands] )) ||
+_arf__subcmd__config__subcmd__help__subcmd__check_commands() {
     local commands; commands=()
     _describe -t commands 'arf config help check commands' commands "$@"
 }
-(( $+functions[_arf__config__help__help_commands] )) ||
-_arf__config__help__help_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__help__subcmd__help_commands] )) ||
+_arf__subcmd__config__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'arf config help help commands' commands "$@"
 }
-(( $+functions[_arf__config__help__init_commands] )) ||
-_arf__config__help__init_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__help__subcmd__init_commands] )) ||
+_arf__subcmd__config__subcmd__help__subcmd__init_commands() {
     local commands; commands=()
     _describe -t commands 'arf config help init commands' commands "$@"
 }
-(( $+functions[_arf__config__init_commands] )) ||
-_arf__config__init_commands() {
+(( $+functions[_arf__subcmd__config__subcmd__init_commands] )) ||
+_arf__subcmd__config__subcmd__init_commands() {
     local commands; commands=()
     _describe -t commands 'arf config init commands' commands "$@"
 }
-(( $+functions[_arf__headless_commands] )) ||
-_arf__headless_commands() {
+(( $+functions[_arf__subcmd__headless_commands] )) ||
+_arf__subcmd__headless_commands() {
     local commands; commands=()
     _describe -t commands 'arf headless commands' commands "$@"
 }
-(( $+functions[_arf__help_commands] )) ||
-_arf__help_commands() {
+(( $+functions[_arf__subcmd__help_commands] )) ||
+_arf__subcmd__help_commands() {
     local commands; commands=(
 'completions:Generate shell completion scripts' \
 'config:Configuration management' \
@@ -567,41 +567,41 @@ _arf__help_commands() {
     )
     _describe -t commands 'arf help commands' commands "$@"
 }
-(( $+functions[_arf__help__completions_commands] )) ||
-_arf__help__completions_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__completions_commands] )) ||
+_arf__subcmd__help__subcmd__completions_commands() {
     local commands; commands=()
     _describe -t commands 'arf help completions commands' commands "$@"
 }
-(( $+functions[_arf__help__config_commands] )) ||
-_arf__help__config_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__config_commands] )) ||
+_arf__subcmd__help__subcmd__config_commands() {
     local commands; commands=(
 'init:Generate a default configuration file' \
 'check:Validate the configuration file' \
     )
     _describe -t commands 'arf help config commands' commands "$@"
 }
-(( $+functions[_arf__help__config__check_commands] )) ||
-_arf__help__config__check_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__config__subcmd__check_commands] )) ||
+_arf__subcmd__help__subcmd__config__subcmd__check_commands() {
     local commands; commands=()
     _describe -t commands 'arf help config check commands' commands "$@"
 }
-(( $+functions[_arf__help__config__init_commands] )) ||
-_arf__help__config__init_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__config__subcmd__init_commands] )) ||
+_arf__subcmd__help__subcmd__config__subcmd__init_commands() {
     local commands; commands=()
     _describe -t commands 'arf help config init commands' commands "$@"
 }
-(( $+functions[_arf__help__headless_commands] )) ||
-_arf__help__headless_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__headless_commands] )) ||
+_arf__subcmd__help__subcmd__headless_commands() {
     local commands; commands=()
     _describe -t commands 'arf help headless commands' commands "$@"
 }
-(( $+functions[_arf__help__help_commands] )) ||
-_arf__help__help_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__help_commands] )) ||
+_arf__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'arf help help commands' commands "$@"
 }
-(( $+functions[_arf__help__history_commands] )) ||
-_arf__help__history_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__history_commands] )) ||
+_arf__subcmd__help__subcmd__history_commands() {
     local commands; commands=(
 'schema:Display history database schema and example R code' \
 'import:Import history from another source (experimental)' \
@@ -609,23 +609,23 @@ _arf__help__history_commands() {
     )
     _describe -t commands 'arf help history commands' commands "$@"
 }
-(( $+functions[_arf__help__history__export_commands] )) ||
-_arf__help__history__export_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__history__subcmd__export_commands] )) ||
+_arf__subcmd__help__subcmd__history__subcmd__export_commands() {
     local commands; commands=()
     _describe -t commands 'arf help history export commands' commands "$@"
 }
-(( $+functions[_arf__help__history__import_commands] )) ||
-_arf__help__history__import_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__history__subcmd__import_commands] )) ||
+_arf__subcmd__help__subcmd__history__subcmd__import_commands() {
     local commands; commands=()
     _describe -t commands 'arf help history import commands' commands "$@"
 }
-(( $+functions[_arf__help__history__schema_commands] )) ||
-_arf__help__history__schema_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__history__subcmd__schema_commands] )) ||
+_arf__subcmd__help__subcmd__history__subcmd__schema_commands() {
     local commands; commands=()
     _describe -t commands 'arf help history schema commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc_commands] )) ||
-_arf__help__ipc_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc_commands] )) ||
+_arf__subcmd__help__subcmd__ipc_commands() {
     local commands; commands=(
 'list:List active arf sessions as JSON' \
 'eval:Evaluate R code and return captured output as JSON' \
@@ -636,38 +636,38 @@ _arf__help__ipc_commands() {
     )
     _describe -t commands 'arf help ipc commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__eval_commands] )) ||
-_arf__help__ipc__eval_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__eval_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__eval_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc eval commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__history_commands] )) ||
-_arf__help__ipc__history_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__history_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__history_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc history commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__list_commands] )) ||
-_arf__help__ipc__list_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__list_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__list_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc list commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__send_commands] )) ||
-_arf__help__ipc__send_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__send_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__send_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc send commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__session_commands] )) ||
-_arf__help__ipc__session_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__session_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__session_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc session commands' commands "$@"
 }
-(( $+functions[_arf__help__ipc__shutdown_commands] )) ||
-_arf__help__ipc__shutdown_commands() {
+(( $+functions[_arf__subcmd__help__subcmd__ipc__subcmd__shutdown_commands] )) ||
+_arf__subcmd__help__subcmd__ipc__subcmd__shutdown_commands() {
     local commands; commands=()
     _describe -t commands 'arf help ipc shutdown commands' commands "$@"
 }
-(( $+functions[_arf__history_commands] )) ||
-_arf__history_commands() {
+(( $+functions[_arf__subcmd__history_commands] )) ||
+_arf__subcmd__history_commands() {
     local commands; commands=(
 'schema:Display history database schema and example R code' \
 'import:Import history from another source (experimental)' \
@@ -676,13 +676,13 @@ _arf__history_commands() {
     )
     _describe -t commands 'arf history commands' commands "$@"
 }
-(( $+functions[_arf__history__export_commands] )) ||
-_arf__history__export_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__export_commands] )) ||
+_arf__subcmd__history__subcmd__export_commands() {
     local commands; commands=()
     _describe -t commands 'arf history export commands' commands "$@"
 }
-(( $+functions[_arf__history__help_commands] )) ||
-_arf__history__help_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__help_commands] )) ||
+_arf__subcmd__history__subcmd__help_commands() {
     local commands; commands=(
 'schema:Display history database schema and example R code' \
 'import:Import history from another source (experimental)' \
@@ -691,38 +691,38 @@ _arf__history__help_commands() {
     )
     _describe -t commands 'arf history help commands' commands "$@"
 }
-(( $+functions[_arf__history__help__export_commands] )) ||
-_arf__history__help__export_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__help__subcmd__export_commands] )) ||
+_arf__subcmd__history__subcmd__help__subcmd__export_commands() {
     local commands; commands=()
     _describe -t commands 'arf history help export commands' commands "$@"
 }
-(( $+functions[_arf__history__help__help_commands] )) ||
-_arf__history__help__help_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__help__subcmd__help_commands] )) ||
+_arf__subcmd__history__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'arf history help help commands' commands "$@"
 }
-(( $+functions[_arf__history__help__import_commands] )) ||
-_arf__history__help__import_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__help__subcmd__import_commands] )) ||
+_arf__subcmd__history__subcmd__help__subcmd__import_commands() {
     local commands; commands=()
     _describe -t commands 'arf history help import commands' commands "$@"
 }
-(( $+functions[_arf__history__help__schema_commands] )) ||
-_arf__history__help__schema_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__help__subcmd__schema_commands] )) ||
+_arf__subcmd__history__subcmd__help__subcmd__schema_commands() {
     local commands; commands=()
     _describe -t commands 'arf history help schema commands' commands "$@"
 }
-(( $+functions[_arf__history__import_commands] )) ||
-_arf__history__import_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__import_commands] )) ||
+_arf__subcmd__history__subcmd__import_commands() {
     local commands; commands=()
     _describe -t commands 'arf history import commands' commands "$@"
 }
-(( $+functions[_arf__history__schema_commands] )) ||
-_arf__history__schema_commands() {
+(( $+functions[_arf__subcmd__history__subcmd__schema_commands] )) ||
+_arf__subcmd__history__subcmd__schema_commands() {
     local commands; commands=()
     _describe -t commands 'arf history schema commands' commands "$@"
 }
-(( $+functions[_arf__ipc_commands] )) ||
-_arf__ipc_commands() {
+(( $+functions[_arf__subcmd__ipc_commands] )) ||
+_arf__subcmd__ipc_commands() {
     local commands; commands=(
 'list:List active arf sessions as JSON' \
 'eval:Evaluate R code and return captured output as JSON' \
@@ -734,13 +734,13 @@ _arf__ipc_commands() {
     )
     _describe -t commands 'arf ipc commands' commands "$@"
 }
-(( $+functions[_arf__ipc__eval_commands] )) ||
-_arf__ipc__eval_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__eval_commands] )) ||
+_arf__subcmd__ipc__subcmd__eval_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc eval commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help_commands] )) ||
-_arf__ipc__help_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help_commands] )) ||
+_arf__subcmd__ipc__subcmd__help_commands() {
     local commands; commands=(
 'list:List active arf sessions as JSON' \
 'eval:Evaluate R code and return captured output as JSON' \
@@ -752,63 +752,63 @@ _arf__ipc__help_commands() {
     )
     _describe -t commands 'arf ipc help commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__eval_commands] )) ||
-_arf__ipc__help__eval_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__eval_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__eval_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help eval commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__help_commands] )) ||
-_arf__ipc__help__help_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__help_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help help commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__history_commands] )) ||
-_arf__ipc__help__history_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__history_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__history_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help history commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__list_commands] )) ||
-_arf__ipc__help__list_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__list_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__list_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help list commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__send_commands] )) ||
-_arf__ipc__help__send_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__send_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__send_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help send commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__session_commands] )) ||
-_arf__ipc__help__session_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__session_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__session_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help session commands' commands "$@"
 }
-(( $+functions[_arf__ipc__help__shutdown_commands] )) ||
-_arf__ipc__help__shutdown_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__help__subcmd__shutdown_commands] )) ||
+_arf__subcmd__ipc__subcmd__help__subcmd__shutdown_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc help shutdown commands' commands "$@"
 }
-(( $+functions[_arf__ipc__history_commands] )) ||
-_arf__ipc__history_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__history_commands] )) ||
+_arf__subcmd__ipc__subcmd__history_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc history commands' commands "$@"
 }
-(( $+functions[_arf__ipc__list_commands] )) ||
-_arf__ipc__list_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__list_commands] )) ||
+_arf__subcmd__ipc__subcmd__list_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc list commands' commands "$@"
 }
-(( $+functions[_arf__ipc__send_commands] )) ||
-_arf__ipc__send_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__send_commands] )) ||
+_arf__subcmd__ipc__subcmd__send_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc send commands' commands "$@"
 }
-(( $+functions[_arf__ipc__session_commands] )) ||
-_arf__ipc__session_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__session_commands] )) ||
+_arf__subcmd__ipc__subcmd__session_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc session commands' commands "$@"
 }
-(( $+functions[_arf__ipc__shutdown_commands] )) ||
-_arf__ipc__shutdown_commands() {
+(( $+functions[_arf__subcmd__ipc__subcmd__shutdown_commands] )) ||
+_arf__subcmd__ipc__subcmd__shutdown_commands() {
     local commands; commands=()
     _describe -t commands 'arf ipc shutdown commands' commands "$@"
 }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.2.7 to 0.3.0-rc.1
- Finalize CHANGELOG `[Unreleased]` section as `[0.3.0-rc.1] - 2026-04-11`
- Update banner snapshots for new version string
- Update shell completion snapshots (clap internal naming change)

## Changelog

## [0.3.0-rc.1] - 2026-04-11

### Removed

- **Breaking:** Positional script argument (`arf file.R`) has been removed. Use `-f`/`--file` instead: `arf -f file.R` (#151)

### Fixed

- **Experimental:** Place IPC Unix socket in `$XDG_RUNTIME_DIR/arf/` instead of `~/.cache/arf/sessions/`, which is the correct XDG location for runtime sockets. Falls back to a randomized temporary directory when `XDG_RUNTIME_DIR` is not set (e.g. macOS). The socket directory is now validated for safe ownership and permissions (#145)
- Nested list autocomplete (e.g. `l$a$`) no longer returns "NO RECORDS FOUND" — structural operators (`$`, `@`, `[`, `:`) now correctly trigger a fresh completion fetch instead of filtering the previous cache (#150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)