### PR TITLE
feat: add path completion in shell mode

### DIFF
--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -85,6 +85,9 @@
             "library",
             "require"
           ]
+        },
+        "shell_completion": {
+          "command_names": false
         }
       }
     },
@@ -1599,6 +1602,13 @@
               "require"
             ]
           }
+        },
+        "shell_completion": {
+          "description": "Shell mode completion configuration.",
+          "$ref": "#/$defs/ShellCompletionConfig",
+          "default": {
+            "command_names": false
+          }
         }
       }
     },
@@ -1853,6 +1863,17 @@
           "description": "Comment prefix for output (default: \"#> \").",
           "type": "string",
           "default": "#> "
+        }
+      }
+    },
+    "ShellCompletionConfig": {
+      "description": "Configuration for shell mode completion.\n\nControls what is suggested when Tab is pressed in shell mode.",
+      "type": "object",
+      "properties": {
+        "command_names": {
+          "description": "Enable completion of executable command names from PATH.\n\nWhen enabled, pressing Tab at the start of a shell command suggests\nexecutable names found in PATH directories in addition to path completions.\nWhen disabled (default), only file/directory path completion is provided.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/arf-console/src/completion/meta.rs
+++ b/crates/arf-console/src/completion/meta.rs
@@ -157,6 +157,21 @@ impl MetaCommandCompleter {
         MetaCommandCompleter { excluded_commands }
     }
 
+    /// Commands excluded from meta completion while in shell mode.
+    pub(crate) fn shell_mode_exclusions() -> Vec<&'static str> {
+        vec![
+            "shell",
+            "system",
+            "autoformat",
+            "format",
+            "restart",
+            "reprex",
+            "switch",
+            "h",
+            "help",
+        ]
+    }
+
     /// Complete meta commands.
     fn complete_commands(&self, line: &str, pos: usize) -> Vec<Suggestion> {
         let trimmed = line.trim_start();
@@ -574,17 +589,8 @@ mod tests {
     #[test]
     fn test_meta_command_completer_excludes_shell_mode_commands() {
         // In Shell mode, R-specific commands should be excluded from completion
-        let mut completer = MetaCommandCompleter::with_exclusions(vec![
-            "shell",
-            "system",
-            "autoformat",
-            "format",
-            "restart",
-            "reprex",
-            "switch",
-            "h",
-            "help",
-        ]);
+        let mut completer =
+            MetaCommandCompleter::with_exclusions(MetaCommandCompleter::shell_mode_exclusions());
         let suggestions = completer.complete(":", 1);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
 

--- a/crates/arf-console/src/completion/mod.rs
+++ b/crates/arf-console/src/completion/mod.rs
@@ -7,5 +7,5 @@ pub mod menu;
 mod meta;
 pub(crate) mod path;
 mod r_completer;
-pub mod shell;
+pub(crate) mod shell;
 mod string_context;

--- a/crates/arf-console/src/completion/mod.rs
+++ b/crates/arf-console/src/completion/mod.rs
@@ -7,4 +7,5 @@ pub mod menu;
 mod meta;
 pub(crate) mod path;
 mod r_completer;
+pub mod shell;
 mod string_context;

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -118,17 +118,9 @@ impl ShellCompleter {
     /// command also suggests executable names from PATH directories.
     pub fn new(command_names: bool) -> Self {
         Self {
-            meta_completer: MetaCommandCompleter::with_exclusions(vec![
-                "shell",
-                "system",
-                "autoformat",
-                "format",
-                "restart",
-                "reprex",
-                "switch",
-                "h",
-                "help",
-            ]),
+            meta_completer: MetaCommandCompleter::with_exclusions(
+                MetaCommandCompleter::shell_mode_exclusions(),
+            ),
             command_names,
             command_cache: None,
         }

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -15,6 +15,12 @@ const SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
 ///
 /// Walks forward through the line up to `pos`, tracking the position after
 /// the last whitespace or shell separator character.
+///
+/// Known limitation: quote state is not tracked. Whitespace inside a quoted
+/// segment (e.g. `"dir with spaces/"`) is still treated as a token boundary,
+/// so Tab-completing again inside an already-inserted quoted path may produce
+/// incorrect span positions. Quote-aware tokenization is deferred to a future
+/// version.
 fn current_token_start(line: &str, pos: usize) -> usize {
     let slice = &line[..pos];
     let mut last_sep_end = 0;
@@ -135,7 +141,13 @@ impl Completer for ShellCompleter {
         let mut suggestions =
             path_to_suggestions(partial, pos, token_start, &PathCompletionOptions::default());
 
-        // Wrap paths containing spaces in double quotes for shell safety
+        // Wrap paths containing spaces in double quotes.
+        // Known limitation: this naive quoting is not safe for paths that
+        // contain `"`, `$`, backticks, or backslashes, as those characters
+        // retain special meaning inside double quotes and could cause unintended
+        // shell expansion or injection when the completed command is executed.
+        // Robust shell escaping (e.g. single-quote strategy) is deferred to a
+        // future version.
         for s in &mut suggestions {
             if s.value.contains(' ') {
                 s.value = format!("\"{}\"", s.value);

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -8,8 +8,10 @@ use super::path::PathCompletionOptions;
 use super::string_context::path_to_suggestions;
 use reedline::{Completer, Span, Suggestion};
 
-/// Shell command separators that start a new token and command context.
-const SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
+/// Shell separators that start a new token.
+const TOKEN_SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
+/// Shell separators that start a new command segment.
+const COMMAND_SEPARATORS: &[char] = &['|', ';', '&'];
 
 /// Find the byte position where the current token starts.
 ///
@@ -25,7 +27,7 @@ fn current_token_start(line: &str, pos: usize) -> usize {
     let slice = &line[..pos];
     let mut last_sep_end = 0;
     for (byte_pos, ch) in slice.char_indices() {
-        if ch.is_whitespace() || SEPARATORS.contains(&ch) {
+        if ch.is_whitespace() || TOKEN_SEPARATORS.contains(&ch) {
             last_sep_end = byte_pos + ch.len_utf8();
         }
     }
@@ -44,7 +46,7 @@ fn is_command_position(line: &str, pos: usize) -> bool {
     let last_sep_end = {
         let mut sep_end = 0;
         for (byte_pos, ch) in before_token.char_indices() {
-            if SEPARATORS.contains(&ch) {
+            if COMMAND_SEPARATORS.contains(&ch) {
                 sep_end = byte_pos + ch.len_utf8();
             }
         }
@@ -69,7 +71,11 @@ fn collect_executables_from_path_str(path_str: &str) -> Vec<String> {
     for dir in std::env::split_paths(path_str) {
         if let Ok(read_dir) = std::fs::read_dir(&dir) {
             for entry in read_dir.filter_map(|e| e.ok()) {
-                names.insert(entry.file_name().to_string_lossy().into_owned());
+                if let Ok(file_type) = entry.file_type()
+                    && (file_type.is_file() || file_type.is_symlink())
+                {
+                    names.insert(entry.file_name().to_string_lossy().into_owned());
+                }
             }
         }
     }
@@ -149,8 +155,17 @@ impl Completer for ShellCompleter {
         // Robust shell escaping (e.g. single-quote strategy) is deferred to a
         // future version.
         for s in &mut suggestions {
+            #[cfg(windows)]
+            {
+                s.value = s.value.replace('/', "\\");
+            }
             if s.value.contains(' ') {
                 s.value = format!("\"{}\"", s.value);
+                if let Some(match_indices) = &mut s.match_indices {
+                    for index in match_indices.iter_mut() {
+                        *index += 1;
+                    }
+                }
             }
         }
 
@@ -236,6 +251,11 @@ mod tests {
     }
 
     #[test]
+    fn test_is_command_position_after_redirection_is_false() {
+        assert!(!is_command_position("echo hi > out", 13));
+    }
+
+    #[test]
     fn test_shell_completer_delegates_meta_commands() {
         let mut completer = ShellCompleter::new(false);
         // :cd is available in shell mode (not excluded)
@@ -289,6 +309,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("mybin"), b"").unwrap();
         std::fs::write(dir.path().join("othertool"), b"").unwrap();
+        std::fs::create_dir(dir.path().join("not-a-command-dir")).unwrap();
 
         let path_str = dir.path().to_string_lossy();
         let names = collect_executables_from_path_str(&path_str);
@@ -297,6 +318,10 @@ mod tests {
         assert!(
             names.contains(&"othertool".to_string()),
             "should find othertool"
+        );
+        assert!(
+            !names.contains(&"not-a-command-dir".to_string()),
+            "should not include directory names"
         );
     }
 

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -52,15 +52,15 @@ fn is_command_position(line: &str, pos: usize) -> bool {
         .all(|c| c.is_whitespace())
 }
 
-/// Collect all names of files found in PATH directories.
+/// Collect all file names found in the directories listed in `path_str`.
 ///
 /// Results are sorted and deduplicated. No executable-bit filtering is applied
 /// (false positives are acceptable for completion purposes).
-fn collect_path_executables() -> Vec<String> {
-    let path_var = std::env::var("PATH").unwrap_or_default();
+/// Separated from `collect_path_executables` for testability.
+fn collect_executables_from_path_str(path_str: &str) -> Vec<String> {
     let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    for dir in std::env::split_paths(&path_var) {
+    for dir in std::env::split_paths(path_str) {
         if let Ok(read_dir) = std::fs::read_dir(&dir) {
             for entry in read_dir.filter_map(|e| e.ok()) {
                 names.insert(entry.file_name().to_string_lossy().into_owned());
@@ -71,6 +71,10 @@ fn collect_path_executables() -> Vec<String> {
     let mut result: Vec<String> = names.into_iter().collect();
     result.sort();
     result
+}
+
+fn collect_path_executables() -> Vec<String> {
+    collect_executables_from_path_str(&std::env::var("PATH").unwrap_or_default())
 }
 
 /// Completer for shell mode.
@@ -266,5 +270,108 @@ mod tests {
         for s in &suggestions {
             assert_eq!(s.span.start, 4, "span should start at the token start (4)");
         }
+    }
+
+    #[test]
+    fn test_collect_executables_from_path_str_finds_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mybin"), b"").unwrap();
+        std::fs::write(dir.path().join("othertool"), b"").unwrap();
+
+        let path_str = dir.path().to_string_lossy();
+        let names = collect_executables_from_path_str(&path_str);
+
+        assert!(names.contains(&"mybin".to_string()), "should find mybin");
+        assert!(
+            names.contains(&"othertool".to_string()),
+            "should find othertool"
+        );
+    }
+
+    #[test]
+    fn test_collect_executables_from_path_str_deduplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("shared"), b"").unwrap();
+
+        // Same directory listed twice via std::env::join_paths
+        let twice = std::env::join_paths([dir.path(), dir.path()]).unwrap();
+        let path_str = twice.to_string_lossy();
+        let names = collect_executables_from_path_str(&path_str);
+        let count = names.iter().filter(|n| n.as_str() == "shared").count();
+        assert_eq!(
+            count, 1,
+            "duplicates from repeated PATH entries should be removed"
+        );
+    }
+
+    #[test]
+    fn test_collect_executables_from_path_str_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("zz_last"), b"").unwrap();
+        std::fs::write(dir.path().join("aa_first"), b"").unwrap();
+
+        let path_str = dir.path().to_string_lossy();
+        let names = collect_executables_from_path_str(&path_str);
+
+        let aa = names.iter().position(|n| n == "aa_first").unwrap();
+        let zz = names.iter().position(|n| n == "zz_last").unwrap();
+        assert!(aa < zz, "results should be sorted alphabetically");
+    }
+
+    #[test]
+    fn test_collect_executables_from_path_str_ignores_missing_dirs() {
+        let names =
+            collect_executables_from_path_str("/nonexistent_path_that_does_not_exist_12345");
+        assert!(
+            names.is_empty(),
+            "missing directories should not cause a panic or yield results"
+        );
+    }
+
+    #[test]
+    fn test_shell_completer_command_names_prefix_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("myapp"), b"").unwrap();
+        std::fs::write(dir.path().join("myother"), b"").unwrap();
+        std::fs::write(dir.path().join("unrelated"), b"").unwrap();
+
+        let path_str = dir.path().to_string_lossy().into_owned();
+        let mut completer = ShellCompleter::new(true);
+        // Pre-populate cache with our controlled directory
+        completer.command_cache = Some(collect_executables_from_path_str(&path_str));
+
+        let suggestions = completer.complete("my", 2);
+        let cmd_values: Vec<&str> = suggestions
+            .iter()
+            .filter(|s| s.description.as_deref() == Some("command"))
+            .map(|s| s.value.as_str())
+            .collect();
+
+        assert!(cmd_values.contains(&"myapp"), "should suggest myapp");
+        assert!(cmd_values.contains(&"myother"), "should suggest myother");
+        assert!(
+            !cmd_values.contains(&"unrelated"),
+            "should not suggest unrelated"
+        );
+    }
+
+    #[test]
+    fn test_shell_completer_command_names_not_in_arg_position() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mybin"), b"").unwrap();
+
+        let path_str = dir.path().to_string_lossy().into_owned();
+        let mut completer = ShellCompleter::new(true);
+        completer.command_cache = Some(collect_executables_from_path_str(&path_str));
+
+        // "ls my" — cursor is in argument position, not command position
+        let suggestions = completer.complete("ls my", 5);
+        let has_cmd = suggestions
+            .iter()
+            .any(|s| s.description.as_deref() == Some("command") && s.value == "mybin");
+        assert!(
+            !has_cmd,
+            "command names should not appear in argument position"
+        );
     }
 }

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -11,7 +11,7 @@ use reedline::{Completer, Span, Suggestion};
 /// Shell separators that start a new token.
 const TOKEN_SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
 /// Shell separators that start a new command segment.
-const COMMAND_SEPARATORS: &[char] = &['|', ';', '&'];
+const COMMAND_SEPARATORS: &[char] = &['|', ';'];
 
 /// Find the byte position where the current token starts.
 ///
@@ -24,6 +24,10 @@ const COMMAND_SEPARATORS: &[char] = &['|', ';', '&'];
 /// incorrect span positions. Quote-aware tokenization is deferred to a future
 /// version.
 fn current_token_start(line: &str, pos: usize) -> usize {
+    let pos = pos.min(line.len());
+    if !line.is_char_boundary(pos) {
+        return 0;
+    }
     let slice = &line[..pos];
     let mut last_sep_end = 0;
     for (byte_pos, ch) in slice.char_indices() {
@@ -39,16 +43,24 @@ fn current_token_start(line: &str, pos: usize) -> usize {
 /// Returns true if the current token is the first non-whitespace token in the
 /// current command segment (i.e., after the last shell separator like `|`, `;`).
 fn is_command_position(line: &str, pos: usize) -> bool {
+    let pos = pos.min(line.len());
+    if !line.is_char_boundary(pos) {
+        return false;
+    }
     let token_start = current_token_start(line, pos);
     let before_token = &line[..token_start];
 
     // Find the byte position after the last shell segment separator
     let last_sep_end = {
         let mut sep_end = 0;
+        let mut prev: Option<char> = None;
         for (byte_pos, ch) in before_token.char_indices() {
-            if COMMAND_SEPARATORS.contains(&ch) {
+            let is_separator = COMMAND_SEPARATORS.contains(&ch)
+                || (ch == '&' && !matches!(prev, Some('<' | '>')));
+            if is_separator {
                 sep_end = byte_pos + ch.len_utf8();
             }
+            prev = Some(ch);
         }
         sep_end
     };
@@ -132,6 +144,10 @@ impl ShellCompleter {
 
 impl Completer for ShellCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let pos = pos.min(line.len());
+        if !line.is_char_boundary(pos) {
+            return vec![];
+        }
         let trimmed = line.trim_start();
 
         // Delegate meta commands to MetaCommandCompleter
@@ -160,6 +176,10 @@ impl Completer for ShellCompleter {
                 s.value = s.value.replace('/', "\\");
             }
             if s.value.contains(' ') {
+                #[cfg(windows)]
+                if s.value.ends_with('\\') {
+                    s.value.push('\\');
+                }
                 s.value = format!("\"{}\"", s.value);
                 if let Some(match_indices) = &mut s.match_indices {
                     for index in match_indices.iter_mut() {
@@ -226,6 +246,11 @@ mod tests {
     }
 
     #[test]
+    fn test_current_token_start_non_char_boundary_is_safe() {
+        assert_eq!(current_token_start("aé", 2), 0);
+    }
+
+    #[test]
     fn test_is_command_position_first_token() {
         assert!(is_command_position("ls", 2));
         assert!(is_command_position("  ls", 4));
@@ -253,6 +278,8 @@ mod tests {
     #[test]
     fn test_is_command_position_after_redirection_is_false() {
         assert!(!is_command_position("echo hi > out", 13));
+        assert!(!is_command_position("echo hi 2>&1", "echo hi 2>&1".len()));
+        assert!(!is_command_position("echo hi <&0", "echo hi <&0".len()));
     }
 
     #[test]

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -1,0 +1,270 @@
+//! Shell mode completion.
+//!
+//! Provides path completion and optional executable name completion
+//! for shell mode commands.
+
+use super::meta::MetaCommandCompleter;
+use super::path::PathCompletionOptions;
+use super::string_context::path_to_suggestions;
+use reedline::{Completer, Span, Suggestion};
+
+/// Shell command separators that start a new token and command context.
+const SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
+
+/// Find the byte position where the current token starts.
+///
+/// Walks forward through the line up to `pos`, tracking the position after
+/// the last whitespace or shell separator character.
+fn current_token_start(line: &str, pos: usize) -> usize {
+    let slice = &line[..pos];
+    let mut last_sep_end = 0;
+    for (byte_pos, ch) in slice.char_indices() {
+        if ch.is_whitespace() || SEPARATORS.contains(&ch) {
+            last_sep_end = byte_pos + ch.len_utf8();
+        }
+    }
+    last_sep_end
+}
+
+/// Determine whether the cursor is in a command-name position.
+///
+/// Returns true if the current token is the first non-whitespace token in the
+/// current command segment (i.e., after the last shell separator like `|`, `;`).
+fn is_command_position(line: &str, pos: usize) -> bool {
+    let token_start = current_token_start(line, pos);
+    let before_token = &line[..token_start];
+
+    // Find the byte position after the last shell segment separator
+    let last_sep_end = {
+        let mut sep_end = 0;
+        for (byte_pos, ch) in before_token.char_indices() {
+            if SEPARATORS.contains(&ch) {
+                sep_end = byte_pos + ch.len_utf8();
+            }
+        }
+        sep_end
+    };
+
+    // If everything between the last separator and token start is whitespace,
+    // the current token is the command name in the segment
+    before_token[last_sep_end..]
+        .chars()
+        .all(|c| c.is_whitespace())
+}
+
+/// Collect all names of files found in PATH directories.
+///
+/// Results are sorted and deduplicated. No executable-bit filtering is applied
+/// (false positives are acceptable for completion purposes).
+fn collect_path_executables() -> Vec<String> {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for dir in std::env::split_paths(&path_var) {
+        if let Ok(read_dir) = std::fs::read_dir(&dir) {
+            for entry in read_dir.filter_map(|e| e.ok()) {
+                names.insert(entry.file_name().to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    let mut result: Vec<String> = names.into_iter().collect();
+    result.sort();
+    result
+}
+
+/// Completer for shell mode.
+///
+/// Provides path completion for all arguments and optionally completes
+/// executable names from PATH when the cursor is in command position.
+pub struct ShellCompleter {
+    meta_completer: MetaCommandCompleter,
+    command_names: bool,
+    command_cache: Option<Vec<String>>,
+}
+
+impl ShellCompleter {
+    /// Create a new `ShellCompleter`.
+    ///
+    /// When `command_names` is true, Tab-completing the first token of a shell
+    /// command also suggests executable names from PATH directories.
+    pub fn new(command_names: bool) -> Self {
+        Self {
+            meta_completer: MetaCommandCompleter::with_exclusions(vec![
+                "shell",
+                "system",
+                "autoformat",
+                "format",
+                "restart",
+                "reprex",
+                "switch",
+                "h",
+                "help",
+            ]),
+            command_names,
+            command_cache: None,
+        }
+    }
+
+    fn get_command_names(&mut self) -> &[String] {
+        if self.command_cache.is_none() {
+            self.command_cache = Some(collect_path_executables());
+        }
+        self.command_cache.as_ref().unwrap()
+    }
+}
+
+impl Completer for ShellCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let trimmed = line.trim_start();
+
+        // Delegate meta commands to MetaCommandCompleter
+        if trimmed.starts_with(':') {
+            return self.meta_completer.complete(line, pos);
+        }
+
+        // Find the current token start and extract the partial text
+        let token_start = current_token_start(line, pos);
+        let partial = &line[token_start..pos];
+
+        // Get path completions for the current token
+        let mut suggestions =
+            path_to_suggestions(partial, pos, token_start, &PathCompletionOptions::default());
+
+        // Wrap paths containing spaces in double quotes for shell safety
+        for s in &mut suggestions {
+            if s.value.contains(' ') {
+                s.value = format!("\"{}\"", s.value);
+            }
+        }
+
+        // Add command name completions when in command position and enabled
+        if self.command_names && is_command_position(line, pos) {
+            let cmd_suggestions: Vec<Suggestion> = self
+                .get_command_names()
+                .iter()
+                .filter(|name| partial.is_empty() || name.starts_with(partial))
+                .map(|name| Suggestion {
+                    value: name.clone(),
+                    display_override: None,
+                    description: Some("command".to_string()),
+                    extra: None,
+                    span: Span {
+                        start: token_start,
+                        end: pos,
+                    },
+                    append_whitespace: false,
+                    style: None,
+                    match_indices: None,
+                })
+                .collect();
+
+            // Command names follow path suggestions
+            suggestions.extend(cmd_suggestions);
+        }
+
+        suggestions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_current_token_start_first_token() {
+        assert_eq!(current_token_start("ls", 2), 0);
+        assert_eq!(current_token_start("  ls", 4), 2);
+    }
+
+    #[test]
+    fn test_current_token_start_argument() {
+        // "ls /tmp/" - cursor at end, token starts after space
+        assert_eq!(current_token_start("ls /tmp/", 8), 3);
+    }
+
+    #[test]
+    fn test_current_token_start_after_pipe() {
+        // "ls | cat" - cursor at 8, token starts at 5
+        assert_eq!(current_token_start("ls | cat", 8), 5);
+    }
+
+    #[test]
+    fn test_current_token_start_empty() {
+        assert_eq!(current_token_start("", 0), 0);
+    }
+
+    #[test]
+    fn test_is_command_position_first_token() {
+        assert!(is_command_position("ls", 2));
+        assert!(is_command_position("  ls", 4));
+        assert!(is_command_position("", 0));
+    }
+
+    #[test]
+    fn test_is_command_position_argument() {
+        assert!(!is_command_position("ls /tmp", 7));
+        assert!(!is_command_position("cat foo bar", 11));
+    }
+
+    #[test]
+    fn test_is_command_position_after_pipe() {
+        assert!(is_command_position("ls | ", 5));
+        assert!(is_command_position("ls | cat", 8));
+    }
+
+    #[test]
+    fn test_is_command_position_after_semicolon() {
+        assert!(is_command_position("echo hi; ", 9));
+        assert!(is_command_position("echo hi; ls", 11));
+    }
+
+    #[test]
+    fn test_shell_completer_delegates_meta_commands() {
+        let mut completer = ShellCompleter::new(false);
+        // :cd is available in shell mode (not excluded)
+        let suggestions = completer.complete(":c", 2);
+        assert!(
+            suggestions.iter().any(|s| s.value == "cd"),
+            "should suggest :cd for :c"
+        );
+    }
+
+    #[test]
+    fn test_shell_completer_excludes_shell_mode_meta_commands() {
+        let mut completer = ShellCompleter::new(false);
+        let suggestions = completer.complete(":", 1);
+        let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
+        assert!(
+            !values.contains(&"shell"),
+            ":shell should be excluded in shell mode"
+        );
+        assert!(
+            !values.contains(&"help"),
+            ":help should be excluded in shell mode"
+        );
+    }
+
+    #[test]
+    fn test_shell_completer_no_command_names_when_disabled() {
+        let mut completer = ShellCompleter::new(false);
+        let suggestions = completer.complete("", 0);
+        assert!(
+            suggestions
+                .iter()
+                .all(|s| s.description.as_deref() != Some("command")),
+            "command_names=false should not produce command suggestions"
+        );
+    }
+
+    #[test]
+    fn test_shell_completer_path_completion_for_argument() {
+        // Path completion should work for arguments even when command_names=false
+        let mut completer = ShellCompleter::new(false);
+        // Completing after "cat " - any path suggestions should have span starting at 4
+        let suggestions = completer.complete("cat /", 5);
+        for s in &suggestions {
+            assert_eq!(s.span.start, 4, "span should start at the token start (4)");
+        }
+    }
+}

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -55,8 +55,8 @@ fn is_command_position(line: &str, pos: usize) -> bool {
         let mut sep_end = 0;
         let mut prev: Option<char> = None;
         for (byte_pos, ch) in before_token.char_indices() {
-            let is_separator = COMMAND_SEPARATORS.contains(&ch)
-                || (ch == '&' && !matches!(prev, Some('<' | '>')));
+            let is_separator =
+                COMMAND_SEPARATORS.contains(&ch) || (ch == '&' && !matches!(prev, Some('<' | '>')));
             if is_separator {
                 sep_end = byte_pos + ch.len_utf8();
             }

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -164,12 +164,10 @@ impl Completer for ShellCompleter {
             path_to_suggestions(partial, pos, token_start, &PathCompletionOptions::default());
 
         // Wrap paths containing spaces in double quotes.
-        // Known limitation: this naive quoting is not safe for paths that
-        // contain `"`, `$`, backticks, or backslashes, as those characters
-        // retain special meaning inside double quotes and could cause unintended
-        // shell expansion or injection when the completed command is executed.
-        // Robust shell escaping (e.g. single-quote strategy) is deferred to a
-        // future version.
+        // This intentionally optimizes for common paths and keeps behavior
+        // simple. We do not fully escape shell metacharacters here; paths with
+        // uncommon characters such as `$`, backticks, or embedded quotes may
+        // still require manual editing before execution.
         for s in &mut suggestions {
             #[cfg(windows)]
             {

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -40,6 +40,24 @@ pub struct ExperimentalConfig {
     /// R code completion configuration (fuzzy matching, package functions).
     #[serde(default)]
     pub r_completion: RCompletionConfig,
+
+    /// Shell mode completion configuration.
+    #[serde(default)]
+    pub shell_completion: ShellCompletionConfig,
+}
+
+/// Configuration for shell mode completion.
+///
+/// Controls what is suggested when Tab is pressed in shell mode.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct ShellCompletionConfig {
+    /// Enable completion of executable command names from PATH.
+    ///
+    /// When enabled, pressing Tab at the start of a shell command suggests
+    /// executable names found in PATH directories in addition to path completions.
+    /// When disabled (default), only file/directory path completion is provided.
+    pub command_names: bool,
 }
 
 /// Configuration for R code completion (namespace and library fuzzy matching).
@@ -161,6 +179,9 @@ struct ExperimentalConfigSchema {
 
     /// R code completion configuration (fuzzy matching, package functions).
     pub r_completion: RCompletionConfig,
+
+    /// Shell mode completion configuration.
+    pub shell_completion: ShellCompletionConfig,
 }
 
 // Manual JsonSchema implementation for ExperimentalConfig since nu_ansi_term::Color
@@ -331,6 +352,7 @@ mod tests {
             config.r_completion.package_functions,
             vec!["library".to_string(), "require".to_string()]
         );
+        assert!(!config.shell_completion.command_names); // Disabled by default
     }
 
     #[test]
@@ -397,5 +419,21 @@ fuzzy = true
             config.experimental.r_completion.package_functions,
             vec!["library".to_string(), "require".to_string()]
         );
+    }
+
+    #[test]
+    fn test_shell_completion_default() {
+        let config = ShellCompletionConfig::default();
+        assert!(!config.command_names);
+    }
+
+    #[test]
+    fn test_parse_shell_completion() {
+        let toml_str = r#"
+[experimental.shell_completion]
+command_names = true
+"#;
+        let config: crate::config::Config = toml::from_str(toml_str).unwrap();
+        assert!(config.experimental.shell_completion.command_names);
     }
 }

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -89,6 +89,9 @@ expression: schema
             "library",
             "require"
           ]
+        },
+        "shell_completion": {
+          "command_names": false
         }
       }
     },
@@ -1603,6 +1606,13 @@ expression: schema
               "require"
             ]
           }
+        },
+        "shell_completion": {
+          "description": "Shell mode completion configuration.",
+          "$ref": "#/$defs/ShellCompletionConfig",
+          "default": {
+            "command_names": false
+          }
         }
       }
     },
@@ -1857,6 +1867,17 @@ expression: schema
           "description": "Comment prefix for output (default: \"#> \").",
           "type": "string",
           "default": "#> "
+        }
+      }
+    },
+    "ShellCompletionConfig": {
+      "description": "Configuration for shell mode completion.\n\nControls what is suggested when Tab is pressed in shell mode.",
+      "type": "object",
+      "properties": {
+        "command_names": {
+          "description": "Enable completion of executable command names from PATH.\n\nWhen enabled, pressing Tab at the start of a shell command suggests\nexecutable names found in PATH directories in addition to path completions.\nWhen disabled (default), only file/directory path completion is provided.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
@@ -113,3 +113,6 @@ package_functions = [
     "library",
     "require",
 ]
+
+[experimental.shell_completion]
+command_names = false

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -7,8 +7,9 @@ mod reprex;
 mod shell;
 pub(crate) mod state;
 
-use crate::completion::completer::{CombinedCompleter, MetaCommandCompleter};
+use crate::completion::completer::CombinedCompleter;
 use crate::completion::menu::{FunctionAwareMenu, StateSyncHistoryMenu};
+use crate::completion::shell::ShellCompleter;
 use crate::config::{
     AutoSuggestions, Config, ConfigStatus, EditorMode, ModeIndicatorPosition, RSourceStatus,
     history_dir,
@@ -748,27 +749,11 @@ impl Repl {
             }
         };
 
-        // Set up meta command completer only (no R completion in shell mode) if completion is enabled
+        // Set up shell mode completer with path completion if completion is enabled
         if self.config.completion.enabled {
-            // Exclude Shell mode-irrelevant commands:
-            // - `:shell` - already in Shell mode
-            // - `:system` - can run system commands directly
-            // - `:autoformat`, `:format` - R code formatting
-            // - `:restart` - R session restart
-            // - `:reprex` - R reproducible examples
-            // - `:switch` - R version switching
-            // - `:h`, `:help` - R help browser
-            let completer = Box::new(MetaCommandCompleter::with_exclusions(vec![
-                "shell",
-                "system",
-                "autoformat",
-                "format",
-                "restart",
-                "reprex",
-                "switch",
-                "h",
-                "help",
-            ]));
+            let completer = Box::new(ShellCompleter::new(
+                self.config.experimental.shell_completion.command_names,
+            ));
             shell_editor = shell_editor.with_completer(completer);
 
             // Set up completion menu with height limit for better UX

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,31 @@ The `"cwd"` mode filters suggestions to show only history entries that were reco
 > [!NOTE]
 > The `"cwd"` setting only affects R mode suggestions. Shell mode (`#!` prefix) always searches all history regardless of this setting.
 
+## Shell Mode Completion
+
+In shell mode, tab completion uses `ShellCompleter`.
+
+### Configuration
+
+```toml
+[experimental.shell_completion]
+command_names = false  # Suggest executable names from PATH at command position
+```
+
+`command_names` is disabled by default. When enabled, executable names from `PATH` are suggested only when the cursor is at command position (for example, the first token in a command segment).
+
+### Behavior
+
+- Meta commands (starting with `:`) are delegated to `MetaCommandCompleter`
+- File and directory paths are completed at any token position
+- Command segments are split by separators like `|` and `;`
+- Paths containing spaces are wrapped in double quotes
+
+### Known Limitations
+
+- Quote-aware tokenization is not implemented. Pressing Tab again inside an already-quoted path may produce incorrect span positions.
+- Quoting is optimized for common paths and does not fully escape all shell metacharacters. Paths containing uncommon characters (for example `$`, backticks, or embedded quotes) may require manual editing before execution.
+
 ## Keyboard Shortcuts
 
 arf supports configurable keyboard shortcuts using the [crokey](https://github.com/Canop/crokey) format.


### PR DESCRIPTION
Closes #167

## Summary

- Add `ShellCompleter` in `completion/shell.rs` that provides file/directory path completion for shell mode commands
- Add `experimental.shell_completion.command_names` config option to optionally complete executable names from PATH (disabled by default)
- Replace the bare `MetaCommandCompleter` in shell mode with `ShellCompleter`, which internally delegates meta commands (`:cd`, `:quit`, etc.) while adding path completion for everything else

## Behavior

- **Path completion**: Tab on any argument position completes file/directory paths using the existing fuzzy `complete_path()` engine
- **Pipe/semicolon handling**: separators like `|` and `;` start a new command segment, so completion after a pipe correctly identifies the new command position
- **Quoted paths**: paths containing spaces are wrapped in double quotes
- **Command name completion**: opt-in via `[experimental.shell_completion] command_names = true`; suggests executable names from PATH directories at command position

## Known limitations (documented in source)

- Quote-aware tokenization is not implemented: whitespace inside already-inserted quoted paths (e.g. `"dir with space/"`) may cause incorrect span positions on a second Tab press
- Double-quote wrapping is not safe for paths containing `"`, `$`, backticks, or backslashes (robust shell escaping deferred to a future version)

