### PR TITLE
fix(windows): bump crossterm patch rev for Windows VT input boundary fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "git+https://github.com/crossterm-rs/crossterm?rev=1a5df027974316ce2cf095bb0103c6b16208e399#1a5df027974316ce2cf095bb0103c6b16208e399"
+source = "git+https://github.com/crossterm-rs/crossterm?rev=33c393a04f0198cb7d9ae68357cfc92269894d36#33c393a04f0198cb7d9ae68357cfc92269894d36"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ vt100 = "0.16"
 # Patch crossterm with Windows VT input support (bracketed paste)
 # https://github.com/crossterm-rs/crossterm/pull/1030
 [patch.crates-io]
-crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "1a5df027974316ce2cf095bb0103c6b16208e399" }
+crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "33c393a04f0198cb7d9ae68357cfc92269894d36" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
Fix #180 

## Summary
- update the patched `crossterm` git revision in `Cargo.toml`

## Why
- includes the Windows VT input batch-boundary fix in crossterm-rs/crossterm#1030
- aimed at reducing premature ESC parsing when bracketed-paste sequences are split across input batches
