### PR TITLE
feat: support reading R code from stdin via `-f -` and `ipc eval` / `ipc send`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `arf -f -`: read R script from stdin when `-` is passed as the file argument
+- `arf ipc eval` and `arf ipc send`: `code` argument is now optional; when omitted, code is read from stdin (exits with an error if stdin is a TTY)
+
 ## [0.3.3-alpha.2] - 2026-05-05
 
 ### Fixed

--- a/crates/arf-console/src/cli.rs
+++ b/crates/arf-console/src/cli.rs
@@ -252,7 +252,8 @@ Quick start:
 
 All commands output JSON to stdout (pretty-printed on terminal, compact \
 when piped). Errors are written to stderr as JSON. Exit codes: \
-0 = success, 2 = transport error, 3 = session error, 4 = protocol error.
+0 = success, 2 = client-side failure (transport error or missing/unreadable \
+code input), 3 = session error, 4 = protocol error.
 
 Session discovery:
   By default, sessions are discovered from the platform cache directory.

--- a/crates/arf-console/src/cli.rs
+++ b/crates/arf-console/src/cli.rs
@@ -414,6 +414,9 @@ Examples:
   Evaluate an expression:
     $ arf ipc eval '1 + 1'
 
+  Pipe code via stdin:
+    $ echo '1 + 1' | arf ipc eval
+
   Run code with a 10-second timeout:
     $ arf ipc eval --timeout 10000 'Sys.sleep(5); 42'
 
