### PR TITLE
fix(windows): clear `VT_INPUT` flag on exit to fix nushell key response loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "git+https://github.com/crossterm-rs/crossterm?rev=e81d5d643700f6a1de17c130327acfd7df70420f#e81d5d643700f6a1de17c130327acfd7df70420f"
+source = "git+https://github.com/crossterm-rs/crossterm?rev=1a5df027974316ce2cf095bb0103c6b16208e399#1a5df027974316ce2cf095bb0103c6b16208e399"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ vt100 = "0.16"
 # Patch crossterm with Windows VT input support (bracketed paste)
 # https://github.com/crossterm-rs/crossterm/pull/1030
 [patch.crates-io]
-crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "e81d5d643700f6a1de17c130327acfd7df70420f" }
+crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "1a5df027974316ce2cf095bb0103c6b16208e399" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

Fixes #163.

When arf exits, `ENABLE_VIRTUAL_TERMINAL_INPUT` (0x0200) was left set on the console input handle. Nushell uses standard crossterm (which does not know about this flag), so it misinterprets keystrokes — causing the key response loss described in #163.

The workaround (running `:info` before `exit`) happened to clear the flag as a side effect of the pager's cleanup path (`DisableMouseCapture` → restore saved original mode), which is why it worked.

### Root cause

`try_enable_vt_input()` in our crossterm fork (crossterm-rs/crossterm#1030) sets `ENABLE_VIRTUAL_TERMINAL_INPUT` during the first event read, but `disable_raw_mode()` only restored `LINE_INPUT | ECHO_INPUT | PROCESSED_INPUT` — leaving VT input active after arf exits and Rust destructors are bypassed by R's `exit()` call.

### Fix

Updated the crossterm patch (crossterm-rs/crossterm#1030, commit `1a5df02`) so that `disable_raw_mode()` also clears `ENABLE_VIRTUAL_TERMINAL_INPUT`, but only if this process was the one that enabled it (i.e., it was absent in the saved original console mode). This avoids clobbering the flag in environments where VT input was already active before arf started.

## Test plan

- [ ] Build and test on Windows with nushell — key response loss after `exit` should be resolved without needing the `:info` workaround
- [ ] Normal terminal usage (Windows Terminal, cmd, PowerShell) should be unaffected