### PR TITLE
feat: semicolon shortcut for instant shell mode switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental:** `;` shortcut to switch to shell mode at an empty R prompt (`experimental.shell_semicolon_shortcut`). One keypress — no `:shell` or Enter required. Similar to Julia REPL shell mode. When the buffer is not empty, `;` inserts a semicolon as usual. Disabled by default.
+
 ## [0.3.3] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ arf extends R with `:` prefixed meta commands:
 | `:commands`, `:cmds` | Show available commands |
 | `:quit`, `:exit` | Exit arf |
 
+> [!NOTE]
+> **Experimental:** Enable the `experimental.shell_semicolon_shortcut` option to switch to shell mode by pressing `;` at an empty prompt — no `:shell` or Enter required (similar to Julia REPL behavior).
+
 ## Configuration
 
 arf uses a TOML configuration file located at:

--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -88,7 +88,8 @@
         },
         "shell_completion": {
           "command_names": false
-        }
+        },
+        "shell_semicolon_shortcut": false
       }
     },
     "history": {
@@ -1609,6 +1610,11 @@
           "default": {
             "command_names": false
           }
+        },
+        "shell_semicolon_shortcut": {
+          "description": "Enable `;` as a shortcut to switch to shell mode.\n\nWhen enabled, pressing `;` at an empty R prompt instantly switches to\nshell mode without requiring Enter — similar to Julia REPL behavior.\nWhen the buffer is not empty, `;` inserts a semicolon as usual.\n\nDisabled by default.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -44,6 +44,16 @@ pub struct ExperimentalConfig {
     /// Shell mode completion configuration.
     #[serde(default)]
     pub shell_completion: ShellCompletionConfig,
+
+    /// Enable `;` as a shortcut to switch to shell mode.
+    ///
+    /// When enabled, pressing `;` at an empty R prompt instantly switches to
+    /// shell mode without requiring Enter — similar to Julia REPL behavior.
+    /// When the buffer is not empty, `;` inserts a semicolon as usual.
+    ///
+    /// Disabled by default.
+    #[serde(default)]
+    pub shell_semicolon_shortcut: bool,
 }
 
 /// Configuration for shell mode completion.
@@ -182,6 +192,15 @@ struct ExperimentalConfigSchema {
 
     /// Shell mode completion configuration.
     pub shell_completion: ShellCompletionConfig,
+
+    /// Enable `;` as a shortcut to switch to shell mode.
+    ///
+    /// When enabled, pressing `;` at an empty R prompt instantly switches to
+    /// shell mode without requiring Enter — similar to Julia REPL behavior.
+    /// When the buffer is not empty, `;` inserts a semicolon as usual.
+    ///
+    /// Disabled by default.
+    pub shell_semicolon_shortcut: bool,
 }
 
 // Manual JsonSchema implementation for ExperimentalConfig since nu_ansi_term::Color

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -455,4 +455,20 @@ command_names = true
         let config: crate::config::Config = toml::from_str(toml_str).unwrap();
         assert!(config.experimental.shell_completion.command_names);
     }
