### PR TITLE
fix: fix `:help` failing for functions with `%` operators (e.g. `base::solve`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Experimental:** `;` shortcut to switch to shell mode at an empty R prompt (`experimental.shell_semicolon_shortcut`). One keypress — no `:shell` or Enter required. Similar to Julia REPL shell mode. When the buffer is not empty, `;` inserts a semicolon as usual. Disabled by default.
 
+### Fixed
+
+- `:help` no longer fails to render documentation for functions whose Rd source contains `%` operators (e.g. `base::solve`). The root cause was passing `as.character(rd)` without `deparse = TRUE`, which left `%` unescaped and caused the Rd parser to treat the rest of the line as a comment, losing closing braces and producing a parse error (#194).
+
 ## [0.3.3] - 2026-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,8 +1517,7 @@ dependencies = [
 [[package]]
 name = "rd-parser"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66d937afe2f7737e399a5dd97e62351dad80078e07d44e4afb75744f3141c78"
+source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
 dependencies = [
  "serde",
  "serde_json",
@@ -1528,8 +1527,7 @@ dependencies = [
 [[package]]
 name = "rd2qmd-core"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67667d3e3101f5dc41fd8972e87311e6f55f81e047ed68eb096275b06d3b1f37"
+source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
 dependencies = [
  "rd-parser",
  "rd2qmd-mdast",
@@ -1542,8 +1540,7 @@ dependencies = [
 [[package]]
 name = "rd2qmd-mdast"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e85957ecde3606f71b262bcd501f547e3f6d27fec704c62255bccbd2bc52605"
+source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,8 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "rd-parser"
-version = "0.1.0"
-source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a93ab20c73e7b2edf35e161545972d88a128d8f6c487c69d7644c369985fe4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1526,8 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.1.0"
-source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181e817c8f05452ddaa927f88308e76049ac0ed54b939f4848acbfbfd6efb686"
 dependencies = [
  "rd-parser",
  "rd2qmd-mdast",
@@ -1539,8 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.1.0"
-source = "git+https://github.com/eitsupi/rd2qmd?rev=a5db3392c2f36ea4a647615fb4a683264fdd4894#a5db3392c2f36ea4a647615fb4a683264fdd4894"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94567db64175107f205190c3e49d878c8be085b675de24900772be6d9fd8dc79"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.2"
 
 # Rd to Markdown conversion
-rd2qmd-core = { version = "0.1", features = ["roxygen"] }
+rd2qmd-core = { git = "https://github.com/eitsupi/rd2qmd", rev = "a5db3392c2f36ea4a647615fb4a683264fdd4894", features = ["roxygen"] }
 
 # Markdown parsing
 pulldown-cmark = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.2"
 
 # Rd to Markdown conversion
-rd2qmd-core = { git = "https://github.com/eitsupi/rd2qmd", rev = "a5db3392c2f36ea4a647615fb4a683264fdd4894", features = ["roxygen"] }
+rd2qmd-core = { version = "0.1.1", features = ["roxygen"] }
 
 # Markdown parsing
 pulldown-cmark = "0.13"

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -396,7 +396,7 @@ pub fn get_help_markdown(topic: &str, package: Option<&str>) -> HarpResult<Strin
     if (length(paths) == 0) return(NULL)
     file <- paths[1L]
     rd <- utils:::.getHelpFile(file)
-    paste0(as.character(rd), collapse = "")
+    paste0(as.character(rd, deparse = TRUE), collapse = "")
 }})"#,
             topic = escape_r_string(topic),
             pkg = escape_r_string(pkg)
@@ -409,7 +409,7 @@ pub fn get_help_markdown(topic: &str, package: Option<&str>) -> HarpResult<Strin
     if (length(paths) == 0) return(NULL)
     file <- paths[1L]
     rd <- utils:::.getHelpFile(file)
-    paste0(as.character(rd), collapse = "")
+    paste0(as.character(rd, deparse = TRUE), collapse = "")
 }})"#,
             topic = escape_r_string(topic)
         )

