### PR TITLE
refactor: fix clippy warnings on Rust 1.95.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Run cargo clippy
         run: |
           rustup component add clippy
-          cargo clippy --all-targets --all-features --locked -- -D warnings
+          cargo clippy \
+            --all-targets \
+            --all-features \
+            --locked \
+            -- \
+            -D warnings
 
   test:
     strategy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
+        shell: bash
         run: |
           rustup component add clippy
           cargo clippy \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,13 @@ jobs:
             --check
 
   cargo-clippy:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Cache Rust
@@ -45,12 +51,7 @@ jobs:
       - name: Run cargo clippy
         run: |
           rustup component add clippy
-          cargo clippy \
-            --all-targets \
-            --all-features \
-            --locked \
-            -- \
-            -D warnings
+          cargo clippy --all-targets --all-features --locked -- -D warnings
 
   test:
     strategy:

--- a/crates/arf-console/src/editor/mode.rs
+++ b/crates/arf-console/src/editor/mode.rs
@@ -246,15 +246,11 @@ impl EditorState {
                 self.uncertain = true;
             }
             // Navigation events (used in UntilFound for arrow keys)
-            ReedlineEvent::Left => {
-                if self.cursor_pos > 0 {
-                    self.cursor_pos -= 1;
-                }
+            ReedlineEvent::Left if self.cursor_pos > 0 => {
+                self.cursor_pos -= 1;
             }
-            ReedlineEvent::Right => {
-                if self.cursor_pos < self.buffer_len {
-                    self.cursor_pos += 1;
-                }
+            ReedlineEvent::Right if self.cursor_pos < self.buffer_len => {
+                self.cursor_pos += 1;
             }
             ReedlineEvent::Up | ReedlineEvent::Down => {
                 // History navigation - we can't know the new buffer state.

--- a/crates/arf-console/src/fuzzy.rs
+++ b/crates/arf-console/src/fuzzy.rs
@@ -76,7 +76,7 @@ where
         .collect();
 
     // Sort by score (descending)
-    results.sort_by(|a, b| b.1.score.cmp(&a.1.score));
+    results.sort_by_key(|entry| std::cmp::Reverse(entry.1.score));
 
     results
 }

--- a/crates/arf-console/src/history/search.rs
+++ b/crates/arf-console/src/history/search.rs
@@ -76,7 +76,7 @@ impl FuzzyHistory {
             .collect();
 
         // Sort by score (descending)
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
         // Apply original limit if specified
         let results: Vec<HistoryItem> = if let Some(limit) = query.limit {

--- a/crates/arf-console/src/pager/help.rs
+++ b/crates/arf-console/src/pager/help.rs
@@ -179,12 +179,12 @@ impl HelpBrowser {
                             }
 
                             // Navigation
-                            (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
-                                if self.selected > 0 {
-                                    self.selected -= 1;
-                                    if self.selected < self.scroll_offset {
-                                        self.scroll_offset = self.selected;
-                                    }
+                            (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL)
+                                if self.selected > 0 =>
+                            {
+                                self.selected -= 1;
+                                if self.selected < self.scroll_offset {
+                                    self.scroll_offset = self.selected;
                                 }
                             }
                             (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
@@ -275,33 +275,31 @@ demo("{name}", package = "{pkg}")"#,
                             }
 
                             // Backspace - delete character before cursor
-                            (KeyCode::Backspace, _) => {
-                                if self.cursor_pos > 0 {
-                                    // Find byte position of character before cursor
-                                    let byte_pos = self
-                                        .query
-                                        .char_indices()
-                                        .nth(self.cursor_pos - 1)
-                                        .map(|(i, _)| i)
-                                        .unwrap_or(0);
-                                    self.query.remove(byte_pos);
-                                    self.cursor_pos -= 1;
-                                    self.update_filter();
-                                }
+                            (KeyCode::Backspace, _) if self.cursor_pos > 0 => {
+                                // Find byte position of character before cursor
+                                let byte_pos = self
+                                    .query
+                                    .char_indices()
+                                    .nth(self.cursor_pos - 1)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(0);
+                                self.query.remove(byte_pos);
+                                self.cursor_pos -= 1;
+                                self.update_filter();
                             }
 
                             // Delete - delete character at cursor
-                            (KeyCode::Delete, _) => {
-                                if self.cursor_pos < self.query.chars().count() {
-                                    let byte_pos = self
-                                        .query
-                                        .char_indices()
-                                        .nth(self.cursor_pos)
-                                        .map(|(i, _)| i)
-                                        .unwrap_or(self.query.len());
-                                    self.query.remove(byte_pos);
-                                    self.update_filter();
-                                }
+                            (KeyCode::Delete, _)
+                                if self.cursor_pos < self.query.chars().count() =>
+                            {
+                                let byte_pos = self
+                                    .query
+                                    .char_indices()
+                                    .nth(self.cursor_pos)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(self.query.len());
+                                self.query.remove(byte_pos);
+                                self.update_filter();
                             }
 
                             // Clear query
@@ -326,15 +324,15 @@ demo("{name}", package = "{pkg}")"#,
                             }
 
                             // Cursor movement
-                            (KeyCode::Left, _) | (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
-                                if self.cursor_pos > 0 {
-                                    self.cursor_pos -= 1;
-                                }
+                            (KeyCode::Left, _) | (KeyCode::Char('b'), KeyModifiers::CONTROL)
+                                if self.cursor_pos > 0 =>
+                            {
+                                self.cursor_pos -= 1;
                             }
-                            (KeyCode::Right, _) | (KeyCode::Char('f'), KeyModifiers::CONTROL) => {
-                                if self.cursor_pos < self.query.chars().count() {
-                                    self.cursor_pos += 1;
-                                }
+                            (KeyCode::Right, _) | (KeyCode::Char('f'), KeyModifiers::CONTROL)
+                                if self.cursor_pos < self.query.chars().count() =>
+                            {
+                                self.cursor_pos += 1;
                             }
                             (KeyCode::Home, _) | (KeyCode::Char('a'), KeyModifiers::CONTROL) => {
                                 self.cursor_pos = 0;
@@ -516,7 +514,7 @@ fn fuzzy_search_topics(topics: &[HelpTopic], query: &str) -> Vec<(HelpTopic, u32
         .collect();
 
     // Sort by score (descending)
-    results.sort_by(|a, b| b.1.cmp(&a.1));
+    results.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
     // Limit results
     results.truncate(MAX_FILTERED_RESULTS);

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -256,7 +256,7 @@ impl HistoryBrowser {
 
             // Sort by score (descending) if we have fuzzy scores
             if !self.filter.command_pattern.is_empty() {
-                results.sort_by(|a, b| b.1.cmp(&a.1));
+                results.sort_by_key(|entry| std::cmp::Reverse(entry.1));
             }
 
             self.filtered = results;
@@ -584,10 +584,10 @@ impl HistoryBrowser {
                                 }
 
                                 // Cursor movement
-                                (KeyCode::Left, KeyModifiers::NONE) => {
-                                    if self.filter.cursor_pos > 0 {
-                                        self.filter.cursor_pos -= 1;
-                                    }
+                                (KeyCode::Left, KeyModifiers::NONE)
+                                    if self.filter.cursor_pos > 0 =>
+                                {
+                                    self.filter.cursor_pos -= 1;
                                 }
                                 (KeyCode::Right, KeyModifiers::NONE) => {
                                     let query_len = self.filter.raw_query.chars().count();

--- a/crates/arf-console/src/pager/markdown.rs
+++ b/crates/arf-console/src/pager/markdown.rs
@@ -846,11 +846,7 @@ fn distribute_column_widths(natural: &[usize], available: usize) -> Vec<usize> {
     // Iteratively lock columns whose natural width fits in the fair share.
     loop {
         let remaining = available.saturating_sub(locked_total);
-        let share = if unlocked_count > 0 {
-            remaining / unlocked_count
-        } else {
-            0
-        };
+        let share = remaining.checked_div(unlocked_count).unwrap_or(0);
 
         let mut changed = false;
         for i in 0..n {
@@ -869,7 +865,7 @@ fn distribute_column_widths(natural: &[usize], available: usize) -> Vec<usize> {
     // Distribute remaining space among unlocked (wide) columns.
     if unlocked_count > 0 {
         let remaining = available.saturating_sub(locked_total);
-        let share = remaining / unlocked_count;
+        let share = remaining.checked_div(unlocked_count).unwrap_or(0);
         let extra = remaining % unlocked_count;
         let mut idx = 0;
         for i in 0..n {

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -859,18 +859,18 @@ fn enable_windows_virtual_terminal() {
         // Enable for stdout
         let stdout = std::io::stdout().as_raw_handle();
         let mut mode: u32 = 0;
-        if GetConsoleMode(stdout as *mut _, &mut mode) != 0 {
-            if SetConsoleMode(stdout as *mut _, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0 {
-                log::debug!("[WINDOWS] Enabled virtual terminal processing for stdout");
-            }
+        if GetConsoleMode(stdout as *mut _, &mut mode) != 0
+            && SetConsoleMode(stdout as *mut _, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0
+        {
+            log::debug!("[WINDOWS] Enabled virtual terminal processing for stdout");
         }
 
         // Enable for stderr
         let stderr = std::io::stderr().as_raw_handle();
-        if GetConsoleMode(stderr as *mut _, &mut mode) != 0 {
-            if SetConsoleMode(stderr as *mut _, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0 {
-                log::debug!("[WINDOWS] Enabled virtual terminal processing for stderr");
-            }
+        if GetConsoleMode(stderr as *mut _, &mut mode) != 0
+            && SetConsoleMode(stderr as *mut _, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0
+        {
+            log::debug!("[WINDOWS] Enabled virtual terminal processing for stderr");
         }
     }
 }
@@ -1095,10 +1095,8 @@ extern "C" fn r_callback() {
 /// Windows callback for ShowMessage.
 #[cfg(windows)]
 extern "C" fn r_show_message(msg: *const c_char) {
-    if !msg.is_null() {
-        if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
-            log::info!("[R ShowMessage] {}", s);
-        }
+    if !msg.is_null() && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
+        log::info!("[R ShowMessage] {}", s);
     }
 }
 
@@ -1108,10 +1106,10 @@ extern "C" fn r_show_message(msg: *const c_char) {
 extern "C" fn r_yes_no_cancel(question: *const c_char) -> c_int {
     // This is used during R's CleanUp when SA_SAVEASK is used.
     // We return -1 (No) to avoid saving.
-    if !question.is_null() {
-        if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(question) }.to_str() {
-            log::warn!("[R YesNoCancel] Ignoring question: '{}'. Returning NO.", s);
-        }
+    if !question.is_null()
+        && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(question) }.to_str()
+    {
+        log::warn!("[R YesNoCancel] Ignoring question: '{}'. Returning NO.", s);
     }
     -1 // NO
 }
@@ -1125,11 +1123,9 @@ extern "C" fn r_busy(_which: c_int) {
 /// Windows callback for Suicide (fatal error).
 #[cfg(windows)]
 extern "C" fn r_suicide(msg: *const c_char) {
-    if !msg.is_null() {
-        if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
-            log::error!("[R FATAL] {}", s);
-            eprintln!("R fatal error: {}", s);
-        }
+    if !msg.is_null() && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
+        log::error!("[R FATAL] {}", s);
+        eprintln!("R fatal error: {}", s);
     }
     std::process::exit(1);
 }

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -1095,7 +1095,9 @@ extern "C" fn r_callback() {
 /// Windows callback for ShowMessage.
 #[cfg(windows)]
 extern "C" fn r_show_message(msg: *const c_char) {
-    if !msg.is_null() && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
+    if !msg.is_null()
+        && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str()
+    {
         log::info!("[R ShowMessage] {}", s);
     }
 }
@@ -1123,7 +1125,9 @@ extern "C" fn r_busy(_which: c_int) {
 /// Windows callback for Suicide (fatal error).
 #[cfg(windows)]
 extern "C" fn r_suicide(msg: *const c_char) {
-    if !msg.is_null() && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str() {
+    if !msg.is_null()
+        && let Ok(s) = unsafe { std::ffi::CStr::from_ptr(msg) }.to_str()
+    {
         log::error!("[R FATAL] {}", s);
         eprintln!("R fatal error: {}", s);
     }


### PR DESCRIPTION
I fixed the clippy check warning newly introduced in Rust 1.95.0. The `cargo format` and `cargo clippy` have been passed on both Windows and Linux.

Furthermore, in the previous CI, clippy checks were only run on the Ubuntu platform, which would skip all specific code for the Windows platform (even with `--all-targets`). I added the Windows clippy check in CI (regardless of the Rust compiler version).