### PR TITLE
chore: prepare release 0.3.4-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## [Unreleased]
 
+## [0.3.4-rc.1] - 2026-05-19
+
 ### Added
 
-- **Experimental:** `;` shortcut to switch to shell mode at an empty R prompt (`experimental.shell_semicolon_shortcut`). One keypress — no `:shell` or Enter required. Similar to Julia REPL shell mode. When the buffer is not empty, `;` inserts a semicolon as usual. Disabled by default.
+- **Experimental:** `;` shortcut to switch to shell mode at an empty R prompt (`experimental.shell_semicolon_shortcut`). One keypress — no `:shell` or Enter required. Similar to Julia REPL shell mode. When the buffer is not empty, `;` inserts a semicolon as usual. Disabled by default. (#192)
 
 ### Fixed
 
-- `:help` no longer fails to render documentation for functions whose Rd source contains `%` operators (e.g. `base::solve`). The root cause was passing `as.character(rd)` without `deparse = TRUE`, which left `%` unescaped and caused the Rd parser to treat the rest of the line as a comment, losing closing braces and producing a parse error (#194).
+- `:help` no longer fails to render documentation for functions whose Rd source contains `%` operators (e.g. `base::solve`). The root cause was passing `as.character(rd)` without `deparse = TRUE`, which left `%` unescaped and caused the Rd parser to treat the rest of the line as a comment, losing closing braces and producing a parse error (#198)
+- History menu replacement now works correctly inside auto-matched pairs (e.g. `(`, `[`, `"`): selecting a history entry no longer leaves the closing delimiter behind (#200)
 
 ## [0.3.3] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arf-console"
-version = "0.3.3"
+version = "0.3.4-rc.1"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -103,7 +103,7 @@ dependencies = [
  "insta",
  "libc",
  "log",
- "nix 0.31.2",
+ "nix 0.31.3",
  "nu-ansi-term",
  "nucleo-matcher",
  "once_cell",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.3.3"
+version = "0.3.4-rc.1"
 dependencies = [
  "arf-libr",
  "log",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.3.3"
+version = "0.3.4-rc.1"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -421,7 +421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -893,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1446,7 +1446,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.3.3"
+version = "0.3.4-rc.1"
 dependencies = [
  "htmd",
 ]
@@ -1825,13 +1825,13 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2142,9 +2142,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2382,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2395,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2405,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2418,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -2636,9 +2636,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4-rc.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.3.3", path = "crates/arf-harp" }
-arf-libr = { version = "0.3.3", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.3.3", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.3.4-rc.1", path = "crates/arf-harp" }
+arf-libr = { version = "0.3.4-rc.1", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.3.4-rc.1", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3
+# arf console v0.3.4-rc.1
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3
+# arf console v0.3.4-rc.1
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3
+# arf console v0.3.4-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3
+# arf console v0.3.4-rc.1
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.3.3
+# arf console v0.3.4-rc.1
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.3.3 to 0.3.4-rc.1
- Finalize CHANGELOG `[Unreleased]` section as `[0.3.4-rc.1] - 2026-05-19`
- Update banner snapshots for new version string

## Changelog

### Added

- **Experimental:** `;` shortcut to switch to shell mode at an empty R prompt (`experimental.shell_semicolon_shortcut`). One keypress — no `:shell` or Enter required. Similar to Julia REPL shell mode. When the buffer is not empty, `;` inserts a semicolon as usual. Disabled by default. (#192)

### Fixed

- `:help` no longer fails to render documentation for functions whose Rd source contains `%` operators (e.g. `base::solve`). The root cause was passing `as.character(rd)` without `deparse = TRUE`, which left `%` unescaped and caused the Rd parser to treat the rest of the line as a comment, losing closing braces and producing a parse error (#198)
- History menu replacement now works correctly inside auto-matched pairs (e.g. `(`, `[`, `"`): selecting a history entry no longer leaves the closing delimiter behind (#200)

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Banner snapshots updated via `cargo insta test --accept -- banner`
- [x] `Cargo.lock` regenerated
- [x] No old version string (`0.3.3`) remaining outside CHANGELOG history and Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)