--- a/crates/arf-harp/tests/common/mod.rs
+++ b/crates/arf-harp/tests/common/mod.rs
@@ -21,18 +21,18 @@ pub fn ensure_r_initialized() -> bool {
 
 /// Run a closure with the R runtime lock held.
 ///
-/// Returns `None` if R initialization failed, `Some(result)` otherwise.
-/// Uses poisoned-lock recovery so a panicking test does not block subsequent tests.
-pub fn with_r<F, T>(f: F) -> Option<T>
+/// Panics if R initialization failed. Uses poisoned-lock recovery so a
+/// panicking test does not block subsequent tests.
+pub fn with_r<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
 {
     if !ensure_r_initialized() {
-        return None;
+        panic!("R initialization failed; cannot run test");
     }
     let lock = R_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
-    Some(f())
+    f()
 }
 
 /// Check that `LD_LIBRARY_PATH` includes the R library directory.

--- a/crates/arf-harp/tests/common/mod.rs
+++ b/crates/arf-harp/tests/common/mod.rs
@@ -1,0 +1,53 @@
+//! Shared test helpers for arf-harp integration tests.
+
+use once_cell::sync::OnceCell;
+use std::sync::Mutex;
+
+static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
+
+pub fn ensure_r_initialized() -> bool {
+    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
+
+    *R_INITIALIZED.get_or_init(|| unsafe {
+        match arf_libr::initialize_r() {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("Failed to initialize R: {}", e);
+                false
+            }
+        }
+    })
+}
+
+/// Run a closure with the R runtime lock held.
+///
+/// Returns `None` if R initialization failed, `Some(result)` otherwise.
+/// Uses poisoned-lock recovery so a panicking test does not block subsequent tests.
+pub fn with_r<F, T>(f: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
+    if !ensure_r_initialized() {
+        return None;
+    }
+    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+    Some(f())
+}
+
+/// Check that `LD_LIBRARY_PATH` includes the R library directory.
+///
+/// Tests that require package loading (e.g. utils, methods) must be skipped
+/// when this is not set, because `initialize_r()` cannot re-exec the process
+/// as the binary does via `ensure_ld_library_path()`.
+pub fn ld_library_path_is_set() -> bool {
+    let Ok(lib_path) = arf_libr::find_r_library() else {
+        return false;
+    };
+    let Some(lib_dir) = lib_path.parent() else {
+        return false;
+    };
+    let lib_dir_str = lib_dir.to_string_lossy();
+    let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+    current.split(':').any(|p| p == lib_dir_str.as_ref())
+}

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -24,7 +24,7 @@ fn test_help_base_solve_returns_content() {
         return;
     }
 
