### PR TITLE
docs(readme): restructure and trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,7 @@ fuzzy = true
 
 Both `::` (exported names) and `:::` (internal names) are supported. Package exports are cached per-package with a 5-minute TTL for performance.
 
-The `package_functions` option controls which function calls trigger package-name fuzzy completion (defaults to `["library", "require"]`). Users can add custom functions like `"box::use"`:
-
-```toml
-[experimental.r_completion]
-fuzzy = true
-package_functions = ["library", "require", "box::use"]
-```
+See [Fuzzy R Completion configuration](docs/configuration.md#fuzzy-r-completion) for the `package_functions` option and other details.
 
 ### History forget
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See the full [IPC & Headless Mode Guide](docs/ipc.md) for details.
 
 ## Experimental Features
 
-Features in this section are under development and may change or be removed in future versions. Configure them under the `[experimental]` section.
+Features in this section are under development and may change or be removed in future versions. Configure them under the `[experimental]` table and its subtables (e.g. `[experimental.prompt_spinner]`).
 
 ### Spinner
 

--- a/README.md
+++ b/README.md
@@ -400,13 +400,13 @@ arf uses R's `options(error = ...)` to detect errors from packages like dplyr/rl
 
 ## Related Projects
 
-- [radian](https://github.com/randy3k/radian) — A 21st century R console written in Python.
+- [radian](https://github.com/randy3k/radian) — A 21st century R console written in Python. arf draws inspiration from radian's design philosophy.
 
 - [sircon](https://github.com/lrberge/sircon) — Simple R Console. A Windows-only R console with powerful autocomplete and a macro language for custom shortcuts. Some of sircon's advanced features are future goals for arf.
 
 ## Acknowledgements
 
-arf builds on the following projects:
+arf is built upon the broad Rust ecosystem and the remarkable efforts of those who have created open-source tools for R. In particular, we would like to highlight the following projects:
 
 - **[ark](https://github.com/posit-dev/ark)** — The `arf-libr` and `arf-harp` crates are derived from ark's `libr` and `harp` crates, which provide the foundation for embedding R in Rust applications. Windows initialization follows ark's pattern. [tree-sitter-r](https://github.com/r-lib/tree-sitter-r) powers syntax highlighting and code analysis.
 

--- a/README.md
+++ b/README.md
@@ -52,38 +52,58 @@
 
 ## Installation
 
-Pre-built binaries are available from [GitHub Releases](https://github.com/eitsupi/arf/releases). You can install them using one of the following methods:
+### Pre-built Binaries
 
-### Shell Installer (Linux/macOS)
+Pre-built binaries are available from [GitHub Releases](https://github.com/eitsupi/arf/releases).
+
+#### Shell Installer (Linux/macOS)
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/eitsupi/arf/releases/latest/download/arf-console-installer.sh | sh
 ```
 
-### winget (Windows)
+#### winget (Windows)
 
 ```sh
 winget install --id eitsupi.arf
 ```
 
-### Scoop (Windows)
+#### Scoop (Windows)
 
 ```sh
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 scoop install r-bucket/arf
 ```
 
-### cargo-binstall
+#### cargo-binstall
 
 ```sh
 cargo binstall --git https://github.com/eitsupi/arf arf-console
 ```
 
-### Manual Download
+#### Manual Download
 
 Download the archive for your platform from [GitHub Releases](https://github.com/eitsupi/arf/releases) and extract the binary to a directory in your `PATH`.
 
-## Build from Source
+### Third-Party Packages
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/arf.svg)](https://repology.org/project/arf/versions)
+
+#### Homebrew (macOS/Linux)
+
+```sh
+brew install arf
+```
+
+#### AUR (Arch Linux/Manjaro)
+
+```sh
+yay -S arf-bin
+# or use paru
+paru -S arf-bin
+```
+
+### Build from Source
 
 ```sh
 cargo install --git https://github.com/eitsupi/arf.git
@@ -94,22 +114,6 @@ cargo install --git https://github.com/eitsupi/arf.git
 > ([crossterm#1030](https://github.com/crossterm-rs/crossterm/pull/1030)).
 >
 > So installing from crates.io (`cargo install arf-console`) is **not recommended**.
-
-## Third-Party distributions
-
-### Homebrew (macOS/Linux)
-
-```sh
-brew install arf
-```
-
-### AUR (Arch Linux/Manjaro)
-
-```sh
-yay -S arf-bin
-# or use paru
-paru -S arf-bin
-```
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ Press `:h` or `:help` to open the fuzzy help browser:
   ↑↓ navigate  Tab/Enter select  Esc exit
 ```
 
-### Meta Commands
+## Meta Commands
+
+arf extends R with `:` prefixed meta commands:
 
 | Command | Description |
 |---------|-------------|
@@ -266,25 +268,7 @@ frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # Braille dots
 color = "Cyan"              # Spinner color (default: Cyan)
 ```
 
-**Configuration options:**
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `frames` | `""` (disabled) | Animation frames (each character is one frame). |
-| `color` | `"Cyan"` | Spinner color. Accepts standard ANSI color names: `Black`, `Red`, `Green`, `Yellow`, `Blue`, `Magenta`, `Cyan`, `White`, and their `Light` variants (e.g., `LightBlue`). |
-
-**Frame style examples:**
-
-```toml
-# Braille dots (recommended)
-frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-
-# ASCII spinner (works in all terminals)
-frames = "|/-\\"
-
-# Block spinner
-frames = "▖▘▝▗"
-```
+See [Spinner configuration](docs/configuration.md#spinner) for all options and frame style examples.
 
 ### Auto-completion while typing
 
@@ -327,13 +311,7 @@ delay = 2          # Keep last N failed commands for quick retry
 on_exit_only = false  # Purge on each prompt (false) or only on exit (true)
 ```
 
-**Configuration options:**
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `false` | Enable automatic removal of failed commands. |
-| `delay` | `2` | Number of recent failed commands to keep accessible for retry. Older failed commands are purged. |
-| `on_exit_only` | `false` | If `true`, only purge when session ends. If `false`, purge on each prompt. |
+See [History forget configuration](docs/configuration.md#history-forget) for all options.
 
 ### History export/import
 

--- a/README.md
+++ b/README.md
@@ -21,31 +21,23 @@
 
 </div>
 
-## Highlights
-
-- **Single Binary, Zero Dependencies** — One small executable with no runtime dependencies. Just download and run.
-
-- **rig Integration** — Seamless [rig](https://github.com/r-lib/rig) (R Installation Manager) support. Switch R versions with `--with-r-version` flag, or use the `:switch` meta command to change versions within a running session.
-
-- **Fuzzy History Search** — fzf-style history search with `Ctrl+R`. Type fragments to find past commands quickly. Import your existing history from radian or R's `.Rhistory`.
-
-- **Syntax Highlighting** — Tree-sitter based highlighting for R code with customizable colors.
-
-- **Interactive Help Browser** — Fuzzy search through R documentation with `:help` or `:h`. Find any function across all installed packages instantly.
-
 ## Features
 
+- **Single Binary, Zero Dependencies** — One small executable with no runtime dependencies. Just download and run.
 - Cross-platform: Linux, macOS, and Windows
+- **rig Integration** — Seamless [rig](https://github.com/r-lib/rig) support. Switch R versions with `--with-r-version` or the `:switch` meta command within a running session.
 - Vi and Emacs editing modes
 - Multiline editing with proper indentation
 - Auto-matching brackets and quotes (with smart skip-over)
 - Tab completion for R objects, functions, and file paths inside strings
+- **Fuzzy History Search** — fzf-style history search with `Ctrl+R`. Import existing history from radian or R's `.Rhistory`.
 - Customizable keyboard shortcuts (`Alt+-` → ` <- `, `Alt+P` → ` |> `)
 - Command status indicator (shows error symbol when previous command failed)
+- **Interactive Help Browser** — Fuzzy search through R documentation with `:help` or `:h`. Find any function across all installed packages instantly.
+- Tree-sitter based syntax highlighting with customizable colors
 - Reprex mode with optional auto-formatting via [Air](https://github.com/posit-dev/air)
 - Shell mode (`:shell` to enter, `:r` to return)
 - Configurable prompts and colors with placeholders (`{version}`, `{cwd}`, `{status}`)
-- Syntax highlighting with customizable colors
 - SQLite-backed persistent history with import/export support
 - IPC server for AI agent and CI integration
 - Headless mode for non-interactive environments (CI, background jobs)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br>
 
-**arf** is a modern, cross-platform R console written in Rust. It provides a rich interactive experience with fuzzy help search, intelligent history navigation, and syntax highlighting—all with fast startup times.
+**arf** is a cross-platform R console written in Rust.
 
 > [!WARNING]
 > arf is under active development. The configuration file format and history file format are not yet stable and may change without notice in future versions.
@@ -23,17 +23,17 @@
 
 ## Features
 
-- **Single Binary, Zero Dependencies** — One small executable with no runtime dependencies. Just download and run.
+- Single binary with no runtime dependencies
 - Cross-platform: Linux, macOS, and Windows
-- **rig Integration** — Seamless [rig](https://github.com/r-lib/rig) support. Switch R versions with `--with-r-version` or the `:switch` meta command within a running session.
+- [rig](https://github.com/r-lib/rig) integration — switch R versions with `--with-r-version` or `:switch` within a session
 - Vi and Emacs editing modes
 - Multiline editing with proper indentation
 - Auto-matching brackets and quotes (with smart skip-over)
 - Tab completion for R objects, functions, and file paths inside strings
-- **Fuzzy History Search** — fzf-style history search with `Ctrl+R`. Import existing history from radian or R's `.Rhistory`.
+- fzf-style history search with `Ctrl+R`; import from radian or `.Rhistory`
 - Customizable keyboard shortcuts (`Alt+-` → ` <- `, `Alt+P` → ` |> `)
 - Command status indicator (shows error symbol when previous command failed)
-- **Interactive Help Browser** — Fuzzy search through R documentation with `:help` or `:h`. Find any function across all installed packages instantly.
+- Fuzzy help browser with `:help` or `:h` — search across all installed packages
 - Tree-sitter based syntax highlighting with customizable colors
 - Reprex mode with optional auto-formatting via [Air](https://github.com/posit-dev/air)
 - Shell mode (`:shell` to enter, `:r` to return)
@@ -258,7 +258,7 @@ Features in this section are under development and may change or be removed in f
 
 ### Spinner
 
-Displays an animated spinner at the start of the line while R is evaluating code, providing visual feedback that the system is busy. **Disabled by default.**
+Displays an animated spinner at the start of the line while R is evaluating code. **Disabled by default.**
 
 To enable, set the `frames` option:
 
@@ -394,13 +394,6 @@ arf history import --from radian --hostname "radian-import"
 - Self-import is detected and rejected when importing from an arf database to the same target file.
 - **Important:** Exit arf before exporting to ensure the source databases are in a consistent state. The export itself uses atomic writes to prevent incomplete output files, but reading while arf is writing may capture inconsistent data.
 
-**Restore from backup:**
-
-```sh
-# Restore history from a unified export file
-arf history import --from arf --file ~/arf_backup.db
-```
-
 ## Known Issues
 
 ### Error detection uses `options(error = ...)`
@@ -413,13 +406,13 @@ arf uses R's `options(error = ...)` to detect errors from packages like dplyr/rl
 
 ## Related Projects
 
-- [radian](https://github.com/randy3k/radian) — A 21st century R console written in Python. arf draws inspiration from radian's design philosophy.
+- [radian](https://github.com/randy3k/radian) — A 21st century R console written in Python.
 
 - [sircon](https://github.com/lrberge/sircon) — Simple R Console. A Windows-only R console with powerful autocomplete and a macro language for custom shortcuts. Some of sircon's advanced features are future goals for arf.
 
 ## Acknowledgements
 
-arf is built upon the broad Rust ecosystem and the remarkable efforts of those who have created open-source tools for R. In particular, we would like to highlight the following projects:
+arf builds on the following projects:
 
 - **[ark](https://github.com/posit-dev/ark)** — The `arf-libr` and `arf-harp` crates are derived from ark's `libr` and `harp` crates, which provide the foundation for embedding R in Rust applications. Windows initialization follows ark's pattern. [tree-sitter-r](https://github.com/r-lib/tree-sitter-r) powers syntax highlighting and code analysis.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -712,7 +712,6 @@ color = "Cyan"
 **Frame style examples:**
 
 ```toml
-[experimental.prompt_spinner]
 # Braille dots (recommended)
 frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
@@ -721,6 +720,25 @@ frames = "|/-\\"
 
 # Block spinner
 frames = "▖▘▝▗"
+```
+
+### Fuzzy R Completion
+
+Use fuzzy matching for R code completions. When enabled, typing `sf::geo` can match `sf::st_geometry` and `library(dpl` can match `dplyr`. **Disabled by default.**
+
+```toml
+[experimental.r_completion]
+fuzzy = true
+```
+
+Both `::` (exported names) and `:::` (internal names) are supported. Package exports are cached per-package with a 5-minute TTL for performance.
+
+The `package_functions` option controls which function calls trigger package-name fuzzy completion (defaults to `["library", "require"]`). Add custom functions as needed:
+
+```toml
+[experimental.r_completion]
+fuzzy = true
+package_functions = ["library", "require", "box::use"]
 ```
 
 ### History Forget

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -696,6 +696,12 @@ Features in this section are under development and may change or be removed in f
 
 Displays an animated spinner at the start of the line while R is evaluating code. **Disabled by default** — set `frames` to enable.
 
+```toml
+[experimental.prompt_spinner]
+frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"  # Braille dots
+color = "Cyan"
+```
+
 **Configuration options:**
 
 | Option | Default | Description |
@@ -720,6 +726,13 @@ frames = "▖▘▝▗"
 ### History Forget
 
 Automatically removes commands that produced errors from history. Similar to fish's [sponge](https://github.com/meaningful-ooo/sponge) plugin.
+
+```toml
+[experimental.history_forget]
+enabled = true
+delay = 2          # Keep last N failed commands for quick retry
+on_exit_only = false  # Purge on each prompt (false) or only on exit (true)
+```
 
 **Configuration options:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -688,6 +688,47 @@ arf history import --from r
 > [!NOTE]
 > Re-importing the same file is safe — duplicate entries are automatically skipped by matching command text and timestamp.
 
+## Experimental Features
+
+Features in this section are under development and may change or be removed in future versions.
+
+### Spinner
+
+Displays an animated spinner at the start of the line while R is evaluating code. **Disabled by default** — set `frames` to enable.
+
+**Configuration options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `frames` | `""` (disabled) | Animation frames (each character is one frame). |
+| `color` | `"Cyan"` | Spinner color. Accepts standard ANSI color names: `Black`, `Red`, `Green`, `Yellow`, `Blue`, `Magenta`, `Cyan`, `White`, and their `Light` variants (e.g., `LightBlue`). |
+
+**Frame style examples:**
+
+```toml
+[experimental.prompt_spinner]
+# Braille dots (recommended)
+frames = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+# ASCII spinner (works in all terminals)
+frames = "|/-\\"
+
+# Block spinner
+frames = "▖▘▝▗"
+```
+
+### History Forget
+
+Automatically removes commands that produced errors from history. Similar to fish's [sponge](https://github.com/meaningful-ooo/sponge) plugin.
+
+**Configuration options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable automatic removal of failed commands. |
+| `delay` | `2` | Number of recent failed commands to keep accessible for retry. Older failed commands are purged. |
+| `on_exit_only` | `false` | If `true`, only purge when session ends. If `false`, purge on each prompt. |
+
 ## CLI Options Override
 
 Command-line options take precedence over config file settings:


### PR DESCRIPTION
## Summary

- Consolidate Installation, Build from Source, and Third-Party distributions into a single `## Installation` section with three subsections; add Repology packaging status badge to the Third-Party Packages subsection
- Merge `## Highlights` into `## Features`, removing the redundant section
- Move experimental feature config tables (Spinner, History forget) to `docs/configuration.md`; keep feature descriptions and History export/import in README
- Move Meta Commands table out of Quick Start into its own top-level section
- Remove verbose and AI-sounding phrasing: simplified intro, unified Features list style, removed redundant Spinner phrase, duplicate "Restore from backup" example, and filler in Acknowledgements

## Test plan

- [x] All changes are documentation only (no code changes)
- [x] Verify rendered output on GitHub (section structure, badge display, links to docs)