### PR TITLE
fix: Fix history menu replacement inside auto-match pairs

### DIFF
--- a/crates/arf-console/src/completion/menu.rs
+++ b/crates/arf-console/src/completion/menu.rs
@@ -272,6 +272,15 @@ impl Menu for StateSyncHistoryMenu {
     fn replace_in_buffer(&self, editor: &mut Editor) {
         self.inner.replace_in_buffer(editor);
 
+        // History selection is configured to replace the whole buffer; discard any
+        // stale suffix left by reedline's suggestion span.
+        editor.edit_buffer(
+            |line_buffer| {
+                line_buffer.clear_to_end();
+            },
+            UndoBehavior::CreateUndoPoint,
+        );
+
         // Synchronize the shadow state with the actual buffer state.
         self.sync_editor_state(editor);
     }

--- a/crates/arf-console/src/completion/menu.rs
+++ b/crates/arf-console/src/completion/menu.rs
@@ -254,6 +254,7 @@ impl Menu for StateSyncHistoryMenu {
             },
             UndoBehavior::MoveCursor,
         );
+        self.sync_editor_state(editor);
 
         self.inner.update_values(editor, completer);
     }

--- a/crates/arf-console/src/completion/menu.rs
+++ b/crates/arf-console/src/completion/menu.rs
@@ -248,14 +248,6 @@ impl Menu for StateSyncHistoryMenu {
     }
 
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
-        editor.edit_buffer(
-            |line_buffer| {
-                line_buffer.move_to_end();
-            },
-            UndoBehavior::MoveCursor,
-        );
-        self.sync_editor_state(editor);
-
         self.inner.update_values(editor, completer);
     }
 

--- a/crates/arf-console/src/completion/menu.rs
+++ b/crates/arf-console/src/completion/menu.rs
@@ -248,6 +248,13 @@ impl Menu for StateSyncHistoryMenu {
     }
 
     fn update_values(&mut self, editor: &mut Editor, completer: &mut dyn Completer) {
+        editor.edit_buffer(
+            |line_buffer| {
+                line_buffer.move_to_end();
+            },
+            UndoBehavior::MoveCursor,
+        );
+
         self.inner.update_values(editor, completer);
     }
 

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -268,6 +268,53 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     terminal
+        .clear_buffer()
+        .expect("Should clear previous c() output before executing selection");
+    terminal
+        .send("\n")
+        .expect("Should execute selected history item");
+    terminal
+        .expect("NULL")
+        .expect("c() should execute without a trailing auto-matched paren");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test that history search replaces the whole auto-matched pair created in search mode.
+///
+/// Scenario:
+/// 1. Execute `c()` to add it to history
+/// 2. Press Ctrl+R to open history search
+/// 3. Type `c(` in the search input, which auto-match expands to `c()` with the cursor before `)`
+/// 4. Select the `c()` history entry
+/// 5. Execute - should run `c()`, not `c())`
+#[test]
+#[cfg(unix)]
+fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
+    let mut terminal =
+        Terminal::spawn_with_args(&["--no-completion"]).expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    terminal.send_line("c()").expect("Should send c()");
+    terminal.expect("NULL").expect("c() should output NULL");
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    terminal.send("\x12").expect("Should send Ctrl+R");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    terminal
+        .send("c(")
+        .expect("Should type c( in history search mode");
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    terminal.send("\n").expect("Should select history item");
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear previous c() output before executing selection");
+    terminal
         .send("\n")
         .expect("Should execute selected history item");
     terminal

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -239,6 +239,44 @@ fn test_pty_history_menu_with_auto_match_pair() {
     terminal.quit().expect("Should quit cleanly");
 }
 