+
+    #[test]
+    fn test_shell_semicolon_shortcut_default() {
+        let config = ExperimentalConfig::default();
+        assert!(!config.shell_semicolon_shortcut);
+    }
+
+    #[test]
+    fn test_parse_shell_semicolon_shortcut() {
+        let toml_str = r#"
+[experimental]
+shell_semicolon_shortcut = true
+"#;
+        let config: crate::config::Config = toml::from_str(toml_str).unwrap();
+        assert!(config.experimental.shell_semicolon_shortcut);
+    }
 }

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -92,7 +92,8 @@ expression: schema
         },
         "shell_completion": {
           "command_names": false
-        }
+        },
+        "shell_semicolon_shortcut": false
       }
     },
     "history": {
@@ -1613,6 +1614,11 @@ expression: schema
           "default": {
             "command_names": false
           }
+        },
+        "shell_semicolon_shortcut": {
+          "description": "Enable `;` as a shortcut to switch to shell mode.\n\nWhen enabled, pressing `;` at an empty R prompt instantly switches to\nshell mode without requiring Enter — similar to Julia REPL behavior.\nWhen the buffer is not empty, `;` inserts a semicolon as usual.\n\nDisabled by default.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
@@ -94,6 +94,9 @@ insert = "LightGreen"
 normal = "LightYellow"
 non_vi = "Default"
 
+[experimental]
+shell_semicolon_shortcut = false
+
 [experimental.history_forget]
 enabled = false
 delay = 2

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -143,14 +143,15 @@ pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
 /// `wrap_edit_mode_with_conditional_rules` falls back to `InsertChar(';')`
 /// when the buffer is not empty, preserving normal semicolon input.
 pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
-    keybindings.add_binding(
-        KeyModifiers::NONE,
-        KeyCode::Char(';'),
-        ReedlineEvent::Multiple(vec![
-            ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
-            ReedlineEvent::Submit,
-        ]),
-    );
+    let event = ReedlineEvent::Multiple(vec![
+        ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
+        ReedlineEvent::Submit,
+    ]);
+    // Bind both NONE and SHIFT: on some platforms/layouts crossterm includes
+    // SHIFT in the key event even when it is part of typing the character
+    // (same rationale as add_auto_match_keybindings).
+    keybindings.add_binding(KeyModifiers::NONE, KeyCode::Char(';'), event.clone());
+    keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::Char(';'), event);
 }
 
 /// Add auto-match keybindings for brackets and quotes.

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -154,7 +154,6 @@ pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
     keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::Char(';'), event);
 }
 
-
 /// Add auto-match keybindings for brackets and quotes.
 ///
 /// When typing an opening bracket or quote, automatically inserts the closing

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -1,8 +1,8 @@
 //! Keyboard shortcut configuration.
 
 use crate::editor::mode::{
-    ConditionalEditMode, ConditionalRule, CursorAtBegin, EditorStateRef, create_auto_match_rules,
-    create_bracket_delete_rules, create_skip_over_rules,
+    BufferEmpty, ConditionalEditMode, ConditionalRule, CursorAtBegin, EditorStateRef,
+    create_auto_match_rules, create_bracket_delete_rules, create_skip_over_rules,
 };
 use crokey::KeyCombination;
 use reedline::{EditCommand, EditMode, KeyCode, KeyModifiers, Keybindings, ReedlineEvent};
@@ -66,11 +66,13 @@ pub fn add_common_keybindings(keybindings: &mut Keybindings) {
 /// - Auto-match only inserts closing brackets when cursor is at end of buffer
 /// - Auto-trigger completion when buffer reaches `completion_min_chars` characters
 /// - Tree-sitter based word navigation for Ctrl+Arrow (R token boundaries)
+/// - When `shell_semicolon_shortcut` is true, ';' at empty buffer triggers shell mode
 pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
     edit_mode: E,
     state: EditorStateRef,
     auto_match: bool,
     completion_min_chars: Option<usize>,
+    shell_semicolon_shortcut: bool,
 ) -> Box<dyn EditMode> {
     // Rule: when ':' produces InsertChar + Menu, check if cursor is at position 0
     // If not at position 0, replace with just InsertChar(':')
@@ -105,7 +107,35 @@ pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
         conditional = conditional.with_rules(create_auto_match_rules());
     }
 
+    // When the semicolon shortcut is enabled, ';' at an empty buffer fires
+    // ExecuteHostCommand(":shell"). When the buffer has content, fall back to
+    // inserting a literal semicolon so normal R expressions are unaffected.
+    if shell_semicolon_shortcut {
+        let semicolon_rule = ConditionalRule {
+            match_event: Box::new(
+                |event| matches!(event, ReedlineEvent::ExecuteHostCommand(cmd) if cmd == ":shell"),
+            ),
+            condition: Box::new(BufferEmpty),
+            fallback_event: ReedlineEvent::Edit(vec![EditCommand::InsertChar(';')]),
+        };
+        conditional = conditional.with_rule(semicolon_rule);
+    }
+
     Box::new(conditional)
