### PR TITLE
chore: prepare release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,18 @@
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-10
+
 ### Added
 
 - `arf -f -`: read R script from stdin when `-` is passed as the file argument
 - `arf ipc eval` and `arf ipc send`: `code` argument is now optional; when omitted, code is read from stdin (exits with an error if stdin is a TTY)
 
-## [0.3.3-alpha.2] - 2026-05-05
-
 ### Fixed
 
-- (Windows) Bump patched `crossterm` revision to include a Windows VT input boundary fix (#181)
-
-## [0.3.3-alpha.1] - 2026-05-03
-
-### Fixed
-
-- (Windows) Clear `ENABLE_VIRTUAL_TERMINAL_INPUT` (`VT_INPUT`) on exit to restore key handling in shells such as nushell running in Windows Terminal (#175)
+- (Windows) `crossterm` patch updates for VT input handling in interactive terminals (#175, #181)
+  - Clear `ENABLE_VIRTUAL_TERMINAL_INPUT` (`VT_INPUT`) on exit to restore key handling in shells such as nushell running in Windows Terminal
+  - Bump patched `crossterm` revision to include a VT input batch-boundary parsing fix
 
 ## [0.3.2] - 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arf-console"
-version = "0.3.3-alpha.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.3.3-alpha.2"
+version = "0.3.3"
 dependencies = [
  "arf-libr",
  "log",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.3.3-alpha.2"
+version = "0.3.3"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1446,7 +1446,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.3.3-alpha.2"
+version = "0.3.3"
 dependencies = [
  "htmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.3.3-alpha.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.3.3-alpha.2", path = "crates/arf-harp" }
-arf-libr = { version = "0.3.3-alpha.2", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.3.3-alpha.2", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.3.3", path = "crates/arf-harp" }
+arf-libr = { version = "0.3.3", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.3.3", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3-alpha.2
+# arf console v0.3.3
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3-alpha.2
+# arf console v0.3.3
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3-alpha.2
+# arf console v0.3.3
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3-alpha.2
+# arf console v0.3.3
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3-alpha.2
+# arf console v0.3.3
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.3.3-alpha.2 to 0.3.3
- Finalize CHANGELOG `[Unreleased]` section as `[0.3.3] - 2026-05-10`
- Update banner snapshots for new version string

## Changelog

## [0.3.3] - 2026-05-10

### Added

- `arf -f -`: read R script from stdin when `-` is passed as the file argument
- `arf ipc eval` and `arf ipc send`: `code` argument is now optional; when omitted, code is read from stdin (exits with an error if stdin is a TTY)

### Fixed

- (Windows) `crossterm` patch updates for VT input handling in interactive terminals (#175, #181)
  - Clear `ENABLE_VIRTUAL_TERMINAL_INPUT` (`VT_INPUT`) on exit to restore key handling in shells such as nushell running in Windows Terminal
  - Bump patched `crossterm` revision to include a VT input batch-boundary parsing fix
