### PR TITLE
fix(windows): set `.Platform$GUI` to `"arf-console"` to prevent Rgui-only calls

### DIFF
--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1578,6 +1578,10 @@ fn setup_r_via_rig(version_spec: &str) -> Result<RSourceStatus> {
 /// source these files here.
 #[cfg(windows)]
 fn source_r_profiles(r_args: &[String]) {
+    // Fix .Platform$GUI before any R profiles or packages are loaded.
+    // See: https://github.com/eitsupi/arf/issues/168
+    arf_harp::override_platform_gui();
+
     // Get R_HOME from environment (set earlier in setup_r)
     let r_home = match std::env::var("R_HOME") {
         Ok(path) => PathBuf::from(path),

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1680,17 +1680,22 @@ fn test_platform_gui_non_windows() {
     );
 }
 
-/// `system("echo ok")` must succeed in headless mode.
+/// `system()` must succeed in headless mode.
 ///
 /// On Windows this is a regression test for the `.Platform$GUI` override
 /// introduced in GH#168: verifies that `CharacterMode` still works correctly
 /// after initialization.
+///
+/// Uses `Rscript --version` via `R.home("bin")` as a guaranteed cross-platform
+/// executable (avoids relying on `echo` as a shell builtin).
 #[test]
 fn test_system_works() {
     let process = HeadlessProcess::spawn().expect("Failed to spawn headless");
 
     let result = process
-        .ipc_eval(r#"system("echo ok", ignore.stdout = TRUE, ignore.stderr = TRUE) == 0L"#)
+        .ipc_eval(
+            r#"system(paste(shQuote(file.path(R.home("bin"), "Rscript")), "--version"), ignore.stdout = TRUE, ignore.stderr = TRUE) == 0L"#,
+        )
         .expect("eval should run");
     assert!(
         result.success,
@@ -1701,7 +1706,7 @@ fn test_system_works() {
     assert_eq!(
         json["value"].as_str(),
         Some("[1] TRUE"),
-        r#"system("echo ok") should return exit code 0, got: {}"#,
+        "system(Rscript --version) should return exit code 0, got: {}",
         result.stdout
     );
 }

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1624,3 +1624,48 @@ fn test_ipc_exit_code_protocol_error() {
         "should have message"
     );
 }
+
+/// On Windows, `.Platform$GUI` must be `"arf-console"` so that packages
+/// checking for `"Rgui"` do not call Windows-GUI-only functions.
+#[cfg(windows)]
+#[test]
+fn test_platform_gui_windows() {
+    let process = HeadlessProcess::spawn().expect("Failed to spawn headless");
+
+    let result = process
+        .ipc_eval(r#".Platform$GUI"#)
+        .expect("eval should run");
+    assert!(
+        result.success,
+        "eval should succeed. stderr: {}",
+        result.stderr
+    );
+    assert!(
+        result.stdout.contains(r#"[1] "arf-console""#),
+        r#".Platform$GUI should be "arf-console", got: {}"#,
+        result.stdout
+    );
+}
+
+/// On non-Windows, arf must not set `.Platform$GUI` to `"Rgui"`.
+/// The actual value depends on the environment ("unknown", "X11", etc.),
+/// but `"Rgui"` is always wrong on non-Windows platforms.
+#[cfg(not(windows))]
+#[test]
+fn test_platform_gui_non_windows() {
+    let process = HeadlessProcess::spawn().expect("Failed to spawn headless");
+
+    let result = process
+        .ipc_eval(r#".Platform$GUI"#)
+        .expect("eval should run");
+    assert!(
+        result.success,
+        "eval should succeed. stderr: {}",
+        result.stderr
+    );
+    assert!(
+        !result.stdout.contains(r#"[1] "Rgui""#),
+        r#".Platform$GUI must not be "Rgui" on non-Windows, got: {}"#,
+        result.stdout
+    );
+}

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1647,9 +1647,8 @@ fn test_platform_gui_windows() {
     );
 }
 
-/// On non-Windows, arf must not set `.Platform$GUI` to `"Rgui"`.
-/// The actual value depends on the environment ("unknown", "X11", etc.),
-/// but `"Rgui"` is always wrong on non-Windows platforms.
+/// On non-Windows, `.Platform$GUI` must not be `"arf-console"`: the
+/// Windows-only override must not apply on other platforms.
 #[cfg(not(windows))]
 #[test]
 fn test_platform_gui_non_windows() {
@@ -1664,8 +1663,8 @@ fn test_platform_gui_non_windows() {
         result.stderr
     );
     assert!(
-        !result.stdout.contains(r#"[1] "Rgui""#),
-        r#".Platform$GUI must not be "Rgui" on non-Windows, got: {}"#,
+        !result.stdout.contains(r#"[1] "arf-console""#),
+        r#".Platform$GUI must not be "arf-console" on non-Windows, got: {}"#,
         result.stdout
     );
 }

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1669,9 +1669,12 @@ fn test_platform_gui_non_windows() {
     // ipc_eval returns raw JSON; parse it and check the `value` field to avoid
     // issues with JSON-escaped quotes.
     let json = parse_ipc_json(&result);
+    let value = json["value"]
+        .as_str()
+        .expect(".Platform$GUI eval should return a non-null string value");
     assert_ne!(
-        json["value"].as_str(),
-        Some(r#"[1] "arf-console""#),
+        value,
+        r#"[1] "arf-console""#,
         r#".Platform$GUI must not be "arf-console" on non-Windows, got: {}"#,
         result.stdout
     );

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1676,3 +1676,29 @@ fn test_platform_gui_non_windows() {
         result.stdout
     );
 }
+
+/// `system("echo ok")` must succeed in headless mode.
+///
+/// On Windows this is a regression test for the `.Platform$GUI` override
+/// introduced in GH#168: verifies that `CharacterMode` still works correctly
+/// after initialization.
+#[test]
+fn test_system_works() {
+    let process = HeadlessProcess::spawn().expect("Failed to spawn headless");
+
+    let result = process
+        .ipc_eval(r#"system("echo ok", ignore.stdout = TRUE, ignore.stderr = TRUE) == 0L"#)
+        .expect("eval should run");
+    assert!(
+        result.success,
+        "eval should succeed. stderr: {}",
+        result.stderr
+    );
+    let json = parse_ipc_json(&result);
+    assert_eq!(
+        json["value"].as_str(),
+        Some("[1] TRUE"),
+        r#"system("echo ok") should return exit code 0, got: {}"#,
+        result.stdout
+    );
+}

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1673,8 +1673,7 @@ fn test_platform_gui_non_windows() {
         .as_str()
         .expect(".Platform$GUI eval should return a non-null string value");
     assert_ne!(
-        value,
-        r#"[1] "arf-console""#,
+        value, r#"[1] "arf-console""#,
         r#".Platform$GUI must not be "arf-console" on non-Windows, got: {}"#,
         result.stdout
     );

--- a/crates/arf-console/tests/headless_tests.rs
+++ b/crates/arf-console/tests/headless_tests.rs
@@ -1640,8 +1640,12 @@ fn test_platform_gui_windows() {
         "eval should succeed. stderr: {}",
         result.stderr
     );
-    assert!(
-        result.stdout.contains(r#"[1] "arf-console""#),
+    // ipc_eval returns raw JSON; parse it and check the `value` field to avoid
+    // issues with JSON-escaped quotes (e.g. `\"arf-console\"` vs `"arf-console"`).
+    let json = parse_ipc_json(&result);
+    assert_eq!(
+        json["value"].as_str(),
+        Some(r#"[1] "arf-console""#),
         r#".Platform$GUI should be "arf-console", got: {}"#,
         result.stdout
     );
@@ -1662,8 +1666,12 @@ fn test_platform_gui_non_windows() {
         "eval should succeed. stderr: {}",
         result.stderr
     );
-    assert!(
-        !result.stdout.contains(r#"[1] "arf-console""#),
+    // ipc_eval returns raw JSON; parse it and check the `value` field to avoid
+    // issues with JSON-escaped quotes.
+    let json = parse_ipc_json(&result);
+    assert_ne!(
+        json["value"].as_str(),
+        Some(r#"[1] "arf-console""#),
         r#".Platform$GUI must not be "arf-console" on non-Windows, got: {}"#,
         result.stdout
     );

--- a/crates/arf-harp/src/lib.rs
+++ b/crates/arf-harp/src/lib.rs
@@ -14,6 +14,8 @@ pub use error::*;
 pub use help::*;
 pub use object::*;
 pub use protect::*;
+#[cfg(windows)]
+pub use startup::override_platform_gui;
 pub use startup::{
     call_dot_first, call_dot_first_sys, should_ignore_site_r_profile, should_ignore_user_r_profile,
     source_site_r_profile, source_user_r_profile,

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -30,6 +30,40 @@ use arf_libr::{RLibrary, SEXP, SexpType, r_library, r_nil_value};
 use crate::error::{HarpError, HarpResult};
 use crate::protect::RProtect;
 
+/// Override `.Platform$GUI` to `"arf-console"` in `baseenv()`.
+///
+/// On Windows, arf initializes R with `CharacterMode = RGui` so that R sets up
+/// console callbacks correctly. As a side effect, R sets `.Platform$GUI` to
+/// `"Rgui"`, which causes packages such as `limma` to call Windows-GUI-only
+/// functions (e.g. `winMenuAddItem`) that fail outside an actual Rgui window.
+///
+/// Switching `CharacterMode` to `LinkDLL` before `setup_Rmainloop()` (done to
+/// fix `system()` hangs, see GH#116) does not retroactively update
+/// `.Platform$GUI`, so we correct it here by assigning the proper frontend name.
+///
+/// This follows the same pattern used by ark, which sets `.Platform$GUI` to its
+/// own frontend name via `env_bind_force()`.
+///
+/// Must be called after R is initialised and before any R profiles or packages
+/// are loaded, so that `.onAttach` hooks in user packages see the correct value.
+#[cfg(windows)]
+pub fn override_platform_gui() {
+    let code = r##"local({
+        p <- base::.Platform
+        p[["GUI"]] <- "arf-console"
+        e <- baseenv()
+        locked <- bindingIsLocked(".Platform", e)
+        if (locked) unlockBinding(".Platform", e)
+        assign(".Platform", p, envir = e, inherits = FALSE)
+        if (locked) lockBinding(".Platform", e)
+    })"##;
+
+    match crate::eval_string(code) {
+        Ok(_) => log::info!(r#"[WINDOWS] .Platform$GUI set to "arf-console""#),
+        Err(err) => log::error!("[WINDOWS] Failed to override .Platform$GUI: {err}"),
+    }
+}
+
 /// Check if site R profile loading should be skipped based on command line args.
 pub fn should_ignore_site_r_profile(args: &[String]) -> bool {
     args.iter()


### PR DESCRIPTION
## Summary

- On Windows, arf initializes R with `CharacterMode = RGui` to set up console callbacks correctly, which causes R to set `.Platform$GUI` to `"Rgui"`
- Packages such as `limma` check `.Platform$GUI == "Rgui"` in `.onAttach` and call Windows-GUI-only functions (e.g. `winMenuAddItem`) that fail outside an actual Rgui window
- Override `.Platform$GUI` to `"arf-console"` before R profiles are sourced, following the same pattern used by ark

Fixes #168

## Test plan

- [ ] On Windows: `library(limma)` loads without error
- [x] On Windows: `.Platform$GUI` returns `"arf-console"`
- [x] On Windows: `system()` / `system2()` still work (CharacterMode fix from #116 unaffected)
- [x] On Unix/macOS: no behaviour change (fix is `#[cfg(windows)]` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)