### PR TITLE
fix: fix tab completion timing out inside function call arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Tab completion no longer times out inside function call arguments (e.g. `str(aaa_` + Tab). R's completer takes significantly longer when inside a function call because it also looks up argument names. The fix disables the completion timeout in that context, matching the existing behavior for `::` completions (#204)
+- Tab completion no longer times out inside function call arguments (e.g. `str(aaa_` + Tab). R's completer takes significantly longer when inside a function call because it also looks up argument names. The fix raises the completion timeout floor to 1000ms in that context (and for `::` completions), giving sufficient headroom while retaining a safety boundary against hung completions (#204)
 
 ## [0.3.4] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tab completion no longer times out inside function call arguments (e.g. `str(aaa_` + Tab). R's completer takes significantly longer when inside a function call because it also looks up argument names. The fix disables the completion timeout in that context, matching the existing behavior for `::` completions (#204)
+
 ## [0.3.4] - 2026-05-21
 
 ### Added

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -475,14 +475,16 @@ pub fn get_completions(line: &str, cursor_pos: usize, timeout_ms: u64) -> HarpRe
         }
     }
 
-    // Determine effective timeout:
-    // - Disable timeout for package::func completions (they need full results and are worth waiting for)
-    // - This matches radian's behavior
-    let effective_timeout = if contains_namespace_operator(&line[..cursor_pos.min(line.len())]) {
-        0 // No timeout for :: completions
-    } else {
-        timeout_ms
-    };
+    // Disable timeout in contexts where R's completer does extra work:
+    // - `::` completions: enumerate package exports (slow)
+    // - inside a function call: R also looks up argument names (~150ms vs ~20ms at top level)
+    let before_cursor = &line[..cursor_pos.min(line.len())];
+    let effective_timeout =
+        if contains_namespace_operator(before_cursor) || has_unmatched_open_paren(before_cursor) {
+            0
+        } else {
+            timeout_ms
+        };
 
     get_r_builtin_completions(line, cursor_pos, effective_timeout)
 }
@@ -490,6 +492,19 @@ pub fn get_completions(line: &str, cursor_pos: usize, timeout_ms: u64) -> HarpRe
 /// Check if the text contains a namespace operator (:: or :::).
 fn contains_namespace_operator(text: &str) -> bool {
     text.contains("::")
+}
+
+/// Check if `text` has more `(` than `)`, meaning the cursor is inside a function call.
+fn has_unmatched_open_paren(text: &str) -> bool {
+    let mut depth = 0i32;
+    for c in text.chars() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+    depth > 0
 }
 
 /// Get R's built-in completions using utils package functions.

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -477,7 +477,8 @@ pub fn get_completions(line: &str, cursor_pos: usize, timeout_ms: u64) -> HarpRe
 
     // Disable timeout in contexts where R's completer does extra work:
     // - `::` completions: enumerate package exports (slow)