+}
+
+/// Add the `;` → shell-mode keybinding.
+///
+/// Maps `;` to `ExecuteHostCommand(":shell")` so that pressing `;` at an empty
+/// prompt switches to shell mode immediately (no Enter required). A
+/// `ConditionalRule` added by `wrap_edit_mode_with_conditional_rules` converts
+/// the event back to `InsertChar(';')` when the buffer is not empty.
+pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Char(';'),
+        ReedlineEvent::ExecuteHostCommand(":shell".to_string()),
+    );
 }
 
 /// Add auto-match keybindings for brackets and quotes.

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -154,6 +154,41 @@ pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
     keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::Char(';'), event);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reedline::{EditCommand, KeyCode, KeyModifiers, ReedlineEvent};
+
+    fn shell_event() -> ReedlineEvent {
+        ReedlineEvent::Multiple(vec![
+            ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
+            ReedlineEvent::Submit,
+        ])
+    }
+
+    #[test]
+    fn test_shell_semicolon_keybinding_none_modifier() {
+        let mut kb = reedline::Keybindings::new();
+        add_shell_semicolon_keybinding(&mut kb);
+        assert_eq!(
+            kb.find_binding(KeyModifiers::NONE, KeyCode::Char(';')),
+            Some(shell_event()),
+            "NONE+';' should map to the shell shortcut event"
+        );
+    }
+
+    #[test]
+    fn test_shell_semicolon_keybinding_shift_modifier() {
+        let mut kb = reedline::Keybindings::new();
+        add_shell_semicolon_keybinding(&mut kb);
+        assert_eq!(
+            kb.find_binding(KeyModifiers::SHIFT, KeyCode::Char(';')),
+            Some(shell_event()),
+            "SHIFT+';' should map to the same shell shortcut event for cross-layout support"
+        );
+    }
+}
+
 /// Add auto-match keybindings for brackets and quotes.
 ///
 /// When typing an opening bracket or quote, automatically inserts the closing

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -154,40 +154,6 @@ pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
     keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::Char(';'), event);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use reedline::{EditCommand, KeyCode, KeyModifiers, ReedlineEvent};
-
-    fn shell_event() -> ReedlineEvent {
-        ReedlineEvent::Multiple(vec![
-            ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
-            ReedlineEvent::Submit,
-        ])
-    }
-
-    #[test]
-    fn test_shell_semicolon_keybinding_none_modifier() {
-        let mut kb = reedline::Keybindings::new();
-        add_shell_semicolon_keybinding(&mut kb);
-        assert_eq!(
-            kb.find_binding(KeyModifiers::NONE, KeyCode::Char(';')),
-            Some(shell_event()),
-            "NONE+';' should map to the shell shortcut event"
-        );
-    }
-
-    #[test]
-    fn test_shell_semicolon_keybinding_shift_modifier() {
-        let mut kb = reedline::Keybindings::new();
-        add_shell_semicolon_keybinding(&mut kb);
-        assert_eq!(
-            kb.find_binding(KeyModifiers::SHIFT, KeyCode::Char(';')),
-            Some(shell_event()),
-            "SHIFT+';' should map to the same shell shortcut event for cross-layout support"
-        );
-    }
-}
 
 /// Add auto-match keybindings for brackets and quotes.
 ///
@@ -260,6 +226,41 @@ pub fn add_key_map_keybindings(
             key_event.modifiers,
             key_event.code,
             ReedlineEvent::Edit(vec![EditCommand::InsertString(text.clone())]),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reedline::{EditCommand, KeyCode, KeyModifiers, ReedlineEvent};
+
+    fn shell_event() -> ReedlineEvent {
+        ReedlineEvent::Multiple(vec![
+            ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
+            ReedlineEvent::Submit,
+        ])
+    }
+
+    #[test]
+    fn test_shell_semicolon_keybinding_none_modifier() {
+        let mut kb = reedline::Keybindings::new();
+        add_shell_semicolon_keybinding(&mut kb);
+        assert_eq!(
+            kb.find_binding(KeyModifiers::NONE, KeyCode::Char(';')),
+            Some(shell_event()),
+            "NONE+';' should map to the shell shortcut event"
+        );
+    }
+
+    #[test]
+    fn test_shell_semicolon_keybinding_shift_modifier() {
+        let mut kb = reedline::Keybindings::new();
+        add_shell_semicolon_keybinding(&mut kb);
+        assert_eq!(
+            kb.find_binding(KeyModifiers::SHIFT, KeyCode::Char(';')),
+            Some(shell_event()),
+            "SHIFT+';' should map to the same shell shortcut event for cross-layout support"
         );
     }
 }

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -1,7 +1,7 @@
 //! Keyboard shortcut configuration.
 
 use crate::editor::mode::{
-    BufferEmpty, ConditionalEditMode, ConditionalRule, CursorAtBegin, EditorStateRef,
+    BufferKnownEmpty, ConditionalEditMode, ConditionalRule, CursorAtBegin, EditorStateRef,
     create_auto_match_rules, create_bracket_delete_rules, create_skip_over_rules,
 };
 use crokey::KeyCombination;
