### PR TITLE
fix(windows): bump crossterm patch rev for Windows VT input fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.29.0"
-source = "git+https://github.com/crossterm-rs/crossterm?rev=33c393a04f0198cb7d9ae68357cfc92269894d36#33c393a04f0198cb7d9ae68357cfc92269894d36"
+source = "git+https://github.com/crossterm-rs/crossterm?rev=03bb4f26610a5904b8e875fcb610d16bf7d00814#03bb4f26610a5904b8e875fcb610d16bf7d00814"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ vt100 = "0.16"
 # Patch crossterm with Windows VT input support (bracketed paste)
 # https://github.com/crossterm-rs/crossterm/pull/1030
 [patch.crates-io]
-crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "33c393a04f0198cb7d9ae68357cfc92269894d36" }
+crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "03bb4f26610a5904b8e875fcb610d16bf7d00814" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
Fix #180

## Summary

- Bumps the `[patch.crates-io]` crossterm revision to pick up Windows VT input fixes on the `feature/windows-vt-input` branch
- Fixes bracketed paste corruption/hang on Windows caused by `ENABLE_VIRTUAL_TERMINAL_INPUT` being lost after `disable_raw_mode()` cleared it

## Changes in the new crossterm rev (crossterm-rs/crossterm#1030)

- **Re-enable VT input on each `enable_raw_mode()` call**: `disable_raw_mode()` (introduced in #175) cleared `ENABLE_VIRTUAL_TERMINAL_INPUT` to restore original console state. `enable_raw_mode()` only cleared the LINE/ECHO/PROCESSED bits and never re-enabled VT input, so bracketed paste silently broke on the second and subsequent `read_line()` calls.
- **Flush stalled ESC after no-VT batch**: When a batch contained only mouse/focus/resize records, a lone ESC was held indefinitely with `more=true`. Now `Parser::flush()` is called after such batches.
- **Flush stalled ESC after mixed VT+non-VT batch**: Extended the flush condition to also trigger when the console queue is empty, covering batches like `[ESC_VT_byte, MouseEvent]` where `vt_bytes_consumed=true` but no subsequent batch can complete the buffered sequence.
- **Best-effort VT enable on legacy consoles**: `set_mode` with `ENABLE_VIRTUAL_TERMINAL_INPUT` can fail on consoles that don't support VT input. Now retries without the VT bit so `enable_raw_mode()` always succeeds.
- **Pure helper extraction + unit tests**: `compute_enable_raw_mode()` / `compute_disable_raw_mode()` extracted for platform-independent bit-logic testing. `Parser::flush()` unit tests added.

## Test plan

- [ ] Build passes (`cargo build`)
- [ ] Windows: bracketed paste works correctly on second and subsequent `read_line()` calls
- [ ] Windows: no regression on legacy consoles without VT input support