### PR TITLE
fix(windows): call .First() and .First.sys() after manual profile sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- (Windows) `.First()` and `.First.sys()` are now called after `.Rprofile` is sourced, matching R's standard startup sequence. Previously these hooks were skipped, causing vscode-R session watcher connections to fail and user-defined startup logic in `.First()` to be ignored.
+
 ## [0.3.0] - 2026-04-16
 
 ### Removed

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1347,6 +1347,10 @@ fn run_script(cli: &Cli) -> Result<()> {
         arf_libr::initialize_r_with_args(&r_args_refs).context("Failed to initialize R")?;
     }
 
+    // Source R profile files (Windows only)
+    #[cfg(windows)]
+    source_r_profiles(&r_args);
+
     // Get the code to execute
     let code = if let Some(eval_code) = &cli.eval {
         eval_code.clone()

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1595,8 +1595,8 @@ fn source_r_profiles(r_args: &[String]) {
         log::trace!("Skipping user R profile (--no-init-file or --vanilla)");
     }
 
-    // Call .First() then .First.sys() to mirror R's standard startup sequence.
-    // R's main.c calls these after profiles are loaded:
+    // Call .First() then .First.sys() to match R's documented startup sequence
+    // (see `?Startup`). After profiles are loaded:
     //   1. .First()     — user hook defined in .Rprofile (e.g. vscode-R session watcher)
     //   2. .First.sys() — base package hook that loads default packages (utils, grDevices, ...)
     // On Windows we source profiles manually (profiles disabled in setup_Rmainloop for

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1590,6 +1590,15 @@ fn source_r_profiles(r_args: &[String]) {
     } else {
         log::trace!("Skipping user R profile (--no-init-file or --vanilla)");
     }
+
+    // Call .First() then .First.sys() to mirror R's standard startup sequence.
+    // R's main.c calls these after profiles are loaded:
+    //   1. .First()     — user hook defined in .Rprofile (e.g. vscode-R session watcher)
+    //   2. .First.sys() — base package hook that loads default packages (utils, grDevices, ...)
+    // On Windows we source profiles manually (profiles disabled in setup_Rmainloop for
+    // globalCallingHandlers compatibility), so we must call these hooks manually too.
+    arf_harp::call_dot_first();
+    arf_harp::call_dot_first_sys();
 }
 
 /// Generate a history session ID when history is enabled and a history directory

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -594,6 +594,61 @@ fn test_script_file_not_found() {
     );
 }
 
+/// Test that `arf -e` sources the user's `.Rprofile` during startup.
+///
+/// Verifies the full script-mode startup sequence: .Rprofile sourced →
+/// side effect observable in output. This covers both Unix (R's built-in
+/// profile loading via `setup_Rmainloop`) and Windows (manual
+/// `source_r_profiles()` in `run_script()`), so it guards against
+/// regressions on either path.
+#[test]
+fn test_eval_sources_user_rprofile() {
+    let mut rprofile = NamedTempFile::new().expect("Failed to create temp .Rprofile");
+    writeln!(rprofile, "cat('ARF_RPROFILE_MARKER\\n')").expect("Failed to write .Rprofile");
+    let rprofile_path = rprofile.path().to_path_buf();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .env("R_PROFILE_USER", &rprofile_path)
+        .args(["-e", "1"])
+        .output()
+        .expect("Failed to run arf -e");
+
+    assert!(output.status.success(), "arf -e should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("ARF_RPROFILE_MARKER") || stderr.contains("ARF_RPROFILE_MARKER"),
+        ".Rprofile should be sourced by arf -e. stdout={stdout}, stderr={stderr}"
+    );
+}
+
+/// Test that `arf --vanilla -e` does NOT source the user's `.Rprofile`.
+///
+/// `--vanilla` implies `--no-init-file`, which must suppress .Rprofile
+/// loading on both Unix and Windows startup paths.
+#[test]
+fn test_eval_vanilla_skips_user_rprofile() {
+    let mut rprofile = NamedTempFile::new().expect("Failed to create temp .Rprofile");
+    writeln!(rprofile, "cat('ARF_RPROFILE_MARKER\\n')").expect("Failed to write .Rprofile");
+    let rprofile_path = rprofile.path().to_path_buf();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .env("R_PROFILE_USER", &rprofile_path)
+        .args(["--vanilla", "-e", "1"])
+        .output()
+        .expect("Failed to run arf --vanilla -e");
+
+    assert!(output.status.success(), "arf --vanilla -e should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("ARF_RPROFILE_MARKER") && !stderr.contains("ARF_RPROFILE_MARKER"),
+        ".Rprofile must not be sourced under --vanilla. stdout={stdout}, stderr={stderr}"
+    );
+}
+
 /// Test that positional script argument is rejected (regression test).
 /// The old `arf file.R` syntax was removed; clap now rejects it as an unknown subcommand/argument.
 #[test]