-    let Some(()) = with_r(|| {
+    with_r(|| {
         let result = get_help_markdown("solve", Some("base"));
         match &result {
             Err(e) => panic!(r#"get_help_markdown("solve", Some("base")) failed: {e}"#),
@@ -43,7 +43,5 @@ fn test_help_base_solve_returns_content() {
                 );
             }
         }
-    }) else {
-        panic!("R initialization failed; cannot run test_help_base_solve_returns_content");
-    };
+    });
 }

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -1,0 +1,83 @@
+//! Integration tests for R help rendering via rd2qmd.
+
+use arf_harp::get_help_markdown;
+use once_cell::sync::OnceCell;
+use std::sync::Mutex;
+
+static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
+
+fn ensure_r_initialized() -> bool {
+    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
+
+    *R_INITIALIZED.get_or_init(|| unsafe {
+        match arf_libr::initialize_r() {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("Failed to initialize R: {}", e);
+                false
+            }
+        }
+    })
+}
+
+fn with_r<F, T>(f: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
+    if !ensure_r_initialized() {
+        return None;
+    }
+    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+    Some(f())
+}
+
+fn ld_library_path_is_set() -> bool {
+    let Ok(lib_path) = arf_libr::find_r_library() else {
+        return false;
+    };
+    let Some(lib_dir) = lib_path.parent() else {
+        return false;
+    };
+    let lib_dir_str = lib_dir.to_string_lossy();
+    let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+    current.split(':').any(|p| p == lib_dir_str.as_ref())
+}
+
+/// Regression test for GitHub issue #194 / bd 3dxc:
+/// `base::solve` contains `%*%` in its Rd source. Without `deparse = TRUE`,
+/// `as.character()` emits unescaped `%` which rd-parser treats as a comment,
+/// losing closing braces and producing a parse error. With `deparse = TRUE`
+/// the `%` is escaped as `\%` and rd2qmd parses the page correctly.
+#[cfg(not(windows))]
+#[test]
+fn test_help_base_solve_returns_content() {
+    if !ld_library_path_is_set() {
+        eprintln!(
+            "Skipping test_help_base_solve_returns_content: \
+             LD_LIBRARY_PATH not set."
+        );
+        return;
+    }
+
+    with_r(|| {
+        let result = get_help_markdown("solve", Some("base"));
+        match &result {
+            Err(e) => panic!("get_help_markdown(\"solve\", Some(\"base\")) failed: {e}"),
+            Ok(md) => {
+                assert!(!md.is_empty(), "help markdown must not be empty");
+                // The title of the help page is "Solve a System of Equations"
+                assert!(
+                    md.contains("Solve"),
+                    "expected 'Solve' in help markdown, got:\n{md}"
+                );
+                // The usage section must contain ellipses (from \dots) and braces
+                // from R examples — regression check for rd-parser fixes in PR #21.
+                assert!(
+                    md.contains("...") || md.contains('\u{2026}'),
+                    "expected ellipses in help markdown (\\dots regression), got:\n{md}"
+                );
+            }
+        }
+    });
+}

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -44,12 +44,12 @@ fn ld_library_path_is_set() -> bool {
     current.split(':').any(|p| p == lib_dir_str.as_ref())
 }
 