@@ -426,8 +429,8 @@ Examples:
   Extract the value with jq:
     $ arf ipc eval '1 + 1' | jq -r '.value'")]
     Eval {
-        /// R code to evaluate
-        code: String,
+        /// R code to evaluate (reads from stdin if omitted)
+        code: Option<String>,
         /// PID of the target arf session (optional if only one session is running)
         #[arg(long)]
         pid: Option<u32>,
@@ -450,11 +453,14 @@ Examples:
   Send code that appears in the session output:
     $ arf ipc send 'library(dplyr)'
 
+  Pipe code via stdin:
+    $ echo 'library(dplyr)' | arf ipc send
+
   Target a specific session:
     $ arf ipc send --pid 12345 'print(mtcars)'")]
     Send {
-        /// R code to send
-        code: String,
+        /// R code to send (reads from stdin if omitted)
+        code: Option<String>,
         /// PID of the target arf session (optional if only one session is running)
         #[arg(long)]
         pid: Option<u32>,

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -16,11 +16,13 @@ const DEFAULT_TRANSPORT_TIMEOUT: std::time::Duration = std::time::Duration::from
 // ── Exit codes ───────────────────────────────────────────────────────
 //
 // 0 = success
-// 2 = IPC transport error
+// 2 = client-side failure before IPC: transport error (socket/timeout)
+//     or missing/unreadable code input (NO_CODE_PROVIDED, STDIN_READ_ERROR)
 // 3 = session resolution error
 // 4 = JSON-RPC protocol error
 
-/// IPC transport error (socket connection failed, timeout, etc.).
+/// Client-side failure before IPC: transport error (socket connection failed,
+/// timeout, etc.) or missing/unreadable code input (stdin is a TTY, read error).
 const EXIT_TRANSPORT: i32 = 2;
 /// Session resolution error (no session found, ambiguous PID, etc.).
 const EXIT_SESSION: i32 = 3;

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -23,7 +23,7 @@ const DEFAULT_TRANSPORT_TIMEOUT: std::time::Duration = std::time::Duration::from
 
 /// Client-side failure before IPC: transport error (socket connection failed,
 /// timeout, etc.) or missing/unreadable code input (stdin is a TTY, read error).
-const EXIT_TRANSPORT: i32 = 2;
+const EXIT_CLIENT: i32 = 2;
 /// Session resolution error (no session found, ambiguous PID, etc.).
 const EXIT_SESSION: i32 = 3;
 /// JSON-RPC protocol error (R_BUSY, INPUT_ALREADY_PENDING, etc.).
@@ -228,7 +228,7 @@ fn require_stdin_not_tty() {
     use std::io::IsTerminal;
     if std::io::stdin().is_terminal() {
         exit_error(
-            EXIT_TRANSPORT,
+            EXIT_CLIENT,
             "NO_CODE_PROVIDED",
             "No code provided and stdin is a terminal",
             Some("Pass code as an argument or pipe it via stdin."),
@@ -246,7 +246,7 @@ fn read_stdin_code() -> String {
         .read_to_string(&mut buf)
         .unwrap_or_else(|e| {
             exit_error(
-                EXIT_TRANSPORT,
+                EXIT_CLIENT,
                 "STDIN_READ_ERROR",
                 &format!("Failed to read code from stdin: {e}"),
                 None,
@@ -435,7 +435,7 @@ fn send_request(
                 );
             } else {
                 exit_error(
-                    EXIT_TRANSPORT,
+                    EXIT_CLIENT,
                     "TRANSPORT_ERROR",
                     &format!("{e:#}"),
                     Some("Check that the arf session is running and IPC is enabled."),

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -222,9 +222,10 @@ fn resolve_session(pid: Option<u32>) -> crate::ipc::session::SessionInfo {
     }
 }
 
-/// Read code from stdin, or exit with a structured JSON error if stdin is a TTY.
-fn require_stdin_code() -> String {
-    use std::io::{IsTerminal, Read};
+/// Exit with a structured JSON error if stdin is a TTY (instant, no I/O).
+/// Called before session resolution so TTY errors are reported immediately.
+fn require_stdin_not_tty() {
+    use std::io::IsTerminal;
     if std::io::stdin().is_terminal() {
         exit_error(
             EXIT_TRANSPORT,
@@ -234,6 +235,12 @@ fn require_stdin_code() -> String {
             None,
         );
     }
+}
+
+/// Read all of stdin into a string, or exit with a structured JSON error on failure.
+/// Call `require_stdin_not_tty()` before session resolution to guard against TTY.
+fn read_stdin_code() -> String {
+    use std::io::Read;
     let mut buf = String::new();
     std::io::stdin()
         .read_to_string(&mut buf)
@@ -255,16 +262,21 @@ fn require_stdin_code() -> String {
 /// R evaluation errors are returned as part of the JSON result (exit 0)
 /// — they are a normal response, not an IPC failure.
 /// If `code` is `None`, reads from stdin; exits with a JSON error if stdin is a TTY.
+/// The TTY check runs first (instant), then session is resolved, then stdin is drained,
+/// so a missing-session error is reported without consuming a long stdin stream.
 pub fn cmd_eval(code: Option<&str>, pid: Option<u32>, visible: bool, timeout_ms: Option<u64>) {
+    if code.is_none() {
+        require_stdin_not_tty();
+    }
+    let session = resolve_session(pid);
     let owned;
     let code = match code {
         Some(c) => c,
         None => {
-            owned = require_stdin_code();
+            owned = read_stdin_code();
             &owned
         }
     };
-    let session = resolve_session(pid);
 
     let mut params = serde_json::json!({ "code": code, "visible": visible });
     if let Some(ms) = timeout_ms {
@@ -292,16 +304,21 @@ pub fn cmd_eval(code: Option<&str>, pid: Option<u32>, visible: bool, timeout_ms:
 /// Send code as user input to a running arf session.
 ///
 /// If `code` is `None`, reads from stdin; exits with a JSON error if stdin is a TTY.
+/// The TTY check runs first (instant), then session is resolved, then stdin is drained,
+/// so a missing-session error is reported without consuming a long stdin stream.
 pub fn cmd_send(code: Option<&str>, pid: Option<u32>) {
+    if code.is_none() {
+        require_stdin_not_tty();
+    }
+    let session = resolve_session(pid);
     let owned;
     let code = match code {
         Some(c) => c,
         None => {
-            owned = require_stdin_code();
+            owned = read_stdin_code();
             &owned
         }
     };
-    let session = resolve_session(pid);
 
     let request = serde_json::json!({
         "jsonrpc": "2.0",

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -220,12 +220,48 @@ fn resolve_session(pid: Option<u32>) -> crate::ipc::session::SessionInfo {
     }
 }
 
+/// Read code from stdin, or exit with a structured JSON error if stdin is a TTY.
+fn require_stdin_code() -> String {
+    use std::io::{IsTerminal, Read};
+    if std::io::stdin().is_terminal() {
+        exit_error(
+            EXIT_TRANSPORT,
+            "NO_CODE_PROVIDED",
+            "No code provided and stdin is a terminal",
+            Some("Pass code as an argument or pipe it via stdin."),
+            None,
+        );
+    }
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .unwrap_or_else(|e| {
+            exit_error(
+                EXIT_TRANSPORT,
+                "STDIN_READ_ERROR",
+                &format!("Failed to read code from stdin: {e}"),
+                None,
+                None,
+            );
+        });
+    buf
+}
+
 /// Evaluate R code in a running arf session.
 ///
 /// On success, prints the structured result as JSON to stdout.
 /// R evaluation errors are returned as part of the JSON result (exit 0)
 /// — they are a normal response, not an IPC failure.
-pub fn cmd_eval(code: &str, pid: Option<u32>, visible: bool, timeout_ms: Option<u64>) {
+/// If `code` is `None`, reads from stdin; exits with a JSON error if stdin is a TTY.
+pub fn cmd_eval(code: Option<&str>, pid: Option<u32>, visible: bool, timeout_ms: Option<u64>) {
+    let owned;
+    let code = match code {
+        Some(c) => c,
+        None => {
+            owned = require_stdin_code();
+            &owned
+        }
+    };
     let session = resolve_session(pid);
 
     let mut params = serde_json::json!({ "code": code, "visible": visible });
@@ -252,7 +288,17 @@ pub fn cmd_eval(code: &str, pid: Option<u32>, visible: bool, timeout_ms: Option<
 }
 
 /// Send code as user input to a running arf session.
-pub fn cmd_send(code: &str, pid: Option<u32>) {
+///
+/// If `code` is `None`, reads from stdin; exits with a JSON error if stdin is a TTY.
+pub fn cmd_send(code: Option<&str>, pid: Option<u32>) {
+    let owned;
+    let code = match code {
+        Some(c) => c,
+        None => {
+            owned = require_stdin_code();
+            &owned
+        }
+    };
     let session = resolve_session(pid);
 
     let request = serde_json::json!({

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1027,6 +1027,16 @@ fn handle_history_command(
     }
 }
 
+fn read_code_from_stdin() -> anyhow::Result<String> {
+    use std::io::{IsTerminal, Read};
+    if std::io::stdin().is_terminal() {
+        anyhow::bail!("no code provided: pass code as an argument or pipe via stdin");
+    }
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
 fn handle_ipc_command(action: &IpcAction) {
     match action {
         IpcAction::List => ipc::client::cmd_list(),
@@ -1035,8 +1045,32 @@ fn handle_ipc_command(action: &IpcAction) {
             pid,
             visible,
             timeout,
-        } => ipc::client::cmd_eval(code, *pid, *visible, *timeout),
-        IpcAction::Send { code, pid } => ipc::client::cmd_send(code, *pid),
+        } => {
+            let code = match code {
+                Some(c) => c.clone(),
+                None => match read_code_from_stdin() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("Error: {:#}", e);
+                        std::process::exit(1);
+                    }
+                },
+            };
+            ipc::client::cmd_eval(&code, *pid, *visible, *timeout)
+        }
+        IpcAction::Send { code, pid } => {
+            let code = match code {
+                Some(c) => c.clone(),
+                None => match read_code_from_stdin() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("Error: {:#}", e);
+                        std::process::exit(1);
+                    }
+                },
+            };
+            ipc::client::cmd_send(&code, *pid)
+        }
         IpcAction::Shutdown { pid } => ipc::client::cmd_shutdown(*pid),
         IpcAction::Session { pid } => ipc::client::cmd_session(*pid),
         IpcAction::History {
@@ -1361,8 +1395,17 @@ fn run_script(cli: &Cli) -> Result<()> {
     let code = if let Some(eval_code) = &cli.eval {
         eval_code.clone()
     } else if let Some(script_path) = cli.script_file() {
-        fs::read_to_string(script_path)
-            .with_context(|| format!("Failed to read script file: {}", script_path.display()))?
+        if script_path == std::path::Path::new("-") {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read from stdin")?;
+            buf
+        } else {
+            fs::read_to_string(script_path)
+                .with_context(|| format!("Failed to read script file: {}", script_path.display()))?
+        }
     } else {
         // Should not happen - we checked script_mode earlier
         return Ok(());

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1027,16 +1027,6 @@ fn handle_history_command(
     }
 }
 
-fn read_code_from_stdin() -> anyhow::Result<String> {
-    use std::io::{IsTerminal, Read};
-    if std::io::stdin().is_terminal() {
-        anyhow::bail!("no code provided: pass code as an argument or pipe via stdin");
-    }
-    let mut buf = String::new();
-    std::io::stdin().read_to_string(&mut buf)?;
-    Ok(buf)
-}
-
 fn handle_ipc_command(action: &IpcAction) {
     match action {
         IpcAction::List => ipc::client::cmd_list(),
@@ -1045,32 +1035,8 @@ fn handle_ipc_command(action: &IpcAction) {
             pid,
             visible,
             timeout,
-        } => {
-            let code = match code {
-                Some(c) => c.clone(),
-                None => match read_code_from_stdin() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!("Error: {:#}", e);
-                        std::process::exit(1);
-                    }
-                },
-            };
-            ipc::client::cmd_eval(&code, *pid, *visible, *timeout)
-        }
-        IpcAction::Send { code, pid } => {
-            let code = match code {
-                Some(c) => c.clone(),
-                None => match read_code_from_stdin() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!("Error: {:#}", e);
-                        std::process::exit(1);
-                    }
-                },
-            };
-            ipc::client::cmd_send(&code, *pid)
-        }
+        } => ipc::client::cmd_eval(code.as_deref(), *pid, *visible, *timeout),
+        IpcAction::Send { code, pid } => ipc::client::cmd_send(code.as_deref(), *pid),
         IpcAction::Shutdown { pid } => ipc::client::cmd_shutdown(*pid),
         IpcAction::Session { pid } => ipc::client::cmd_session(*pid),
         IpcAction::History {

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -1035,7 +1035,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__ipc__subcmd__eval)
-            opts="-h --pid --visible --timeout --help <CODE>"
+            opts="-h --pid --visible --timeout --help [CODE]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1217,7 +1217,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__ipc__subcmd__send)
-            opts="-h --pid --help <CODE>"
+            opts="-h --pid --help [CODE]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -255,7 +255,7 @@ _arguments "${_arguments_options[@]}" : \
 '--visible[Also show output in the session (REPL or headless stdout)]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':code -- R code to evaluate:_default' \
+'::code -- R code to evaluate (reads from stdin if omitted):_default' \
 && ret=0
 ;;
 (send)
@@ -263,7 +263,7 @@ _arguments "${_arguments_options[@]}" : \
 '--pid=[PID of the target arf session (optional if only one session is running)]:PID:_default' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':code -- R code to send:_default' \
+'::code -- R code to send (reads from stdin if omitted):_default' \
 && ret=0
 ;;
 (session)

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -671,8 +671,10 @@ fn test_script_file_stdin_reprex() {
 /// The command fails at IPC (no running session) not at argument parsing.
 #[test]
 fn test_ipc_eval_stdin_fallback() {
+    let sessions_dir = tempfile::tempdir().expect("Failed to create temp sessions dir");
     let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
         .args(["ipc", "eval"])
+        .env("ARF_IPC_SESSIONS_DIR", sessions_dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -708,8 +710,10 @@ fn test_ipc_eval_stdin_fallback() {
 /// Test that `arf ipc send` without a code argument reads from stdin.
 #[test]
 fn test_ipc_send_stdin_fallback() {
+    let sessions_dir = tempfile::tempdir().expect("Failed to create temp sessions dir");
     let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
         .args(["ipc", "send"])
+        .env("ARF_IPC_SESSIONS_DIR", sessions_dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -5,7 +5,7 @@
 //! All tests use `std::process::Command` and work on all platforms.
 
 use std::io::Write;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
 
 // ============================================================================
@@ -590,6 +590,137 @@ fn test_script_file_not_found() {
     assert!(
         stderr.contains("Failed to read") || stderr.contains("No such file"),
         "Should show file not found error: {}",
+        stderr
+    );
+}
+
+/// Test that `arf -f -` reads R code from stdin and executes it.
+#[test]
+fn test_script_file_stdin() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["-f", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn arf");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"x <- 7\ny <- 8\nx + y\n")
+        .expect("Failed to write to stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for arf");
+
+    assert!(
+        output.status.success(),
+        "arf -f - should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[1] 15"),
+        "Script via stdin should output [1] 15: {}",
+        stdout
+    );
+}
+
+/// Test that `arf -f -` in reprex mode echoes source and prefixes output.
+#[test]
+fn test_script_file_stdin_reprex() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["--reprex", "-f", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn arf");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"1 + 1\n")
+        .expect("Failed to write to stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for arf");
+
+    assert!(
+        output.status.success(),
+        "arf --reprex -f - should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("1 + 1"),
+        "Reprex via stdin should echo source code: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("#> [1] 2"),
+        "Reprex via stdin should prefix output with #>: {}",
+        stdout
+    );
+}
+
+/// Test that `arf ipc eval` without a code argument reads from stdin.
+/// The command fails at IPC (no running session) not at argument parsing.
+#[test]
+fn test_ipc_eval_stdin_fallback() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["ipc", "eval"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn arf");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"1 + 1\n")
+        .expect("Failed to write to stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for arf");
+
+    // Should fail at IPC level (no running session), not with "no code provided"
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("no code provided"),
+        "Should not complain about missing code when stdin is provided: {}",
+        stderr
+    );
+}
+
+/// Test that `arf ipc send` without a code argument reads from stdin.
+#[test]
+fn test_ipc_send_stdin_fallback() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .args(["ipc", "send"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn arf");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"print('hello')\n")
+        .expect("Failed to write to stdin");
+
+    let output = child.wait_with_output().expect("Failed to wait for arf");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("no code provided"),
+        "Should not complain about missing code when stdin is provided: {}",
         stderr
     );
 }

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -690,9 +690,17 @@ fn test_ipc_eval_stdin_fallback() {
 
     // Should fail at IPC level (no running session), not with "no code provided"
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stderr.contains("no code provided"),
         "Should not complain about missing code when stdin is provided: {}",
+        stderr
+    );
+    // Confirm failure reached IPC execution (SESSION_NOT_FOUND), not argument parsing
+    assert!(
+        stdout.contains("SESSION_NOT_FOUND") || stderr.contains("SESSION_NOT_FOUND"),
+        "Should fail at IPC level with SESSION_NOT_FOUND: stdout={} stderr={}",
+        stdout,
         stderr
     );
 }
@@ -718,9 +726,17 @@ fn test_ipc_send_stdin_fallback() {
     let output = child.wait_with_output().expect("Failed to wait for arf");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stderr.contains("no code provided"),
         "Should not complain about missing code when stdin is provided: {}",
+        stderr
+    );
+    // Confirm failure reached IPC execution (SESSION_NOT_FOUND), not argument parsing
+    assert!(
+        stdout.contains("SESSION_NOT_FOUND") || stderr.contains("SESSION_NOT_FOUND"),
+        "Should fail at IPC level with SESSION_NOT_FOUND: stdout={} stderr={}",
+        stdout,
         stderr
     );
 }

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -694,7 +694,7 @@ fn test_ipc_eval_stdin_fallback() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        !stderr.contains("no code provided"),
+        !stderr.contains("NO_CODE_PROVIDED"),
         "Should not complain about missing code when stdin is provided: {}",
         stderr
     );
@@ -732,7 +732,7 @@ fn test_ipc_send_stdin_fallback() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        !stderr.contains("no code provided"),
+        !stderr.contains("NO_CODE_PROVIDED"),
         "Should not complain about missing code when stdin is provided: {}",
         stderr
     );

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -672,23 +672,16 @@ fn test_script_file_stdin_reprex() {
 #[test]
 fn test_ipc_eval_stdin_fallback() {
     let sessions_dir = tempfile::tempdir().expect("Failed to create temp sessions dir");
-    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+    // Piped stdin is sufficient to make is_terminal() return false; no data
+    // needs to be written since the process exits at session resolution first.
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
         .args(["ipc", "eval"])
         .env("ARF_IPC_SESSIONS_DIR", sessions_dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
+        .output()
         .expect("Failed to spawn arf");
-
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"1 + 1\n")
-        .expect("Failed to write to stdin");
-
-    let output = child.wait_with_output().expect("Failed to wait for arf");
 
     // Should fail at IPC level (no running session), not with "no code provided"
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -711,23 +704,16 @@ fn test_ipc_eval_stdin_fallback() {
 #[test]
 fn test_ipc_send_stdin_fallback() {
     let sessions_dir = tempfile::tempdir().expect("Failed to create temp sessions dir");
-    let mut child = Command::new(env!("CARGO_BIN_EXE_arf"))
+    // Piped stdin is sufficient to make is_terminal() return false; no data
+    // needs to be written since the process exits at session resolution first.
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
         .args(["ipc", "send"])
         .env("ARF_IPC_SESSIONS_DIR", sessions_dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
+        .output()
         .expect("Failed to spawn arf");
-
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(b"print('hello')\n")
-        .expect("Failed to write to stdin");
-
-    let output = child.wait_with_output().expect("Failed to wait for arf");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -516,13 +516,15 @@ mod ipc_tests {
         );
 
         // Extract and parse the JSON error from the PTY output.
-        // PTY merges stdout+stderr; find the first {...} block and parse it.
+        // PTY merges stdout+stderr; slice from first '{' to last '}' to handle
+        // any ANSI escape sequences or control characters before/after the JSON.
         let json_start = output
             .find('{')
             .unwrap_or_else(|| panic!("no JSON object found in PTY output: {output}"));
-        let json_str = &output[json_start..];
-        // Trim any trailing whitespace/control characters after the JSON.
-        let json_str = json_str.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '}');
+        let json_end = output
+            .rfind('}')
+            .unwrap_or_else(|| panic!("no closing '}}' found in PTY output: {output}"));
+        let json_str = &output[json_start..=json_end];
         let json: serde_json::Value = serde_json::from_str(json_str)
             .unwrap_or_else(|e| panic!("PTY output is not valid JSON: {e}\noutput: {output}"));
         assert_eq!(

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -505,8 +505,10 @@ mod ipc_tests {
         // Read all PTY output (stdout and stderr are merged on the PTY master).
         let mut output = String::new();
         let mut reader = pair.master.try_clone_reader().expect("clone reader");
-        // EIO on Linux signals the child has exited and the PTY is gone.
-        let _ = reader.read_to_string(&mut output);
+        // EIO (errno=5) is expected on Unix when the child exits and the PTY closes.
+        if let Err(e) = reader.read_to_string(&mut output) {
+            assert_eq!(e.raw_os_error(), Some(5), "unexpected PTY read error: {e}");
+        }
 
         let status = child.wait().expect("Failed to wait for child");
         assert_eq!(

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -466,4 +466,57 @@ mod ipc_tests {
 
         terminal.quit().expect("Should quit cleanly");
     }
+
+    /// Test that `arf ipc eval` without a code argument exits with code 2
+    /// and emits a structured JSON error when stdin is a TTY.
+    ///
+    /// This test uses a PTY so that `is_terminal()` on stdin returns true,
+    /// which triggers the NO_CODE_PROVIDED error path.
+    #[test]
+    fn test_ipc_eval_no_code_tty_error() {
+        use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+        use std::io::Read;
+
+        let sessions_dir = tempfile::tempdir().expect("Failed to create temp sessions dir");
+
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("Failed to open PTY");
+
+        let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_arf"));
+        cmd.args(["ipc", "eval"]);
+        cmd.env("ARF_IPC_SESSIONS_DIR", sessions_dir.path());
+
+        let mut child = pair
+            .slave
+            .spawn_command(cmd)
+            .expect("Failed to spawn arf ipc eval");
+
+        // Drop slave so the child's stdin/stdout/stderr are connected to the PTY only.
+        // Don't write anything — stdin is a TTY, so NO_CODE_PROVIDED fires immediately.
+        drop(pair.slave);
+
+        // Read all PTY output (stdout and stderr are merged on the PTY master).
+        let mut output = String::new();
+        let mut reader = pair.master.try_clone_reader().expect("clone reader");
+        // EIO on Linux signals the child has exited and the PTY is gone.
+        let _ = reader.read_to_string(&mut output);
+
+        let status = child.wait().expect("Failed to wait for child");
+        assert_eq!(
+            status.exit_code(),
+            2,
+            "should exit with code 2 (client-side failure): output={output}"
+        );
+        assert!(
+            output.contains("NO_CODE_PROVIDED"),
+            "stderr should contain NO_CODE_PROVIDED: {output}"
+        );
+    }
 }

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -514,9 +514,29 @@ mod ipc_tests {
             2,
             "should exit with code 2 (client-side failure): output={output}"
         );
+
+        // Extract and parse the JSON error from the PTY output.
+        // PTY merges stdout+stderr; find the first {...} block and parse it.
+        let json_start = output
+            .find('{')
+            .unwrap_or_else(|| panic!("no JSON object found in PTY output: {output}"));
+        let json_str = &output[json_start..];
+        // Trim any trailing whitespace/control characters after the JSON.
+        let json_str = json_str.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '}');
+        let json: serde_json::Value = serde_json::from_str(json_str)
+            .unwrap_or_else(|e| panic!("PTY output is not valid JSON: {e}\noutput: {output}"));
+        assert_eq!(
+            json["error"]["code"].as_str(),
+            Some("NO_CODE_PROVIDED"),
+            "error.code should be NO_CODE_PROVIDED: {json}"
+        );
         assert!(
-            output.contains("NO_CODE_PROVIDED"),
-            "stderr should contain NO_CODE_PROVIDED: {output}"
+            json["error"]["message"].as_str().is_some(),
+            "error.message should be present: {json}"
+        );
+        assert!(
+            json["error"]["hint"].as_str().is_some(),
+            "error.hint should be present: {json}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `arf -f -`: reads R script from stdin when dash is passed as the file argument (Unix convention: same as `awk -f -`, `cat -`)
- `arf ipc eval` / `arf ipc send`: `code` argument is now optional; when omitted, code is read from stdin and exits with an error if stdin is a terminal
- No new dependencies — uses `is_terminal()` check only (no platform-specific fd type detection needed for explicit user invocation)

## Test plan

- [x] `test_script_file_stdin`: `arf -f -` reads and executes R code from piped stdin
- [x] `test_script_file_stdin_reprex`: `arf --reprex -f -` reprex mode works via stdin
- [x] `test_ipc_eval_stdin_fallback`: omitting code reads from stdin; failure reaches IPC level (SESSION_NOT_FOUND), not argument parsing
- [x] `test_ipc_send_stdin_fallback`: same for `ipc send`
- [x] All existing CLI snapshot and integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)