@@ -126,7 +126,7 @@ pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
                         && matches!(&events[1], ReedlineEvent::Submit)
                 )
             }),
-            condition: Box::new(BufferEmpty),
+            condition: Box::new(BufferKnownEmpty),
             fallback_event: ReedlineEvent::Edit(vec![EditCommand::InsertChar(';')]),
         };
         conditional = conditional.with_rule(semicolon_rule);

--- a/crates/arf-console/src/editor/keybindings.rs
+++ b/crates/arf-console/src/editor/keybindings.rs
@@ -107,14 +107,25 @@ pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
         conditional = conditional.with_rules(create_auto_match_rules());
     }
 
-    // When the semicolon shortcut is enabled, ';' at an empty buffer fires
-    // ExecuteHostCommand(":shell"). When the buffer has content, fall back to
-    // inserting a literal semicolon so normal R expressions are unaffected.
+    // When the semicolon shortcut is enabled, ';' at an empty buffer inserts
+    // ":shell" and submits immediately. When the buffer has content, fall back
+    // to inserting a literal semicolon so normal R expressions are unaffected.
     if shell_semicolon_shortcut {
         let semicolon_rule = ConditionalRule {
-            match_event: Box::new(
-                |event| matches!(event, ReedlineEvent::ExecuteHostCommand(cmd) if cmd == ":shell"),
-            ),
+            match_event: Box::new(|event| {
+                matches!(
+                    event,
+                    ReedlineEvent::Multiple(events)
+                    if events.len() == 2
+                        && matches!(
+                            &events[0],
+                            ReedlineEvent::Edit(cmds)
+                            if cmds.len() == 1
+                                && matches!(&cmds[0], EditCommand::InsertString(s) if s == ":shell")
+                        )
+                        && matches!(&events[1], ReedlineEvent::Submit)
+                )
+            }),
             condition: Box::new(BufferEmpty),
             fallback_event: ReedlineEvent::Edit(vec![EditCommand::InsertChar(';')]),
         };
@@ -126,15 +137,19 @@ pub fn wrap_edit_mode_with_conditional_rules<E: EditMode + 'static>(
 
 /// Add the `;` → shell-mode keybinding.
 ///
-/// Maps `;` to `ExecuteHostCommand(":shell")` so that pressing `;` at an empty
-/// prompt switches to shell mode immediately (no Enter required). A
-/// `ConditionalRule` added by `wrap_edit_mode_with_conditional_rules` converts
-/// the event back to `InsertChar(';')` when the buffer is not empty.
+/// Maps `;` to `Multiple([InsertString(":shell"), Submit])` so that pressing
+/// `;` at an empty prompt inserts `:shell` and submits it immediately — no
+/// Enter required. A `ConditionalRule` added by
+/// `wrap_edit_mode_with_conditional_rules` falls back to `InsertChar(';')`
+/// when the buffer is not empty, preserving normal semicolon input.
 pub fn add_shell_semicolon_keybinding(keybindings: &mut Keybindings) {
     keybindings.add_binding(
         KeyModifiers::NONE,
         KeyCode::Char(';'),
-        ReedlineEvent::ExecuteHostCommand(":shell".to_string()),
+        ReedlineEvent::Multiple(vec![
+            ReedlineEvent::Edit(vec![EditCommand::InsertString(":shell".to_string())]),
+            ReedlineEvent::Submit,
+        ]),
     );
 }
 

--- a/crates/arf-console/src/editor/mode.rs
+++ b/crates/arf-console/src/editor/mode.rs
@@ -396,6 +396,16 @@ impl KeyCondition for BufferEmpty {
     }
 }
 