--- a/crates/arf-harp/src/lib.rs
+++ b/crates/arf-harp/src/lib.rs
@@ -15,6 +15,6 @@ pub use help::*;
 pub use object::*;
 pub use protect::*;
 pub use startup::{
-    should_ignore_site_r_profile, should_ignore_user_r_profile, source_site_r_profile,
-    source_user_r_profile,
+    call_dot_first, call_dot_first_sys, should_ignore_site_r_profile, should_ignore_user_r_profile,
+    source_site_r_profile, source_user_r_profile,
 };

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -25,7 +25,7 @@
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
-use arf_libr::{SEXP, SexpType, r_library, r_nil_value};
+use arf_libr::{RLibrary, SEXP, SexpType, r_library, r_nil_value};
 
 use crate::error::{HarpError, HarpResult};
 use crate::protect::RProtect;
@@ -179,6 +179,22 @@ unsafe extern "C" fn source_callback(payload: *mut std::ffi::c_void) {
     data.result = Some(result);
 }
 
+/// Return `true` if `val` is bound to a callable R function.
+///
+/// R functions can be any of three SEXPTYPEs: `CLOSXP` (user-defined closures),
+/// `BUILTINSXP` (built-in functions with eager argument evaluation), and
+/// `SPECIALSXP` (built-in functions with lazy argument evaluation — e.g. `if`,
+/// `quote`). Mirrors the semantics of `Rf_isFunction`.
+unsafe fn is_callable_function(val: SEXP, lib: &RLibrary) -> bool {
+    if val == unsafe { *lib.r_unboundvalue } {
+        return false;
+    }
+    let t = unsafe { (lib.rf_typeof)(val) };
+    t == SexpType::ClosSxp as std::os::raw::c_int
+        || t == SexpType::BuiltinSxp as std::os::raw::c_int
+        || t == SexpType::SpecialSxp as std::os::raw::c_int
+}
+
 /// Install (intern) an R symbol by name.
 unsafe fn install_symbol(name: &str) -> HarpResult<SEXP> {
     let lib = r_library()?;
@@ -236,10 +252,9 @@ fn call_dot_first_impl() -> HarpResult<bool> {
         let global_env = *lib.r_globalenv;
         let val = (lib.rf_findvar)(sym, global_env);
 
-        // Only call if .First is defined and is a closure (function)
-        let is_closure = val != *lib.r_unboundvalue
-            && (lib.rf_typeof)(val) == SexpType::ClosSxp as std::os::raw::c_int;
-        if !is_closure {
+        // Only call if .First is defined and bound to a function (any of the
+        // three callable SEXPTYPEs — closure, builtin, or special).
+        if !is_callable_function(val, lib) {
             return Ok(false);
         }
 
@@ -275,9 +290,7 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
         let base_ns = *lib.r_basenamespace;
         let val = (lib.rf_findvar)(sym, base_ns);
 
-        let is_closure = val != *lib.r_unboundvalue
-            && (lib.rf_typeof)(val) == SexpType::ClosSxp as std::os::raw::c_int;
-        if !is_closure {
+        if !is_callable_function(val, lib) {
             return Ok(false);
         }
 

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -286,7 +286,9 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
     unsafe {
         let mut protect = RProtect::new();
         let sym = install_symbol(".First.sys")?;
-        // Look up in base namespace, eval in base env (mirrors R's main.c)
+        // Look up and evaluate in R_BaseNamespace so the symbol is always
+        // findable. R's main.c evaluates the call in R_BaseEnv, but
+        // .First.sys is not exported there in all R versions.
         let base_ns = *lib.r_basenamespace;
         let val = (lib.rf_findvar)(sym, base_ns);
 

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -207,8 +207,9 @@ unsafe fn install_symbol(name: &str) -> HarpResult<SEXP> {
 
 /// Call `.First()` if it is defined as a function in `.GlobalEnv`.
 ///
-/// Mirrors R's `main.c` startup sequence: after profiles are sourced,
-/// call `.First()` if it was defined by the user's `.Rprofile`.
+/// Matches R's documented startup sequence (see `?Startup`):
+/// after profiles are sourced, call `.First()` if it was defined by
+/// the user's `.Rprofile`.
 /// Uses `R_ToplevelExec` for safe error handling.
 ///
 /// Returns `true` if `.First` was invoked, `false` if it was undefined,
@@ -299,8 +300,8 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
         // defined — it is not exported to R_BaseEnv in all R versions), then
         // build the call with the function value as its head. Using the
         // resolved value skips a symbol lookup during eval and lets us
-        // evaluate in R_BaseEnv, matching R's main.c semantics so
-        // parent.frame() / sys.parent() inside .First.sys() see R_BaseEnv.
+        // evaluate in R_BaseEnv so parent.frame() / sys.parent() inside
+        // .First.sys() see R_BaseEnv, matching R's normal startup behavior.
         let base_ns = *lib.r_basenamespace;
         let val = protect.protect((lib.rf_findvar)(sym, base_ns));
 

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -295,20 +295,27 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
     unsafe {
         let mut protect = RProtect::new();
         let sym = install_symbol(".First.sys")?;
-        // Look up and evaluate in R_BaseNamespace so the symbol is always
-        // findable. R's main.c evaluates the call in R_BaseEnv, but
-        // .First.sys is not exported there in all R versions.
+        // Resolve the function value in R_BaseNamespace (where .First.sys is
+        // defined — it is not exported to R_BaseEnv in all R versions), then
+        // build the call with the function value as its head. Using the
+        // resolved value skips a symbol lookup during eval and lets us
+        // evaluate in R_BaseEnv, matching R's main.c semantics so
+        // parent.frame() / sys.parent() inside .First.sys() see R_BaseEnv.
         let base_ns = *lib.r_basenamespace;
-        let val = (lib.rf_findvar)(sym, base_ns);
+        let val = protect.protect((lib.rf_findvar)(sym, base_ns));
 
         if !is_callable_function(val, lib) {
             return Ok(false);
         }
 
         let nil = r_nil_value()?;
-        let call = protect.protect((lib.rf_lcons)(sym, nil));
+        let call = protect.protect((lib.rf_lcons)(val, nil));
 
-        let mut payload = CallPayload { call, env: base_ns };
+        let base_env = *lib.r_baseenv;
+        let mut payload = CallPayload {
+            call,
+            env: base_env,
+        };
         let success = (lib.r_toplevelexec)(
             Some(call_callback),
             &mut payload as *mut CallPayload as *mut std::ffi::c_void,

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -231,6 +231,7 @@ fn call_dot_first_impl() -> HarpResult<bool> {
     let lib = r_library()?;
 
     unsafe {
+        let mut protect = RProtect::new();
         let sym = install_symbol(".First")?;
         let global_env = *lib.r_globalenv;
         let val = (lib.rf_findvar)(sym, global_env);
@@ -244,7 +245,7 @@ fn call_dot_first_impl() -> HarpResult<bool> {
 
         // Build call: (.First) — lang1 equivalent
         let nil = r_nil_value()?;
-        let call = (lib.rf_lcons)(sym, nil);
+        let call = protect.protect((lib.rf_lcons)(sym, nil));
 
         let mut payload = CallPayload {
             call,
@@ -268,6 +269,7 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
     let lib = r_library()?;
 
     unsafe {
+        let mut protect = RProtect::new();
         let sym = install_symbol(".First.sys")?;
         // Look up in base namespace, eval in base env (mirrors R's main.c)
         let base_ns = *lib.r_basenamespace;
@@ -280,7 +282,7 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
         }
 
         let nil = r_nil_value()?;
-        let call = (lib.rf_lcons)(sym, nil);
+        let call = protect.protect((lib.rf_lcons)(sym, nil));
 
         let mut payload = CallPayload {
             call,

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -284,10 +284,7 @@ fn call_dot_first_sys_impl() -> HarpResult<bool> {
         let nil = r_nil_value()?;
         let call = protect.protect((lib.rf_lcons)(sym, nil));
 
-        let mut payload = CallPayload {
-            call,
-            env: *lib.r_baseenv,
-        };
+        let mut payload = CallPayload { call, env: base_ns };
         let success = (lib.r_toplevelexec)(
             Some(call_callback),
             &mut payload as *mut CallPayload as *mut std::ffi::c_void,

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -210,16 +210,21 @@ unsafe fn install_symbol(name: &str) -> HarpResult<SEXP> {
 /// Mirrors R's `main.c` startup sequence: after profiles are sourced,
 /// call `.First()` if it was defined by the user's `.Rprofile`.
 /// Uses `R_ToplevelExec` for safe error handling.
-pub fn call_dot_first() {
+///
+/// Returns `true` if `.First` was invoked, `false` if it was undefined,
+/// bound to a non-function, or if the call raised an R error.
+pub fn call_dot_first() -> bool {
     match call_dot_first_impl() {
         Ok(called) => {
             if called {
                 log::info!("Called .First()");
             }
+            called
         }
         Err(err) => {
             log::error!("Error calling .First(): {err}");
             eprintln!("Error in .First():\n{err}");
+            false
         }
     }
 }
@@ -229,16 +234,20 @@ pub fn call_dot_first() {
 /// `.First.sys()` loads the default packages (utils, grDevices, etc.) via
 /// `require()`. It must be called after `.First()` in the startup sequence.
 /// Uses `R_ToplevelExec` for safe error handling.
-pub fn call_dot_first_sys() {
+///
+/// Returns `true` if `.First.sys` was invoked, `false` otherwise.
+pub fn call_dot_first_sys() -> bool {
     match call_dot_first_sys_impl() {
         Ok(called) => {
             if called {
                 log::info!("Called .First.sys()");
             }
+            called
         }
         Err(err) => {
             log::error!("Error calling .First.sys(): {err}");
             eprintln!("Error in .First.sys():\n{err}");
+            false
         }
     }
 }

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -25,7 +25,7 @@
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
-use arf_libr::{SEXP, r_library, r_nil_value};
+use arf_libr::{SEXP, SexpType, r_library, r_nil_value};
 
 use crate::error::{HarpError, HarpResult};
 use crate::protect::RProtect;
@@ -187,6 +187,133 @@ unsafe fn install_symbol(name: &str) -> HarpResult<SEXP> {
         actual: "string with null byte".to_string(),
     })?;
     unsafe { Ok((lib.rf_install)(name_cstring.as_ptr())) }
+}
+
+/// Call `.First()` if it is defined as a function in `.GlobalEnv`.
+///
+/// Mirrors R's `main.c` startup sequence: after profiles are sourced,
+/// call `.First()` if it was defined by the user's `.Rprofile`.
+/// Uses `R_ToplevelExec` for safe error handling.
+pub fn call_dot_first() {
+    match call_dot_first_impl() {
+        Ok(called) => {
+            if called {
+                log::info!("Called .First()");
+            }
+        }
+        Err(err) => {
+            log::error!("Error calling .First(): {err}");
+            eprintln!("Error in .First():\n{err}");
+        }
+    }
+}
+
+/// Call `.First.sys()` from the base namespace.
+///
+/// `.First.sys()` loads the default packages (utils, grDevices, etc.) via
+/// `require()`. It must be called after `.First()` in the startup sequence.
+/// Uses `R_ToplevelExec` for safe error handling.
+pub fn call_dot_first_sys() {
+    match call_dot_first_sys_impl() {
+        Ok(called) => {
+            if called {
+                log::info!("Called .First.sys()");
+            }
+        }
+        Err(err) => {
+            log::error!("Error calling .First.sys(): {err}");
+            eprintln!("Error in .First.sys():\n{err}");
+        }
+    }
+}
+
+fn call_dot_first_impl() -> HarpResult<bool> {
+    let lib = r_library()?;
+
+    unsafe {
+        let sym = install_symbol(".First")?;
+        let global_env = *lib.r_globalenv;
+        let val = (lib.rf_findvar)(sym, global_env);
+
+        // Only call if .First is defined and is a closure (function)
+        let is_closure = val != *lib.r_unboundvalue
+            && (lib.rf_typeof)(val) == SexpType::ClosSxp as std::os::raw::c_int;
+        if !is_closure {
+            return Ok(false);
+        }
+
+        // Build call: (.First) — lang1 equivalent
+        let nil = r_nil_value()?;
+        let call = (lib.rf_lcons)(sym, nil);
+
+        let mut payload = CallPayload {
+            call,
+            env: global_env,
+        };
+        let success = (lib.r_toplevelexec)(
+            Some(call_callback),
+            &mut payload as *mut CallPayload as *mut std::ffi::c_void,
+        );
+
+        if success == 0 {
+            return Err(HarpError::RError(arf_libr::RError::EvalError(
+                "Error in .First() (R error occurred)".to_string(),
+            )));
+        }
+    }
+    Ok(true)
+}
+
+fn call_dot_first_sys_impl() -> HarpResult<bool> {
+    let lib = r_library()?;
+
+    unsafe {
+        let sym = install_symbol(".First.sys")?;
+        // Look up in base namespace, eval in base env (mirrors R's main.c)
+        let base_ns = *lib.r_basenamespace;
+        let val = (lib.rf_findvar)(sym, base_ns);
+
+        let is_closure = val != *lib.r_unboundvalue
+            && (lib.rf_typeof)(val) == SexpType::ClosSxp as std::os::raw::c_int;
+        if !is_closure {
+            return Ok(false);
+        }
+
+        let nil = r_nil_value()?;
+        let call = (lib.rf_lcons)(sym, nil);
+
+        let mut payload = CallPayload {
+            call,
+            env: *lib.r_baseenv,
+        };
+        let success = (lib.r_toplevelexec)(
+            Some(call_callback),
+            &mut payload as *mut CallPayload as *mut std::ffi::c_void,
+        );
+
+        if success == 0 {
+            return Err(HarpError::RError(arf_libr::RError::EvalError(
+                "Error in .First.sys() (R error occurred)".to_string(),
+            )));
+        }
+    }
+    Ok(true)
+}
+
+/// Payload for call_callback.
+struct CallPayload {
+    call: SEXP,
+    env: SEXP,
+}
+
+/// R_ToplevelExec callback for calling a no-arg R function.
+unsafe extern "C" fn call_callback(payload: *mut std::ffi::c_void) {
+    let data = unsafe { &mut *(payload as *mut CallPayload) };
+    let lib = match r_library() {
+        Ok(lib) => lib,
+        Err(_) => return,
+    };
+    unsafe { (lib.rf_eval)(data.call, data.env) };
 }
 
 /// Find site-level R profile.

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -1,0 +1,118 @@
+//! Integration tests for R startup hook functions.
+
+use arf_harp::{call_dot_first, call_dot_first_sys, eval_string};
+use once_cell::sync::OnceCell;
+use std::sync::Mutex;
+
+static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
+
+fn ensure_r_initialized() -> bool {
+    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
+
+    *R_INITIALIZED.get_or_init(|| unsafe {
+        match arf_libr::initialize_r() {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("Failed to initialize R: {}", e);
+                false
+            }
+        }
+    })
+}
+
+fn with_r<F, T>(f: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
+    if !ensure_r_initialized() {
+        return None;
+    }
+    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
+    // Use into_inner() to recover from a poisoned lock caused by a previous panic.
+    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+    Some(f())
+}
+
+/// Check that LD_LIBRARY_PATH includes the R library directory.
+/// Tests that require package loading (e.g. utils, methods) must be skipped
+/// when this is not set, because `initialize_r()` cannot re-exec the process
+/// as the binary does via `ensure_ld_library_path()`.
+fn ld_library_path_is_set() -> bool {
+    let Ok(lib_path) = arf_libr::find_r_library() else {
+        return false;
+    };
+    let Some(lib_dir) = lib_path.parent() else {
+        return false;
+    };
+    let lib_dir_str = lib_dir.to_string_lossy();
+    let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+    current.split(':').any(|p| p == lib_dir_str.as_ref())
+}
+
+#[test]
+fn test_call_dot_first_noop_when_undefined() {
+    // .First is not defined after plain R initialization — call should be a no-op.
+    with_r(|| {
+        eval_string("rm(list = intersect('.First', ls(.GlobalEnv)))").ok();
+        // Must not panic or error
+        call_dot_first();
+    });
+}
+
+#[test]
+fn test_call_dot_first_invokes_function() {
+    with_r(|| {
+        // Define .First in GlobalEnv with a detectable side effect
+        eval_string(".arf_test_first_called <- FALSE").unwrap();
+        eval_string(".First <- function() { .arf_test_first_called <<- TRUE }").unwrap();
+
+        call_dot_first();
+
+        eval_string("stopifnot(isTRUE(.arf_test_first_called))")
+            .expect(".First() should have been called and set .arf_test_first_called");
+
+        // Clean up
+        eval_string("rm('.First', '.arf_test_first_called', envir = .GlobalEnv)").ok();
+    });
+}
+
+#[test]
+fn test_call_dot_first_skips_non_function() {
+    with_r(|| {
+        // .First is defined but is not a function — should be skipped silently
+        eval_string(".First <- 42L").unwrap();
+
+        call_dot_first(); // must not panic or error
+
+        eval_string("rm('.First', envir = .GlobalEnv)").ok();
+    });
+}
+
+#[test]
+fn test_call_dot_first_sys_does_not_error() {
+    // .First.sys() loads default packages via require(). On Linux, R's
+    // setup_Rmainloop() already called it during initialization, so calling
+    // it again exercises the idempotent require() path.
+    with_r(|| {
+        call_dot_first_sys(); // must not panic or error
+    });
+}
+
+#[test]
+fn test_call_dot_first_sys_loads_default_packages() {
+    // After call_dot_first_sys(), the standard default packages should be attached.
+    // Requires LD_LIBRARY_PATH to be set so package shared libraries can be found.
+    if !ld_library_path_is_set() {
+        eprintln!(
+            "Skipping test_call_dot_first_sys_loads_default_packages: \
+             LD_LIBRARY_PATH not set. Run with LD_LIBRARY_PATH pointing to R's lib dir."
+        );
+        return;
+    }
+
+    with_r(|| {
+        call_dot_first_sys();
+        eval_string("stopifnot(isNamespaceLoaded('utils'))")
+            .expect("utils namespace should be loaded after .First.sys()");
+    });
+}

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -134,9 +134,9 @@ fn test_call_dot_first_sys_does_not_error() {
 #[test]
 fn test_call_dot_first_sys_evaluates_in_base_env() {
     // Guard against regressing the eval environment used for .First.sys().
-    // R's main.c evaluates the call in R_BaseEnv so parent.frame() inside
-    // .First.sys() returns R_BaseEnv. Evaluating in R_BaseNamespace instead
-    // would silently change that contract.
+    // R's normal startup evaluates the call in R_BaseEnv so parent.frame()
+    // inside .First.sys() returns R_BaseEnv. Evaluating in R_BaseNamespace
+    // instead would silently change that contract.
     //
     // The test overrides base::.First.sys with a probe that records its
     // caller frame, invokes call_dot_first_sys(), and asserts the recorded

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -89,6 +89,23 @@ fn test_call_dot_first_skips_non_function() {
 }
 
 #[test]
+fn test_call_dot_first_accepts_builtin() {
+    // .First can legitimately be bound to a BUILTINSXP primitive (e.g. `sum`).
+    // The callable-function detection must accept builtins, not only closures,
+    // so invocation must not panic or error. `sum()` with no args returns 0L,
+    // which is a safe no-side-effect call.
+    with_r(|| {
+        eval_string(".First <- sum").unwrap();
+        eval_string("stopifnot(typeof(.First) == 'builtin')")
+            .expect(".First should be bound to a BUILTINSXP primitive");
+
+        call_dot_first(); // must not panic or error
+
+        eval_string("rm('.First', envir = .GlobalEnv)").ok();
+    });
+}
+
+#[test]
 fn test_call_dot_first_sys_does_not_error() {
     // .First.sys() loads default packages via require(). On Linux, R's
     // setup_Rmainloop() already called it during initialization, so calling

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -51,11 +51,14 @@ fn ld_library_path_is_set() -> bool {
 
 #[test]
 fn test_call_dot_first_noop_when_undefined() {
-    // .First is not defined after plain R initialization — call should be a no-op.
+    // .First is not defined after plain R initialization — call must return
+    // false (skipped) and must not panic or error.
     with_r(|| {
         eval_string("try(rm('.First', envir = .GlobalEnv), silent = TRUE)").ok();
-        // Must not panic or error
-        call_dot_first();
+        assert!(
+            !call_dot_first(),
+            ".First is undefined, so call_dot_first() must report skipped"
+        );
     });
 }
 
@@ -66,7 +69,10 @@ fn test_call_dot_first_invokes_function() {
         eval_string(".arf_test_first_called <- FALSE").unwrap();
         eval_string(".First <- function() { .arf_test_first_called <<- TRUE }").unwrap();
 
-        call_dot_first();
+        assert!(
+            call_dot_first(),
+            "closure .First must be reported as invoked"
+        );
 
         eval_string("stopifnot(isTRUE(.arf_test_first_called))")
             .expect(".First() should have been called and set .arf_test_first_called");
@@ -79,10 +85,13 @@ fn test_call_dot_first_invokes_function() {
 #[test]
 fn test_call_dot_first_skips_non_function() {
     with_r(|| {
-        // .First is defined but is not a function — should be skipped silently
+        // .First is defined but is not a function — must be skipped silently.
         eval_string(".First <- 42L").unwrap();
 
-        call_dot_first(); // must not panic or error
+        assert!(
+            !call_dot_first(),
+            "non-function .First must be reported as skipped"
+        );
 
         eval_string("rm('.First', envir = .GlobalEnv)").ok();
     });
@@ -91,15 +100,18 @@ fn test_call_dot_first_skips_non_function() {
 #[test]
 fn test_call_dot_first_accepts_builtin() {
     // .First can legitimately be bound to a BUILTINSXP primitive (e.g. `sum`).
-    // The callable-function detection must accept builtins, not only closures,
-    // so invocation must not panic or error. `sum()` with no args returns 0L,
-    // which is a safe no-side-effect call.
+    // The callable-function detection must accept builtins, not only closures.
+    // `sum()` with no args returns 0L, which is a safe no-side-effect call.
     with_r(|| {
         eval_string(".First <- sum").unwrap();
         eval_string("stopifnot(typeof(.First) == 'builtin')")
             .expect(".First should be bound to a BUILTINSXP primitive");
 
-        call_dot_first(); // must not panic or error
+        assert!(
+            call_dot_first(),
+            "builtin .First must be reported as invoked — \
+             returning false would indicate it was silently skipped"
+        );
 
         eval_string("rm('.First', envir = .GlobalEnv)").ok();
     });
@@ -109,9 +121,13 @@ fn test_call_dot_first_accepts_builtin() {
 fn test_call_dot_first_sys_does_not_error() {
     // .First.sys() loads default packages via require(). On Linux, R's
     // setup_Rmainloop() already called it during initialization, so calling
-    // it again exercises the idempotent require() path.
+    // it again exercises the idempotent require() path. It must be reported
+    // as invoked since the base namespace always defines it.
     with_r(|| {
-        call_dot_first_sys(); // must not panic or error
+        assert!(
+            call_dot_first_sys(),
+            ".First.sys from R's base namespace must always be reported as invoked"
+        );
     });
 }
 
@@ -131,7 +147,10 @@ fn test_call_dot_first_sys_loads_default_packages() {
     }
 
     with_r(|| {
-        call_dot_first_sys();
+        assert!(
+            call_dot_first_sys(),
+            ".First.sys from R's base namespace must always be reported as invoked"
+        );
         eval_string("stopifnot(isNamespaceLoaded('utils'))")
             .expect("utils namespace should be loaded after .First.sys()");
     });

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -131,6 +131,50 @@ fn test_call_dot_first_sys_does_not_error() {
     });
 }
 
+#[test]
+fn test_call_dot_first_sys_evaluates_in_base_env() {
+    // Guard against regressing the eval environment used for .First.sys().
+    // R's main.c evaluates the call in R_BaseEnv so parent.frame() inside
+    // .First.sys() returns R_BaseEnv. Evaluating in R_BaseNamespace instead
+    // would silently change that contract.
+    //
+    // The test overrides base::.First.sys with a probe that records its
+    // caller frame, invokes call_dot_first_sys(), and asserts the recorded
+    // frame is identical to baseenv(). Every operation uses base-package
+    // primitives so no extra packages (utils / methods) are required.
+    with_r(|| {
+        eval_string(
+            "local({ \
+                 ns <- asNamespace('base'); \
+                 unlockBinding('.First.sys', ns); \
+                 .arf_saved_first_sys <<- ns$.First.sys; \
+                 ns$.First.sys <- function() { \
+                     assign('.arf_captured_frame', parent.frame(), envir = globalenv()) \
+                 } \
+             })",
+        )
+        .expect("should install .First.sys probe");
+
+        let invoked = call_dot_first_sys();
+
+        // Always restore the original binding, even if the assertions below fail.
+        let restored = eval_string(
+            "local({ \
+                 ns <- asNamespace('base'); \
+                 ns$.First.sys <- .arf_saved_first_sys; \
+                 lockBinding('.First.sys', ns); \
+                 rm('.arf_saved_first_sys', envir = globalenv()) \
+             })",
+        );
+
+        assert!(invoked, ".First.sys must be reported as invoked");
+        eval_string("stopifnot(identical(.arf_captured_frame, baseenv()))")
+            .expect(".First.sys must be evaluated in R_BaseEnv");
+        eval_string("rm('.arf_captured_frame', envir = globalenv())").ok();
+        restored.expect(".First.sys restoration should succeed");
+    });
+}
+
 // Windows does not use LD_LIBRARY_PATH, so package shared libraries are located
 // differently. Exclude this test on Windows until a Windows-equivalent check exists.
 #[cfg(not(windows))]

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -53,7 +53,7 @@ fn ld_library_path_is_set() -> bool {
 fn test_call_dot_first_noop_when_undefined() {
     // .First is not defined after plain R initialization — call should be a no-op.
     with_r(|| {
-        eval_string("rm(list = intersect('.First', ls(.GlobalEnv)))").ok();
+        eval_string("try(rm('.First', envir = .GlobalEnv), silent = TRUE)").ok();
         // Must not panic or error
         call_dot_first();
     });
@@ -98,6 +98,9 @@ fn test_call_dot_first_sys_does_not_error() {
     });
 }
 
+// Windows does not use LD_LIBRARY_PATH, so package shared libraries are located
+// differently. Exclude this test on Windows until a Windows-equivalent check exists.
+#[cfg(not(windows))]
 #[test]
 fn test_call_dot_first_sys_loads_default_packages() {
     // After call_dot_first_sys(), the standard default packages should be attached.

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -77,6 +77,7 @@ pub struct RLibrary {
     pub r_nilvalue: *mut SEXP,
     pub r_globalenv: *mut SEXP,
     pub r_baseenv: *mut SEXP,
+    pub r_basenamespace: *mut SEXP,
     pub r_unboundvalue: *mut SEXP,
 
     // Environment and variable manipulation
@@ -332,6 +333,7 @@ impl RLibrary {
             load_ptr!(r_nilvalue, b"R_NilValue\0", SEXP);
             load_ptr!(r_globalenv, b"R_GlobalEnv\0", SEXP);
             load_ptr!(r_baseenv, b"R_BaseEnv\0", SEXP);
+            load_ptr!(r_basenamespace, b"R_BaseNamespace\0", SEXP);
             load_ptr!(r_unboundvalue, b"R_UnboundValue\0", SEXP);
 
             // Load environment and variable manipulation functions
@@ -579,6 +581,7 @@ impl RLibrary {
                 r_nilvalue,
                 r_globalenv,
                 r_baseenv,
+                r_basenamespace,
                 r_unboundvalue,
                 rf_findvar,
                 rf_definevar,


### PR DESCRIPTION
## Summary

- On Windows, arf disables R's built-in profile loading during `setup_Rmainloop()` for `globalCallingHandlers()` compatibility, then sources `.Rprofile` manually. However, the standard R startup hooks `.First()` and `.First.sys()` were never called, causing the vscode-R session watcher to fail to connect and user startup logic in `.First()` to be silently skipped.
- Add `call_dot_first()` and `call_dot_first_sys()` to `arf-harp`, implemented using the same `R_ToplevelExec` + `Rf_eval` pattern as profile sourcing. Called in `source_r_profiles()` after profile files are loaded, in the same `.First()` → `.First.sys()` order described by R's documented startup (`?Startup`). Both return `bool` so callers (and tests) can observe whether the hook was actually invoked.
- Apply the same manual startup hook sequence in script mode (`arf -e` and `-f`) on Windows, matching the REPL and headless startup paths.
- Broaden `.First` / `.First.sys` callable detection from `CLOSXP` only to `CLOSXP | BUILTINSXP | SPECIALSXP`, matching `Rf_isFunction` semantics so primitive bindings are not silently skipped.
- Add `R_BaseNamespace` pointer to `arf-libr` so `.First.sys` can be located even in R versions that do not expose it from `R_BaseEnv`. Evaluate the call in `R_BaseEnv` so `parent.frame()` / `sys.parent()` inside `.First.sys()` behave identically to R's normal startup.

## Test plan

- [x] Integration test (`crates/arf-console/tests/cli_tests.rs`): `arf -e` sources `R_PROFILE_USER` and `--vanilla` suppresses it — covers Unix's built-in loader and Windows's `source_r_profiles()` with the same observable behavior
- [x] Integration tests (`crates/arf-harp/tests/startup.rs`): `.First` as closure / non-function / builtin / undefined, and `.First.sys` from base namespace; each asserts the `bool` return value so dispatch (not just absence of panic) is verified
- [x] Integration test (`crates/arf-harp/tests/startup.rs`): `.First.sys()` is evaluated in `R_BaseEnv` — overrides `base::.First.sys` with a probe that records `parent.frame()` and asserts it is `identical(baseenv())`
- [x] On Windows: start arf with a `.Rprofile` that defines `.First <- function() message("hello from .First")` and confirm the message appears on startup
- [x] On Windows: confirm default packages (`utils`, `grDevices`, etc.) are available after startup (loaded by `.First.sys()`)
- [ ] On Windows: confirm vscode-R session watcher connects successfully
- [x] Unix behavior unchanged (script-mode `source_r_profiles()` call is `#[cfg(windows)]`; unit/integration tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)