### PR TITLE
fix: scope error handler variables to prevent `.GlobalEnv` leak

### DIFF
--- a/crates/arf-console/tests/pty_basic_tests.rs
+++ b/crates/arf-console/tests/pty_basic_tests.rs
@@ -685,12 +685,13 @@ auto_width = false
 ///
 /// The `options(error = ...)` handler previously used `quote({...})`, which caused
 /// temporary variables to be assigned in .GlobalEnv on every error. Using
-/// `function() {...}` scopes them locally, leaving .GlobalEnv empty after an error.
+/// `function() {...}` scopes them locally, leaving no user-visible objects in
+/// .GlobalEnv after an error.
 #[test]
 #[cfg(unix)]
 fn test_pty_error_handler_no_globalenv_leak() {
     let mut terminal =
-        Terminal::spawn_with_args(&["--no-auto-match"]).expect("Failed to spawn arf");
+        Terminal::spawn_with_args(&["--no-auto-match", "--vanilla"]).expect("Failed to spawn arf");
 
     terminal.wait_for_prompt().expect("Should show prompt");
 
@@ -699,7 +700,7 @@ fn test_pty_error_handler_no_globalenv_leak() {
         .send_line("nonexistent_object")
         .expect("Should send expression");
     terminal
-        .expect("not found")
+        .expect("nonexistent_object")
         .expect("Should see error message");
     terminal
         .wait_for_prompt()

--- a/crates/arf-console/tests/pty_basic_tests.rs
+++ b/crates/arf-console/tests/pty_basic_tests.rs
@@ -700,7 +700,7 @@ fn test_pty_error_handler_no_globalenv_leak() {
         .send_line("nonexistent_object")
         .expect("Should send expression");
     terminal
-        .expect("nonexistent_object")
+        .clear_and_expect("'nonexistent_object'")
         .expect("Should see error message");
     terminal
         .wait_for_prompt()

--- a/crates/arf-console/tests/pty_basic_tests.rs
+++ b/crates/arf-console/tests/pty_basic_tests.rs
@@ -680,3 +680,38 @@ auto_width = false
 
     terminal.quit().expect("Should quit cleanly");
 }
+
+/// Regression test: error handler must not pollute .GlobalEnv.
+///
+/// The `options(error = ...)` handler previously used `quote({...})`, which caused
+/// temporary variables to be assigned in .GlobalEnv on every error. Using
+/// `function() {...}` scopes them locally, leaving .GlobalEnv empty after an error.
+#[test]
+#[cfg(unix)]
+fn test_pty_error_handler_no_globalenv_leak() {
+    let mut terminal =
+        Terminal::spawn_with_args(&["--no-auto-match"]).expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Trigger an error
+    terminal
+        .send_line("nonexistent_object")
+        .expect("Should send expression");
+    terminal
+        .expect("not found")
+        .expect("Should see error message");
+    terminal
+        .wait_for_prompt()
+        .expect("Should return to prompt after error");
+
+    // .GlobalEnv should have no user-visible objects after an error
+    terminal
+        .send_line("identical(ls(), character(0))")
+        .expect("Should send ls() check");
+    terminal.clear_and_expect("[1] TRUE").expect(
+        ".GlobalEnv should be empty after an error — error handler must not leak variables",
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -1698,7 +1698,7 @@ local({
 
     # Set up our error handler using options(error = ...)
     # This is called at the END of R's error handling, just before returning to prompt
-    options(error = quote({
+    options(error = function() {
         # Mark that an error occurred
         env <- get(".arf_error_state", envir = globalenv())
         env$had_error <- TRUE
@@ -1706,9 +1706,9 @@ local({
         # Chain to the previous handler if it exists
         prev <- get(".arf_prev_error_handler", envir = globalenv())
         if (!is.null(prev)) {
-            eval(prev)
+            if (is.function(prev)) prev() else eval(prev, envir = globalenv())
         }
-    }))
+    })
 
     invisible(NULL)
 })


### PR DESCRIPTION
## Summary

Fixes #185.

Each time an error occurred, `options(error = quote({...}))` caused the temporary variables `env` and `prev` to be assigned into `.GlobalEnv` because quoted expressions are evaluated in the calling environment (`.GlobalEnv`). Replacing `quote({...})` with `function() {...}` scopes these variables locally.

Also fixes the chained handler dispatch: if the previous handler is a quoted expression rather than a function, it is now evaluated with `eval(prev, envir = globalenv())` to preserve the expected evaluation environment.

## Test plan

- [x] Added PTY regression test `test_pty_error_handler_no_globalenv_leak` that:
  - Triggers an error in interactive mode
  - Verifies `ls()` returns `character(0)` (no leaked variables)
  - Confirmed the test **fails** before the fix and **passes** after

## Notes

This bug only manifests in interactive (PTY) mode. In headless (`ipc eval`) mode, errors are caught by `tryCatch` before reaching the top-level, so `options(error = ...)` is never invoked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)