+/// Test that history selection replaces the whole auto-matched pair buffer.
+///
+/// Scenario:
+/// 1. Execute `c()` to add it to history
+/// 2. Type `c(`, which auto-match expands to `c()` with the cursor before `)`
+/// 3. Press Ctrl+R and select the `c()` history entry
+/// 4. Execute - should run `c()`, not `c())`
+#[test]
+#[cfg(unix)]
+fn test_pty_history_menu_with_auto_match_paren_pair() {
+    let mut terminal =
+        Terminal::spawn_with_args(&["--no-completion"]).expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    terminal.send_line("c()").expect("Should send c()");
+    terminal.expect("NULL").expect("c() should output NULL");
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    terminal.send("c(").expect("Should type c(");
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    terminal.send("\x12").expect("Should send Ctrl+R");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    terminal.send("\n").expect("Should select history item");
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    terminal
+        .send("\n")
+        .expect("Should execute selected history item");
+    terminal
+        .expect("NULL")
+        .expect("c() should execute without a trailing auto-matched paren");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
 /// Regression test: backtick input should not crash.
 /// Sending a backtick (which becomes `` with auto-match) should produce an
 /// R error about zero-length variable name, not crash with RefCell double borrow.

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -273,7 +273,7 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
 
     terminal
         .clear_buffer()
-        .expect("Should clear previous c() output before executing selection");
+        .expect("Should clear setup output before executing selection");
     terminal
         .send("\n")
         .expect("Should execute selected history item");
@@ -321,7 +321,7 @@ fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
 
     terminal
         .clear_buffer()
-        .expect("Should clear previous c() output before executing selection");
+        .expect("Should clear setup output before executing selection");
     terminal
         .send("\n")
         .expect("Should execute selected history item");

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -242,10 +242,10 @@ fn test_pty_history_menu_with_auto_match_pair() {
 /// Test that history selection replaces the whole auto-matched pair buffer.
 ///
 /// Scenario:
-/// 1. Execute `c()` to add it to history
+/// 1. Execute `length(c())` to add it to history
 /// 2. Type `c(`, which auto-match expands to `c()` with the cursor before `)`
-/// 3. Press Ctrl+R and select the `c()` history entry
-/// 4. Execute - should run `c()`, not `c())`
+/// 3. Press Ctrl+R and select the `length(c())` history entry
+/// 4. Execute - should run `length(c())`, not the pre-menu `c()` or a stale-suffix `length(c()))`
 #[test]
 #[cfg(unix)]
 fn test_pty_history_menu_with_auto_match_paren_pair() {
@@ -254,8 +254,12 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
 
     terminal.wait_for_prompt().expect("Should show prompt");
 
-    terminal.send_line("c()").expect("Should send c()");
-    terminal.expect("NULL").expect("c() should output NULL");
+    terminal
+        .send_line("length(c())")
+        .expect("Should send length(c())");
+    terminal
+        .expect("[1] 0")
+        .expect("length(c()) should output 0");
     terminal.wait_for_prompt().expect("Should show prompt");
 
     terminal.send("c(").expect("Should type c(");
@@ -274,8 +278,8 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
         .send("\n")
         .expect("Should execute selected history item");
     terminal
-        .expect("NULL")
-        .expect("c() should execute without a trailing auto-matched paren");
+        .expect("[1] 0")
+        .expect("length(c()) should execute without a trailing auto-matched paren");
 
     terminal.quit().expect("Should quit cleanly");
 }
@@ -283,11 +287,11 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
 /// Test that history search replaces the whole auto-matched pair created in search mode.
 ///
 /// Scenario:
-/// 1. Execute `c()` to add it to history
+/// 1. Execute `length(c())` to add it to history
 /// 2. Press Ctrl+R to open history search
 /// 3. Type `c(` in the search input, which auto-match expands to `c()` with the cursor before `)`
-/// 4. Select the `c()` history entry
-/// 5. Execute - should run `c()`, not `c())`
+/// 4. Select the `length(c())` history entry
+/// 5. Execute - should run `length(c())`, not the search buffer `c()` or a stale-suffix `length(c()))`
 #[test]
 #[cfg(unix)]
 fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
@@ -296,8 +300,12 @@ fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
 
     terminal.wait_for_prompt().expect("Should show prompt");
 
-    terminal.send_line("c()").expect("Should send c()");
-    terminal.expect("NULL").expect("c() should output NULL");
+    terminal
+        .send_line("length(c())")
+        .expect("Should send length(c())");
+    terminal
+        .expect("[1] 0")
+        .expect("length(c()) should output 0");
     terminal.wait_for_prompt().expect("Should show prompt");
 
     terminal.send("\x12").expect("Should send Ctrl+R");
@@ -318,8 +326,8 @@ fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
         .send("\n")
         .expect("Should execute selected history item");
     terminal
-        .expect("NULL")
-        .expect("c() should execute without a trailing auto-matched paren");
+        .expect("[1] 0")
+        .expect("length(c()) should execute without a trailing auto-matched paren");
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -264,6 +264,10 @@ fn test_pty_history_menu_with_auto_match_paren_pair() {
 
     terminal.send("c(").expect("Should type c(");
     std::thread::sleep(std::time::Duration::from_millis(200));
+    terminal
+        .current_line()
+        .assert_contains("c()")
+        .expect("Auto-match should insert the closing paren before history selection");
 
     terminal.send("\x12").expect("Should send Ctrl+R");
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -315,6 +319,10 @@ fn test_pty_history_menu_search_mode_auto_match_paren_pair() {
         .send("c(")
         .expect("Should type c( in history search mode");
     std::thread::sleep(std::time::Duration::from_millis(300));
+    terminal
+        .current_line()
+        .assert_contains("c()")
+        .expect("Auto-match should insert the closing paren before history selection");
 
     terminal.send("\n").expect("Should select history item");
     std::thread::sleep(std::time::Duration::from_millis(300));


### PR DESCRIPTION
Fix #195

## Summary
- Clear any stale suffix left after accepting a history item, since the history menu is configured to replace the whole buffer.
- Keep history menu value updates from changing the user's cursor position when the menu is canceled.
- Add PTY regression tests for selecting `length(c())` from history after auto-match creates `c(|)`, including the case where `c(` is typed after opening Ctrl+R search.

## Verification
- `cargo fmt --check`
- `cargo test -p arf-console --test pty_advanced_tests test_pty_history_menu_search_mode_auto_match_paren_pair -- --nocapture`
- `cargo test -p arf-console --test pty_advanced_tests test_pty_history_menu_ -- --nocapture`
- `cargo test -p arf-console --test headless_tests` (ran with elevated permissions because sandboxed IPC server startup fails with `Operation not permitted`)
