### PR TITLE
fix: enable bracketed paste early to prevent raw escape sequence echo

### DIFF
--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -514,6 +514,21 @@ fn run() -> Result<()> {
         config.startup.mode.autoformat = false;
     }
 
+    // Enable bracketed paste mode and disable echo early, so that any code
+    // sent by vscode-R (or other editors) immediately after terminal creation
+    // is not echoed as raw escape sequences. Without this, the first
+    // Ctrl+Enter send (which vscode-R wraps in \033[200~...\033[201~ markers
+    // when "r.bracketedPaste": true is set) arrives before the REPL has
+    // initialised bracketed paste handling, causing the markers to appear
+    // literally as "^[[200~ls()^[[201~" in the terminal.
+    // See https://github.com/eitsupi/arf/issues/213
+    let _ = crossterm::terminal::enable_raw_mode();
+    let _ = std::io::Write::write_all(
+        &mut std::io::stdout(),
+        b"\x1b[?2004h",
+    );
+    let _ = std::io::stdout().flush();
+
     // Set up R based on r_source config (with optional CLI override)
     let r_source_status = setup_r(
         &config.startup.r_source,


### PR DESCRIPTION
Enable bracketed paste mode early in startup so that code sent by vscode-R
immediately after terminal creation is handled correctly.

**Problem:** When `"r.bracketedPaste": true` is set in VS Code settings,
vscode-R wraps code in bracketed paste markers (`\033[200~...\033[201~`)
before writing to the PTY. If arf is not yet running when this first write
arrives, the terminal echoes the markers literally because bracketed paste
mode has not been enabled yet. This manifests as:

    ^[[200~ls()^[[201~

The markers only appear on the *first* send because reedline's
`use_bracketed_paste(true)` (in `Repl::run_with_r_mainloop` /
`run_standalone`) enables bracketed paste handling -- but that happens
after R setup and initialisation, which is hundreds of milliseconds into
startup.

**Fix:** Send the bracketed paste enable sequence (`\033[?2004h`) to stdout
and disable terminal echo early in `run()`, before R setup. This way the
terminal is ready to handle bracketed paste markers from the moment arf
starts, and the PTY will not echo early input bytes.

Closes #213
