### PR TITLE
docs: add per-crate READMEs and LICENSE files for crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Download the archive for your platform from [GitHub Releases](https://github.com
 cargo install --git https://github.com/eitsupi/arf.git
 ```
 
+> [!NOTE]
+> **For Windows**: A fix for VT input handling (bracketed paste, etc.) is pending in an upstream dependency
+> ([crossterm#1030](https://github.com/crossterm-rs/crossterm/pull/1030)).
+>
+> So installing from crates.io (`cargo install arf-console`) is **not recommended**.
+
 ## Third-Party distributions
 
 ### AUR (Arch Linux/Manjaro)

--- a/crates/arf-console/Cargo.toml
+++ b/crates/arf-console/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "A cross-platform R console written in Rust"
+readme = "../../README.md"
 
 [[bin]]
 name = "arf"

--- a/crates/arf-harp/LICENSE.md
+++ b/crates/arf-harp/LICENSE.md
@@ -1,0 +1,22 @@
+# MIT License
+
+Copyright (c) 2026 arf authors
+Copyright (c) 2024 Posit Software, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/arf-harp/README.md
+++ b/crates/arf-harp/README.md
@@ -1,0 +1,18 @@
+# arf-harp
+
+High-level R abstractions for safe R object manipulation, used internally by
+[arf](https://github.com/eitsupi/arf).
+
+> [!WARNING]
+> This crate is an **internal implementation detail** of arf. The API provides
+> no stability guarantees and may change in any release without notice. It is
+> not intended for use outside of the arf project.
+
+## Acknowledgements
+
+Portions of this crate are derived from
+[ark](https://github.com/posit-dev/ark) by Posit Software, PBC (MIT licensed).
+
+## License
+
+MIT

--- a/crates/arf-libr/LICENSE.md
+++ b/crates/arf-libr/LICENSE.md
@@ -1,0 +1,22 @@
+# MIT License
+
+Copyright (c) 2026 arf authors
+Copyright (c) 2024 Posit Software, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/arf-libr/README.md
+++ b/crates/arf-libr/README.md
@@ -1,0 +1,18 @@
+# arf-libr
+
+Low-level R FFI bindings using dynamic loading, used internally by
+[arf](https://github.com/eitsupi/arf).
+
+> [!WARNING]
+> This crate is an **internal implementation detail** of arf. The API provides
+> no stability guarantees and may change in any release without notice. It is
+> not intended for use outside of the arf project.
+
+## Acknowledgements
+
+The R initialization patterns in this crate were developed with reference to
+[ark](https://github.com/posit-dev/ark) by Posit Software, PBC (MIT licensed).
+
+## License
+
+MIT

--- a/crates/r-vignette-to-md/README.md
+++ b/crates/r-vignette-to-md/README.md
@@ -1,0 +1,14 @@
+# r-vignette-to-md
+
+Converts Pandoc-generated R vignette HTML to Markdown. Used internally by
+[arf](https://github.com/eitsupi/arf) to render R package vignettes in the
+terminal help browser.
+
+> [!WARNING]
+> This crate is an **internal implementation detail** of arf. The API provides
+> no stability guarantees and may change in any release without notice. It is
+> not intended for use outside of the arf project.
+
+## License
+
+MIT

--- a/crates/r-vignette-to-md/README.md
+++ b/crates/r-vignette-to-md/README.md
@@ -1,13 +1,10 @@
 # r-vignette-to-md
 
-Converts Pandoc-generated R vignette HTML to Markdown. Used internally by
-[arf](https://github.com/eitsupi/arf) to render R package vignettes in the
-terminal help browser.
+Converts Pandoc-generated R vignette HTML to Markdown.
 
-> [!WARNING]
-> This crate is an **internal implementation detail** of arf. The API provides
-> no stability guarantees and may change in any release without notice. It is
-> not intended for use outside of the arf project.
+Used by [arf](https://github.com/eitsupi/arf) to render R package vignettes
+in the terminal help browser, but designed as a standalone utility with no
+dependency on arf internals.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `README.md` to `arf-harp`, `arf-libr`, and `r-vignette-to-md` with internal crate warnings and ark attribution where applicable
- Add `LICENSE.md` to `arf-harp` and `arf-libr` including Posit Software, PBC copyright for ark-derived code
- Point `arf-console` readme to the workspace `README.md` via `Cargo.toml`
- Add a note to the Build from Source section about the Windows crates.io limitation

## Notes

- `arf-harp` and `arf-libr` contain code derived from [ark](https://github.com/posit-dev/ark) (MIT, Posit Software, PBC). Their LICENSE files now list both copyright holders.
- Installing from crates.io on Windows is not recommended until crossterm updated.

## Test plan

- [x] `cargo package --list -p arf-console` includes `README.md`
- [x] `cargo package --list -p arf-harp` includes `README.md` and `LICENSE.md`
- [x] `cargo package --list -p arf-libr` includes `README.md` and `LICENSE.md`
- [x] `cargo package --list -p r-vignette-to-md` includes `README.md`