+/// Condition: buffer is known to be empty (empty and not uncertain).
+#[derive(Debug, Clone, Copy)]
+pub struct BufferKnownEmpty;
+
+impl KeyCondition for BufferKnownEmpty {
+    fn check(&self, state: &EditorState) -> bool {
+        state.is_empty() && !state.uncertain
+    }
+}
+
 /// Condition: cursor is at the end of the buffer.
 ///
 /// This is useful for auto-match behavior where we only want to insert

--- a/crates/arf-console/src/editor/mode.rs
+++ b/crates/arf-console/src/editor/mode.rs
@@ -1116,6 +1116,32 @@ mod tests {
     }
 
     #[test]
+    fn test_buffer_known_empty_condition() {
+        let condition = BufferKnownEmpty;
+
+        let mut state = EditorState::new();
+        state.buffer_len = 0;
+        state.uncertain = false;
+        assert!(
+            condition.check(&state),
+            "certain empty buffer should trigger semicolon shortcut condition"
+        );
+
+        state.uncertain = true;
+        assert!(
+            !condition.check(&state),
+            "uncertain empty buffer should NOT trigger semicolon shortcut condition"
+        );
+
+        state.buffer_len = 1;
+        state.uncertain = false;
+        assert!(
+            !condition.check(&state),
+            "non-empty buffer should not match"
+        );
+    }
+
+    #[test]
     fn test_cursor_at_end_condition() {
         let condition = CursorAtEnd;
 

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::editor::keybindings::{
     add_auto_match_keybindings, add_common_keybindings, add_key_map_keybindings,
-    wrap_edit_mode_with_conditional_rules,
+    add_shell_semicolon_keybinding, wrap_edit_mode_with_conditional_rules,
 };
 use crate::editor::validator::RValidator;
 use banner::format_banner;
@@ -269,6 +269,9 @@ impl Repl {
                 if self.config.editor.auto_match {
                     add_auto_match_keybindings(&mut insert_keybindings);
                 }
+                if self.config.experimental.shell_semicolon_shortcut {
+                    add_shell_semicolon_keybinding(&mut insert_keybindings);
+                }
                 add_key_map_keybindings(&mut insert_keybindings, &self.config.editor.key_map);
                 let vi = Vi::new(insert_keybindings, default_vi_normal_keybindings());
                 line_editor.with_edit_mode(wrap_edit_mode_with_conditional_rules(
@@ -276,6 +279,7 @@ impl Repl {
                     editor_state.clone(),
                     self.config.editor.auto_match,
                     self.config.experimental.completion_min_chars,
+                    self.config.experimental.shell_semicolon_shortcut,
                 ))
             }
             EditorMode::Emacs => {
@@ -284,6 +288,9 @@ impl Repl {
                 if self.config.editor.auto_match {
                     add_auto_match_keybindings(&mut keybindings);
                 }
+                if self.config.experimental.shell_semicolon_shortcut {
+                    add_shell_semicolon_keybinding(&mut keybindings);
+                }
                 add_key_map_keybindings(&mut keybindings, &self.config.editor.key_map);
                 let emacs = Emacs::new(keybindings);
                 line_editor.with_edit_mode(wrap_edit_mode_with_conditional_rules(
@@ -291,6 +298,7 @@ impl Repl {
                     editor_state.clone(),
                     self.config.editor.auto_match,
                     self.config.experimental.completion_min_chars,
+                    self.config.experimental.shell_semicolon_shortcut,
                 ))
             }
         };
@@ -569,6 +577,9 @@ impl Repl {
                 if self.config.editor.auto_match {
                     add_auto_match_keybindings(&mut insert_keybindings);
                 }
+                if self.config.experimental.shell_semicolon_shortcut {
+                    add_shell_semicolon_keybinding(&mut insert_keybindings);
+                }
                 add_key_map_keybindings(&mut insert_keybindings, &self.config.editor.key_map);
                 let vi = Vi::new(insert_keybindings, default_vi_normal_keybindings());
                 line_editor.with_edit_mode(wrap_edit_mode_with_conditional_rules(
@@ -576,6 +587,7 @@ impl Repl {
                     editor_state.clone(),
                     self.config.editor.auto_match,
                     self.config.experimental.completion_min_chars,
+                    self.config.experimental.shell_semicolon_shortcut,
                 ))
             }
             EditorMode::Emacs => {
@@ -584,6 +596,9 @@ impl Repl {
                 if self.config.editor.auto_match {
                     add_auto_match_keybindings(&mut keybindings);
                 }
+                if self.config.experimental.shell_semicolon_shortcut {
+                    add_shell_semicolon_keybinding(&mut keybindings);
+                }
                 add_key_map_keybindings(&mut keybindings, &self.config.editor.key_map);
                 let emacs = Emacs::new(keybindings);
                 line_editor.with_edit_mode(wrap_edit_mode_with_conditional_rules(
@@ -591,6 +606,7 @@ impl Repl {
                     editor_state.clone(),
                     self.config.editor.auto_match,
                     self.config.experimental.completion_min_chars,
+                    self.config.experimental.shell_semicolon_shortcut,
                 ))
             }
         };

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -226,6 +226,106 @@ fn test_pty_shell_mode_ctrl_c_exit() {
     terminal.quit().expect("Should quit cleanly");
 }
 
+/// Test `;` shortcut enters shell mode when `experimental.shell_semicolon_shortcut` is enabled.
+///
+/// Pressing `;` at an empty prompt should automatically insert `:shell` and
+/// submit it — no Enter required — switching to shell mode immediately.
+#[test]
+#[cfg(unix)]
+fn test_pty_shell_semicolon_shortcut() {
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let mut config_file = NamedTempFile::new().expect("Failed to create temp config file");
+    writeln!(
+        config_file,
+        r#"
+[experimental]
+shell_semicolon_shortcut = true
+"#
+    )
+    .expect("Failed to write config file");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--config",
+        config_file.path().to_str().unwrap(),
+        "--no-auto-match",
+        "--no-completion",
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Press ';' alone — the keybinding inserts ":shell" and submits without Enter
+    terminal.send(";").expect("Should send semicolon");
+    terminal
+        .expect("Shell mode enabled")
+        .expect("Should show shell mode message");
+    terminal
+        .expect("] $")
+        .expect("Should show shell mode prompt");
+
+    // Execute a shell command to verify shell mode is functional
+    terminal
+        .send_line("echo semicolon_test")
+        .expect("Should send shell command");
+    terminal
+        .expect("semicolon_test")
+        .expect("Should see shell output");
+
+    // Return to R mode
+    terminal.send_line(":r").expect("Should send :r");
+    terminal
+        .expect("Returned to R mode")
+        .expect("Should return to R mode");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test `;` inserts a literal semicolon when `experimental.shell_semicolon_shortcut` is enabled
+/// but the buffer is not empty.
+///
+/// The `;` shortcut must only fire when the prompt is empty; mid-expression
+/// semicolons must still be inserted as normal characters.
+#[test]
+#[cfg(unix)]
+fn test_pty_shell_semicolon_shortcut_nonempty_buffer() {
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let mut config_file = NamedTempFile::new().expect("Failed to create temp config file");
+    writeln!(
+        config_file,
+        r#"
+[experimental]
+shell_semicolon_shortcut = true
+"#
+    )
+    .expect("Failed to write config file");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--config",
+        config_file.path().to_str().unwrap(),
+        "--no-auto-match",
+        "--no-completion",
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Type something first so the buffer is not empty, then press ';'
+    terminal.send("1").expect("Should send 1");
+    terminal.send(";").expect("Should send semicolon");
+
+    // ';' should be inserted literally; submit "1;2" and verify R evaluates both statements
+    terminal.send_line("2").expect("Should send 2");
+    terminal
+        .expect("[1] 2")
+        .expect("Semicolon should not trigger shell mode; 1;2 should evaluate as R expression");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
 /// Test :help command opens interactive browser in alternate screen.
 ///
 /// This tests that:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,8 +146,7 @@ color = "Cyan"             # Spinner color
 format = "{value} "        # Duration display format ({value} = time string)
 threshold_ms = 2000        # Show duration only for commands slower than this (ms)
 
-[experimental]
-shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
+experimental.shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
 ```
 
 ## Bracket Highlighting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,9 @@ color = "Cyan"             # Spinner color
 [experimental.prompt_duration]
 format = "{value} "        # Duration display format ({value} = time string)
 threshold_ms = 2000        # Show duration only for commands slower than this (ms)
+
+[experimental]
+shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
 ```
 
 ## Bracket Highlighting
@@ -759,6 +762,17 @@ on_exit_only = false  # Purge on each prompt (false) or only on exit (true)
 | `enabled` | `false` | Enable automatic removal of failed commands. |
 | `delay` | `2` | Number of recent failed commands to keep accessible for retry. Older failed commands are purged. |
 | `on_exit_only` | `false` | If `true`, only purge when session ends. If `false`, purge on each prompt. |
+
+### Shell Semicolon Shortcut
+
+Pressing `;` at an empty R prompt instantly switches to shell mode — no `:shell` or Enter required. Similar to [Julia REPL](https://docs.julialang.org/en/v1/stdlib/REPL/#man-shell-mode) shell mode behavior. **Disabled by default.**
+
+```toml
+[experimental]
+shell_semicolon_shortcut = true
+```
+
+When the buffer is not empty, `;` inserts a semicolon as usual, so normal R expressions like `for (i in 1:10) { ... }` are unaffected.
 
 ## CLI Options Override
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,8 @@ color = "Cyan"             # Spinner color
 format = "{value} "        # Duration display format ({value} = time string)
 threshold_ms = 2000        # Show duration only for commands slower than this (ms)
 
-experimental.shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
+[experimental]
+shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
 ```
 
 ## Bracket Highlighting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,9 @@ insert = "LightGreen"     # Color for vi insert mode indicator
 normal = "LightYellow"    # Color for vi normal mode indicator
 non_vi = "Default"         # Color for non-vi modes (Emacs, etc.)
 
+[experimental]
+shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
+
 [experimental.history_forget]
 enabled = false            # Auto-remove failed commands from history
 delay = 2                  # Keep last N failed commands for retry
@@ -146,8 +149,6 @@ color = "Cyan"             # Spinner color
 format = "{value} "        # Duration display format ({value} = time string)
 threshold_ms = 2000        # Show duration only for commands slower than this (ms)
 
-[experimental]
-shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
 ```
 
 ## Bracket Highlighting


### PR DESCRIPTION
## Summary

- Add `experimental.shell_semicolon_shortcut` config option (default: `false`)
- When enabled, pressing `;` at an **empty** R prompt instantly switches to shell mode — no `:shell` or Enter required
- When the buffer is **not empty**, `;` inserts a semicolon as usual (normal R expressions unaffected)
- Similar to [Julia REPL shell mode](https://docs.julialang.org/en/v1/stdlib/REPL/#man-shell-mode) behavior

## Implementation

- Keybinding: `Multiple([InsertString(":shell"), Submit])` — visually shows `:shell` then submits in one keypress
- Both `KeyModifiers::NONE` and `KeyModifiers::SHIFT` are bound (cross-platform/layout compatibility)
- A `ConditionalRule` in `ConditionalEditMode` routes to `InsertChar(';')` fallback when buffer is not empty

## Test plan

- [x] PTY integration test: empty buffer → sends `;` → shell mode entered (no Enter required)
- [x] PTY integration test: non-empty buffer → sends `1`, `;`, `2\n` → evaluates `[1] 2` (semicolon literal)
- [x] Unit tests: keybinding registered for both `NONE` and `SHIFT` modifier variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)