-    // - inside a function call: R also looks up argument names (~150ms vs ~20ms at top level)
+    // - inside an unclosed `(` (function call or grouped expression): R also looks up argument
+    //   names (~150ms vs ~20ms at top level)
     let before_cursor = &line[..cursor_pos.min(line.len())];
     let effective_timeout =
         if contains_namespace_operator(before_cursor) || has_unmatched_open_paren(before_cursor) {
@@ -494,9 +495,10 @@ fn contains_namespace_operator(text: &str) -> bool {
     text.contains("::")
 }
 
-/// Returns true if the cursor (end of `text`) is inside an unclosed function
-/// call — i.e., there is at least one `(` with no matching `)` that is not
-/// inside a string literal or comment.
+/// Returns true if the cursor (end of `text`) is inside an unclosed `(` — i.e.,
+/// there is at least one `(` with no matching `)` that is not inside a string
+/// literal or comment. This covers both function calls (`str(aaa_`) and grouped
+/// expressions (`x <- (aaa_`).
 ///
 /// Uses a forward scan with lightweight string tracking (double/single quotes
 /// and backslash escapes). Unmatched `)` are treated as no-ops (depth clamped
@@ -1143,10 +1145,6 @@ mod tests {
         assert!(has_unmatched_open_paren("foo(x, y ="));
         // Cursor after comma: e.g. full line "foo(x,)" with cursor at pos 6
         assert!(has_unmatched_open_paren("foo(x,"));
-
-        // Auto-matched closing paren: before_cursor stops before it, so still unmatched
-        // e.g. full line "str(aaa_)" but cursor_pos=8 → before_cursor="str(aaa_"
-        assert!(has_unmatched_open_paren("str(aaa_"));
 
         // Nested: cursor inside outer call, inner call already closed
         // e.g. "foo(x = bar()" → outer ( unmatched

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -1106,4 +1106,28 @@ mod tests {
         assert_eq!(extract_identifier_before_cursor("123"), None);
         assert_eq!(extract_identifier_before_cursor("x <- "), None);
     }
+
+    #[test]
+    fn test_has_unmatched_open_paren() {
+        // Inside a function call (cursor before closing paren)
+        assert!(has_unmatched_open_paren("str(aaa_"));
+        assert!(has_unmatched_open_paren("foo(x ="));
+        assert!(has_unmatched_open_paren("foo(x, y ="));
+
+        // Auto-matched closing paren: before_cursor stops before it, so still unmatched
+        // e.g. full line "str(aaa_)" but cursor_pos=8 → before_cursor="str(aaa_"
+        assert!(has_unmatched_open_paren("str(aaa_"));
+
+        // Nested: cursor inside outer call, inner call already closed
+        // e.g. "foo(x = bar()" → outer ( unmatched
+        assert!(has_unmatched_open_paren("foo(x = bar()"));
+
+        // Top-level: no open paren
+        assert!(!has_unmatched_open_paren("aaa_bbb"));
+        assert!(!has_unmatched_open_paren(""));
+
+        // Balanced parens (cursor after closing paren)
+        assert!(!has_unmatched_open_paren("str(aaa_)"));
+        assert!(!has_unmatched_open_paren("foo(x = bar())"));
+    }
 }

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -1113,6 +1113,8 @@ mod tests {
         assert!(has_unmatched_open_paren("str(aaa_"));
         assert!(has_unmatched_open_paren("foo(x ="));
         assert!(has_unmatched_open_paren("foo(x, y ="));
+        // Cursor after comma: e.g. full line "foo(x,)" with cursor at pos 6
+        assert!(has_unmatched_open_paren("foo(x,"));
 
         // Auto-matched closing paren: before_cursor stops before it, so still unmatched
         // e.g. full line "str(aaa_)" but cursor_pos=8 → before_cursor="str(aaa_"

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -494,17 +494,25 @@ fn contains_namespace_operator(text: &str) -> bool {
     text.contains("::")
 }
 
-/// Check if `text` has more `(` than `)`, meaning the cursor is inside a function call.
+/// Check if the cursor is inside a function call by scanning backwards for an unmatched `(`.
+///
+/// Backwards scan correctly handles cases like `1) + str(aaa_` where a forward depth
+/// count would give 0 (balanced overall) even though the cursor is inside `str(`.
 fn has_unmatched_open_paren(text: &str) -> bool {
     let mut depth = 0i32;
-    for c in text.chars() {
+    for c in text.chars().rev() {
         match c {
-            '(' => depth += 1,
-            ')' => depth -= 1,
+            ')' => depth += 1,
+            '(' => {
+                if depth == 0 {
+                    return true;
+                }
+                depth -= 1;
+            }
             _ => {}
         }
     }
-    depth > 0
+    false
 }
 
 /// Get R's built-in completions using utils package functions.
@@ -1123,6 +1131,10 @@ mod tests {
         // Nested: cursor inside outer call, inner call already closed
         // e.g. "foo(x = bar()" → outer ( unmatched
         assert!(has_unmatched_open_paren("foo(x = bar()"));
+
+        // Unbalanced ) earlier in line: forward count would give 0 (false negative),
+        // backwards scan correctly finds the unmatched ( nearest the cursor.
+        assert!(has_unmatched_open_paren("1) + str(aaa_"));
 
         // Top-level: no open paren
         assert!(!has_unmatched_open_paren("aaa_bbb"));

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -475,14 +475,16 @@ pub fn get_completions(line: &str, cursor_pos: usize, timeout_ms: u64) -> HarpRe
         }
     }
 
-    // Disable timeout in contexts where R's completer does extra work:
+    // Raise timeout for contexts where R's completer does extra work:
     // - `::` completions: enumerate package exports (slow)
     // - inside an unclosed `(` (function call or grouped expression): R also looks up argument
     //   names (~150ms vs ~20ms at top level)
+    // Use a generous fixed cap (1000ms) rather than disabling entirely so that
+    // unusually slow environments still get a safety boundary.
     let before_cursor = &line[..cursor_pos.min(line.len())];
     let effective_timeout =
         if contains_namespace_operator(before_cursor) || has_unmatched_open_paren(before_cursor) {
-            0
+            1000
         } else {
             timeout_ms
         };

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -505,6 +505,7 @@ fn contains_namespace_operator(text: &str) -> bool {
 fn has_unmatched_open_paren(text: &str) -> bool {
     let mut in_double = false;
     let mut in_single = false;
+    let mut in_comment = false;
     let mut escaped = false;
     let mut depth = 0i32;
 
@@ -513,8 +514,15 @@ fn has_unmatched_open_paren(text: &str) -> bool {
             escaped = false;
             continue;
         }
+        // Comment runs to end of line only; resume scanning on the next line.
+        if in_comment {
+            if c == '\n' {
+                in_comment = false;
+            }
+            continue;
+        }
         match c {
-            '#' if !in_double && !in_single => break,
+            '#' if !in_double && !in_single => in_comment = true,
             '\\' if in_double || in_single => escaped = true,
             '"' if !in_single => in_double = !in_double,
             '\'' if !in_double => in_single = !in_single,
@@ -1161,7 +1169,14 @@ mod tests {
         assert!(has_unmatched_open_paren(r#"paste("(", x"#)); // cursor inside paste()
         assert!(has_unmatched_open_paren("paste('(', x")); // single-quoted string
 
-        // Paren in comment is ignored
+        // Paren in single-line comment is ignored
         assert!(!has_unmatched_open_paren("# str(aaa_"));
+
+        // Multiline: comment on first line must not swallow subsequent lines
+        assert!(has_unmatched_open_paren("# note (\nstr(aaa_"));
+        // Function call before comment, cursor on next line
+        assert!(has_unmatched_open_paren("foo( # comment\naaa_"));
+        // Comment-only first line, no function call after
+        assert!(!has_unmatched_open_paren("# note (\naaa_"));
     }
 }

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -479,15 +479,17 @@ pub fn get_completions(line: &str, cursor_pos: usize, timeout_ms: u64) -> HarpRe
     // - `::` completions: enumerate package exports (slow)
     // - inside an unclosed `(` (function call or grouped expression): R also looks up argument
     //   names (~150ms vs ~20ms at top level)
-    // Use a generous fixed cap (1000ms) rather than disabling entirely so that
-    // unusually slow environments still get a safety boundary.
+    // Use a generous fixed floor (1000ms) so unusually slow environments still get
+    // a safety boundary. timeout_ms=0 (no limit) is preserved as-is.
     let before_cursor = &line[..cursor_pos.min(line.len())];
-    let effective_timeout =
-        if contains_namespace_operator(before_cursor) || has_unmatched_open_paren(before_cursor) {
-            1000
-        } else {
-            timeout_ms
-        };
+    let effective_timeout = if timeout_ms == 0 {
+        0
+    } else if contains_namespace_operator(before_cursor) || has_unmatched_open_paren(before_cursor)
+    {
+        timeout_ms.max(1000)
+    } else {
+        timeout_ms
+    };
 
     get_r_builtin_completions(line, cursor_pos, effective_timeout)
 }

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -494,25 +494,37 @@ fn contains_namespace_operator(text: &str) -> bool {
     text.contains("::")
 }
 
-/// Check if the cursor is inside a function call by scanning backwards for an unmatched `(`.
+/// Returns true if the cursor (end of `text`) is inside an unclosed function
+/// call — i.e., there is at least one `(` with no matching `)` that is not
+/// inside a string literal or comment.
 ///
-/// Backwards scan correctly handles cases like `1) + str(aaa_` where a forward depth
-/// count would give 0 (balanced overall) even though the cursor is inside `str(`.
+/// Uses a forward scan with lightweight string tracking (double/single quotes
+/// and backslash escapes). Unmatched `)` are treated as no-ops (depth clamped
+/// at 0) so that expressions like `1) + str(aaa_` are correctly detected as
+/// being inside `str(`.
 fn has_unmatched_open_paren(text: &str) -> bool {
+    let mut in_double = false;
+    let mut in_single = false;
+    let mut escaped = false;
     let mut depth = 0i32;
-    for c in text.chars().rev() {
+
+    for c in text.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
         match c {
-            ')' => depth += 1,
-            '(' => {
-                if depth == 0 {
-                    return true;
-                }
-                depth -= 1;
-            }
+            '#' if !in_double && !in_single => break,
+            '\\' if in_double || in_single => escaped = true,
+            '"' if !in_single => in_double = !in_double,
+            '\'' if !in_double => in_single = !in_single,
+            '(' if !in_double && !in_single => depth += 1,
+            ')' if !in_double && !in_single => depth = (depth - 1).max(0),
             _ => {}
         }
     }
-    false
+
+    depth > 0
 }
 
 /// Get R's built-in completions using utils package functions.
@@ -1132,8 +1144,7 @@ mod tests {
         // e.g. "foo(x = bar()" → outer ( unmatched
         assert!(has_unmatched_open_paren("foo(x = bar()"));
 
-        // Unbalanced ) earlier in line: forward count would give 0 (false negative),
-        // backwards scan correctly finds the unmatched ( nearest the cursor.
+        // Extra `)` earlier in line: depth is clamped at 0 so the `str(` is still found.
         assert!(has_unmatched_open_paren("1) + str(aaa_"));
 
         // Top-level: no open paren
@@ -1143,5 +1154,14 @@ mod tests {
         // Balanced parens (cursor after closing paren)
         assert!(!has_unmatched_open_paren("str(aaa_)"));
         assert!(!has_unmatched_open_paren("foo(x = bar())"));
+
+        // Parens inside string literals are ignored
+        assert!(!has_unmatched_open_paren(r#"x <- "("; aaa_"#));
+        assert!(!has_unmatched_open_paren(r#""("#));
+        assert!(has_unmatched_open_paren(r#"paste("(", x"#)); // cursor inside paste()
+        assert!(has_unmatched_open_paren("paste('(', x")); // single-quoted string
+
+        // Paren in comment is ignored
+        assert!(!has_unmatched_open_paren("# str(aaa_"));
     }
 }

--- a/crates/arf-harp/tests/completion.rs
+++ b/crates/arf-harp/tests/completion.rs
@@ -1,7 +1,5 @@
 //! Integration tests for R code completion.
 
-#![cfg(target_os = "linux")]
-
 mod common;
 
 use arf_harp::completion::get_completions;
@@ -34,8 +32,8 @@ fn test_completion_inside_function_call() {
 
         assert!(
             completions.iter().any(|c| c == "aaa_bbb"),
-            "Expected 'aaa_bbb' in completions for 'str(aaa_' at pos 8 with 50ms timeout, \
-             got: {:?}",
+            "Expected 'aaa_bbb' in completions for 'str(aaa_' at pos 8 \
+             (timeout_ms=1, bypassed inside function call), got: {:?}",
             completions
         );
     });

--- a/crates/arf-harp/tests/completion.rs
+++ b/crates/arf-harp/tests/completion.rs
@@ -26,14 +26,14 @@ fn test_completion_inside_function_call() {
     with_r(|| {
         eval_string_with_visibility("aaa_bbb <- 1").expect("assignment should succeed");
 
-        // timeout_ms=1 forces the timeout path on any platform, making this a genuine
-        // red test before the fix. The fix bypasses timeout when inside a function call.
+        // timeout_ms=1 would cause a timeout at top level, but inside a function call
+        // the effective timeout is raised to 1000ms so the completion succeeds.
         let completions = get_completions("str(aaa_", 8, 1).expect("should not error");
 
         assert!(
             completions.iter().any(|c| c == "aaa_bbb"),
             "Expected 'aaa_bbb' in completions for 'str(aaa_' at pos 8 \
-             (timeout_ms=1, bypassed inside function call), got: {:?}",
+             (timeout_ms=1, raised to 1000ms inside function call), got: {:?}",
             completions
         );
     });

--- a/crates/arf-harp/tests/completion.rs
+++ b/crates/arf-harp/tests/completion.rs
@@ -1,0 +1,66 @@
+//! Integration tests for R code completion.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use arf_harp::completion::get_completions;
+use arf_harp::eval_string_with_visibility;
+use common::{ld_library_path_is_set, with_r};
+
+/// Regression test for GitHub issue #204:
+/// Tab completion should work inside function call arguments.
+///
+/// R's `.completeToken()` takes significantly longer (~150ms) when inside a
+/// function call than at the top level (~20ms), because it also looks up
+/// function argument names. The 50ms default timeout causes these completions
+/// to time out and return empty.
+#[test]
+fn test_completion_inside_function_call() {
+    if !ld_library_path_is_set() {
+        eprintln!(
+            "Skipping test_completion_inside_function_call: \
+             LD_LIBRARY_PATH not set."
+        );
+        return;
+    }
+
+    with_r(|| {
+        eval_string_with_visibility("aaa_bbb <- 1").expect("assignment should succeed");
+
+        // timeout_ms=1 forces the timeout path on any platform, making this a genuine
+        // red test before the fix. The fix bypasses timeout when inside a function call.
+        let completions = get_completions("str(aaa_", 8, 1).expect("should not error");
+
+        assert!(
+            completions.iter().any(|c| c == "aaa_bbb"),
+            "Expected 'aaa_bbb' in completions for 'str(aaa_' at pos 8 with 50ms timeout, \
+             got: {:?}",
+            completions
+        );
+    });
+}
+
+/// Baseline: top-level completion finishes well within 50ms.
+#[test]
+fn test_completion_at_top_level_within_timeout() {
+    if !ld_library_path_is_set() {
+        eprintln!(
+            "Skipping test_completion_at_top_level_within_timeout: \
+             LD_LIBRARY_PATH not set."
+        );
+        return;
+    }
+
+    with_r(|| {
+        eval_string_with_visibility("aaa_bbb <- 1").expect("assignment should succeed");
+
+        let completions = get_completions("aaa_", 4, 50).expect("should not error");
+
+        assert!(
+            completions.iter().any(|c| c == "aaa_bbb"),
+            "Expected 'aaa_bbb' in completions for 'aaa_' at pos 4, got: {:?}",
+            completions
+        );
+    });
+}


### PR DESCRIPTION
## Summary

- Tab completion inside function call arguments (e.g. `str(aaa_` + Tab) was returning empty results on some platforms
- Root cause: R's `.completeToken()` takes ~150ms when inside a function call (it also looks up argument names), vs ~20ms at top level. The 50ms default timeout caused completions to time out
- Fix: detect an unmatched open parenthesis before the cursor and raise the completion timeout floor to 1000ms in that context. The same floor is also applied to `::` completions (which enumerate package exports and can also be slow). Previously both contexts disabled the timeout entirely (`0`); 1000ms is generous enough for any platform while still providing a safety boundary against hung completions.

Detection uses a **forward scan** with depth clamping (unmatched `)` are treated as no-ops, depth floored at 0), so cases like `1) + str(aaa_` are correctly identified as being inside an open `(`. The check covers both function calls (`str(aaa_`) and grouped expressions (`x <- (aaa_`), with string literals and `#` comments excluded from paren tracking.

The timeout floor is computed before any early-return branch so it applies uniformly — including the namespace-candidate path where a bare identifier like `aaa_` inside `str(aaa_` would otherwise bypass the floor.

## Test plan

- [x] Regression test added in `crates/arf-harp/tests/completion.rs`: uses `timeout_ms=1` to simulate a tight top-level timeout, verifying the fix raises it to 1000ms when inside a function call
- [x] Existing top-level completion test still passes with `timeout_ms=50`
- [x] Unit tests for `has_unmatched_open_paren` cover: basic function call, named args (`foo(x =)`, `foo(x, y =)`), cursor after comma (`foo(x,|)`), nested calls, unbalanced `)` earlier in line (`1) + str(aaa_`), top-level, balanced parens, string literals containing `(`, single-line `#` comments, multiline buffers
- [x] `cargo clippy` passes with no warnings
- [x] Integration test file no longer gated to Linux-only (`#![cfg(target_os = "linux")]` removed)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)