-/// Regression test for GitHub issue #194 / bd 3dxc:
+/// Regression test for GitHub issue #194:
 /// `base::solve` contains `%*%` in its Rd source. Without `deparse = TRUE`,
 /// `as.character()` emits unescaped `%` which rd-parser treats as a comment,
 /// losing closing braces and producing a parse error. With `deparse = TRUE`
 /// the `%` is escaped as `\%` and rd2qmd parses the page correctly.
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 #[test]
 fn test_help_base_solve_returns_content() {
     if !ld_library_path_is_set() {
@@ -60,7 +60,7 @@ fn test_help_base_solve_returns_content() {
         return;
     }
 
-    with_r(|| {
+    let Some(()) = with_r(|| {
         let result = get_help_markdown("solve", Some("base"));
         match &result {
             Err(e) => panic!(r#"get_help_markdown("solve", Some("base")) failed: {e}"#),
@@ -79,5 +79,7 @@ fn test_help_base_solve_returns_content() {
                 );
             }
         }
-    });
+    }) else {
+        panic!("R initialization failed; cannot run test_help_base_solve_returns_content");
+    };
 }

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -63,7 +63,7 @@ fn test_help_base_solve_returns_content() {
     with_r(|| {
         let result = get_help_markdown("solve", Some("base"));
         match &result {
-            Err(e) => panic!("get_help_markdown(\"solve\", Some(\"base\")) failed: {e}"),
+            Err(e) => panic!(r#"get_help_markdown("solve", Some("base")) failed: {e}"#),
             Ok(md) => {
                 assert!(!md.is_empty(), "help markdown must not be empty");
                 // The title of the help page is "Solve a System of Equations"

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -1,48 +1,9 @@
 //! Integration tests for R help rendering via rd2qmd.
 
+mod common;
+
 use arf_harp::get_help_markdown;
-use once_cell::sync::OnceCell;
-use std::sync::Mutex;
-
-static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
-
-fn ensure_r_initialized() -> bool {
-    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
-
-    *R_INITIALIZED.get_or_init(|| unsafe {
-        match arf_libr::initialize_r() {
-            Ok(()) => true,
-            Err(e) => {
-                eprintln!("Failed to initialize R: {}", e);
-                false
-            }
-        }
-    })
-}
-
-fn with_r<F, T>(f: F) -> Option<T>
-where
-    F: FnOnce() -> T,
-{
-    if !ensure_r_initialized() {
-        return None;
-    }
-    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
-    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
-    Some(f())
-}
-
-fn ld_library_path_is_set() -> bool {
-    let Ok(lib_path) = arf_libr::find_r_library() else {
-        return false;
-    };
-    let Some(lib_dir) = lib_path.parent() else {
-        return false;
-    };
-    let lib_dir_str = lib_dir.to_string_lossy();
-    let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
-    current.split(':').any(|p| p == lib_dir_str.as_ref())
-}
+use common::{ld_library_path_is_set, with_r};
 
 /// Regression test for GitHub issue #194:
 /// `base::solve` contains `%*%` in its Rd source. Without `deparse = TRUE`,
@@ -71,8 +32,8 @@ fn test_help_base_solve_returns_content() {
                     md.contains("Solve"),
                     "expected 'Solve' in help markdown, got:\n{md}"
                 );
-                // The usage section must contain ellipses (from \dots) and braces
-                // from R examples — regression check for rd-parser fixes in PR #21.
+                // Regression check for rd-parser fix: \dots must be emitted as
+                // ellipses rather than being swallowed by a mis-terminated macro name.
                 assert!(
                     md.contains("...") || md.contains('\u{2026}'),
                     "expected ellipses in help markdown (\\dots regression), got:\n{md}"

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -1,5 +1,9 @@
 //! Integration tests for R help rendering via rd2qmd.
 
+// All tests in this file are Linux-only. Gate the entire module to avoid
+// unused-import warnings on other platforms (e.g. Windows clippy -D warnings).
+#![cfg(target_os = "linux")]
+
 mod common;
 
 use arf_harp::get_help_markdown;
@@ -10,7 +14,6 @@ use common::{ld_library_path_is_set, with_r};
 /// `as.character()` emits unescaped `%` which rd-parser treats as a comment,
 /// losing closing braces and producing a parse error. With `deparse = TRUE`
 /// the `%` is escaped as `\%` and rd2qmd parses the page correctly.
-#[cfg(target_os = "linux")]
 #[test]
 fn test_help_base_solve_returns_content() {
     if !ld_library_path_is_set() {

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -3,9 +3,9 @@
 mod common;
 
 use arf_harp::{call_dot_first, call_dot_first_sys, eval_string};
-use common::with_r;
 #[cfg(not(windows))]
 use common::ld_library_path_is_set;
+use common::with_r;
 
 #[test]
 fn test_call_dot_first_noop_when_undefined() {

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -1,53 +1,9 @@
 //! Integration tests for R startup hook functions.
 
+mod common;
+
 use arf_harp::{call_dot_first, call_dot_first_sys, eval_string};
-use once_cell::sync::OnceCell;
-use std::sync::Mutex;
-
-static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
-
-fn ensure_r_initialized() -> bool {
-    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
-
-    *R_INITIALIZED.get_or_init(|| unsafe {
-        match arf_libr::initialize_r() {
-            Ok(()) => true,
-            Err(e) => {
-                eprintln!("Failed to initialize R: {}", e);
-                false
-            }
-        }
-    })
-}
-
-fn with_r<F, T>(f: F) -> Option<T>
-where
-    F: FnOnce() -> T,
-{
-    if !ensure_r_initialized() {
-        return None;
-    }
-    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
-    // Use into_inner() to recover from a poisoned lock caused by a previous panic.
-    let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
-    Some(f())
-}
-
-/// Check that LD_LIBRARY_PATH includes the R library directory.
-/// Tests that require package loading (e.g. utils, methods) must be skipped
-/// when this is not set, because `initialize_r()` cannot re-exec the process
-/// as the binary does via `ensure_ld_library_path()`.
-fn ld_library_path_is_set() -> bool {
-    let Ok(lib_path) = arf_libr::find_r_library() else {
-        return false;
-    };
-    let Some(lib_dir) = lib_path.parent() else {
-        return false;
-    };
-    let lib_dir_str = lib_dir.to_string_lossy();
-    let current = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
-    current.split(':').any(|p| p == lib_dir_str.as_ref())
-}
+use common::{ld_library_path_is_set, with_r};
 
 #[test]
 fn test_call_dot_first_noop_when_undefined() {

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -3,7 +3,9 @@
 mod common;
 
 use arf_harp::{call_dot_first, call_dot_first_sys, eval_string};
-use common::{ld_library_path_is_set, with_r};
+use common::with_r;
+#[cfg(not(windows))]
+use common::ld_library_path_is_set;
 
 #[test]
 fn test_call_dot_first_noop_when_undefined() {

--- a/crates/arf-harp/tests/visibility.rs
+++ b/crates/arf-harp/tests/visibility.rs
@@ -6,45 +6,10 @@
 //! - Variable lookups are visible
 //! - The `invisible()` function makes results invisible
 
+mod common;
+
 use arf_harp::eval_string_with_visibility;
-use once_cell::sync::OnceCell;
-use std::env;
-use std::sync::Mutex;
-
-/// Global lock to ensure R tests run serially (R is not thread-safe).
-static R_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
-
-/// Initialize R once for all tests.
-fn ensure_r_initialized() -> bool {
-    static R_INITIALIZED: OnceCell<bool> = OnceCell::new();
-
-    *R_INITIALIZED.get_or_init(|| {
-        // Initialize R
-        unsafe {
-            match arf_libr::initialize_r() {
-                Ok(()) => true,
-                Err(e) => {
-                    eprintln!("Failed to initialize R: {}", e);
-                    false
-                }
-            }
-        }
-    })
-}
-
-/// Run a test with R lock held.
-fn with_r<F, T>(f: F) -> Option<T>
-where
-    F: FnOnce() -> T,
-{
-    if !ensure_r_initialized() {
-        return None;
-    }
-
-    let lock = R_LOCK.get_or_init(|| Mutex::new(()));
-    let _guard = lock.lock().unwrap();
-    Some(f())
-}
+use common::{ld_library_path_is_set, with_r};
 
 #[test]
 fn test_simple_expression_is_visible() {
@@ -140,19 +105,6 @@ fn test_vector_creation_is_visible() {
         let result = eval_string_with_visibility("c(1, 2, 3)").expect("eval should succeed");
         assert!(result.visible, "Vector creation should be visible");
     });
-}
-
-/// Check if LD_LIBRARY_PATH includes the R library directory.
-fn ld_library_path_is_set() -> bool {
-    let Ok(lib_path) = arf_libr::find_r_library() else {
-        return false;
-    };
-    let Some(lib_dir) = lib_path.parent() else {
-        return false;
-    };
-    let lib_dir_str = lib_dir.to_string_lossy();
-    let current = env::var("LD_LIBRARY_PATH").unwrap_or_default();
-    current.split(':').any(|p| p == lib_dir_str.as_ref())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Pass `as.character(rd, deparse = TRUE)` instead of the bare form when converting Rd objects to string before handing to rd2qmd. Without `deparse = TRUE`, percent operators like `%*%` were left unescaped, causing the Rd parser to treat `%` as a comment start, lose closing braces, and produce a parse error — so `:help base::solve` silently returned no documentation.
- Bump `rd2qmd-core` from `0.1` to `0.1.1` (released to crates.io), which includes the rd-parser fix for zero-argument macro termination (`\dots)`) and literal brace preservation in code sections.
- Add integration test `test_help_base_solve_returns_content` to guard against regression.
- Extract shared R test helpers (`with_r`, `ensure_r_initialized`, `ld_library_path_is_set`) into `tests/common/mod.rs` to avoid duplication across test files.

Closes #194.

## Test plan

- [x] `cargo test -p arf-harp --test help` passes (`test_help_base_solve_returns_content`)
- [x] Manual: launch arf, `:help` → `base::solve` → documentation renders correctly
- [x] Manual: spot-check another function with `%` in its Rd source (e.g. `base::crossprod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)