### PR TITLE
feat(experimental): add fish-style abbreviations for shell mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental:** Fish-style abbreviations for shell mode (`experimental.shell_abbreviations`). Abbreviations are expanded automatically when you press Space or Enter. Only applies to the shell editor, not the R editor. Example: `"gc" = "git commit"`.
+
 ## [0.4.0] - 2026-05-31
 
 ### Added

--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -86,6 +86,7 @@
             "require"
           ]
         },
+        "shell_abbreviations": {},
         "shell_completion": {
           "command_names": false
         },
@@ -1603,6 +1604,14 @@
               "require"
             ]
           }
+        },
+        "shell_abbreviations": {
+          "description": "Fish-style abbreviations for shell mode.\n\nAbbreviations are expanded automatically when you press Space or Enter.\nOnly applies to the shell editor (not the R editor).\n\nFormat: `\"abbreviation\" = \"expansion\"`\nExample: `\"gc\" = \"git commit\"`",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
         },
         "shell_completion": {
           "description": "Shell mode completion configuration.",

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -3,6 +3,7 @@
 use nu_ansi_term::Color;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Experimental features configuration.
 ///
@@ -54,6 +55,16 @@ pub struct ExperimentalConfig {
     /// Disabled by default.
     #[serde(default)]
     pub shell_semicolon_shortcut: bool,
+
+    /// Fish-style abbreviations for shell mode.
+    ///
+    /// Abbreviations are expanded automatically when you press Space or Enter.
+    /// Only applies to the shell editor (not the R editor).
+    ///
+    /// Format: `"abbreviation" = "expansion"`
+    /// Example: `"gc" = "git commit"`
+    #[serde(default)]
+    pub shell_abbreviations: BTreeMap<String, String>,
 }
 
 /// Configuration for shell mode completion.
@@ -201,6 +212,15 @@ struct ExperimentalConfigSchema {
     ///
     /// Disabled by default.
     pub shell_semicolon_shortcut: bool,
+
+    /// Fish-style abbreviations for shell mode.
+    ///
+    /// Abbreviations are expanded automatically when you press Space or Enter.
+    /// Only applies to the shell editor (not the R editor).
+    ///
+    /// Format: `"abbreviation" = "expansion"`
+    /// Example: `"gc" = "git commit"`
+    pub shell_abbreviations: BTreeMap<String, String>,
 }
 
 // Manual JsonSchema implementation for ExperimentalConfig since nu_ansi_term::Color

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -90,6 +90,7 @@ expression: schema
             "require"
           ]
         },
+        "shell_abbreviations": {},
         "shell_completion": {
           "command_names": false
         },
@@ -1607,6 +1608,14 @@ expression: schema
               "require"
             ]
           }
+        },
+        "shell_abbreviations": {
+          "description": "Fish-style abbreviations for shell mode.\n\nAbbreviations are expanded automatically when you press Space or Enter.\nOnly applies to the shell editor (not the R editor).\n\nFormat: `\"abbreviation\" = \"expansion\"`\nExample: `\"gc\" = \"git commit\"`",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
         },
         "shell_completion": {
           "description": "Shell mode completion configuration.",

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
@@ -119,3 +119,5 @@ package_functions = [
 
 [experimental.shell_completion]
 command_names = false
+
+[experimental.shell_abbreviations]

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -32,6 +32,7 @@ use reedline::{
     default_vi_normal_keybindings,
 };
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicU16, Ordering};
 
@@ -806,6 +807,17 @@ impl Repl {
             let hinter =
                 DefaultHinter::default().with_style(Style::new().italic().fg(Color::DarkGray));
             shell_editor = shell_editor.with_hinter(Box::new(hinter));
+        }
+
+        if !self.config.experimental.shell_abbreviations.is_empty() {
+            let abbrs: HashMap<String, String> = self
+                .config
+                .experimental
+                .shell_abbreviations
+                .clone()
+                .into_iter()
+                .collect();
+            shell_editor = shell_editor.with_abbreviations(abbrs);
         }
 
         // Set up idle callback to process R events during input waiting.

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -690,3 +690,97 @@ fn test_pty_history_browser() {
 
     terminal.quit().expect("Should quit cleanly");
 }
+
+/// Test fish-style abbreviation expansion in shell mode.
+///
+/// An abbreviation defined via `experimental.shell_abbreviations` should
+/// expand automatically when Enter is pressed at the end of the matching word.
+/// The expanded text is then executed as a shell command, producing the
+/// expected output.
+#[test]
+#[cfg(unix)]
+fn test_pty_shell_abbreviations_expand_in_shell_mode() {
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let mut config_file = NamedTempFile::new().expect("Failed to create temp config file");
+    writeln!(
+        config_file,
+        r#"
+[experimental.shell_abbreviations]
+"abbr_test" = "echo abbr_expanded"
+"#
+    )
+    .expect("Failed to write config file");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--config",
+        config_file.path().to_str().unwrap(),
+        "--no-auto-match",
+        "--no-completion",
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Enter shell mode
+    terminal.send_line(":shell").expect("Should send :shell");
+    terminal
+        .expect("] $")
+        .expect("Should show shell mode prompt");
+
+    // Type the abbreviation and press Enter — expansion fires before submission
+    terminal
+        .send_line("abbr_test")
+        .expect("Should send abbreviation");
+    terminal
+        .expect("abbr_expanded")
+        .expect("Abbreviation should expand to 'echo abbr_expanded' and execute");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test that shell abbreviations do NOT expand in the R editor.
+///
+/// `experimental.shell_abbreviations` applies only to the shell editor.
+/// Typing an abbreviation in the R prompt must not trigger expansion; the
+/// word is evaluated as a regular R expression instead.
+#[test]
+#[cfg(unix)]
+fn test_pty_shell_abbreviations_do_not_expand_in_r_mode() {
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let mut config_file = NamedTempFile::new().expect("Failed to create temp config file");
+    writeln!(
+        config_file,
+        r#"
+[experimental.shell_abbreviations]
+"abbr_test" = "echo abbr_expanded"
+"#
+    )
+    .expect("Failed to write config file");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--config",
+        config_file.path().to_str().unwrap(),
+        "--no-auto-match",
+        "--no-completion",
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Type the abbreviation word at the R prompt and press Enter
+    terminal
+        .send_line("abbr_test")
+        .expect("Should send abbreviation word at R prompt");
+
+    // R should evaluate `abbr_test` as an R expression (object not found),
+    // NOT expand it to "echo abbr_expanded"
+    terminal
+        .expect("abbr_test")
+        .expect("R should echo back the identifier name in the error, not expand it");
+
+    terminal.quit().expect("Should quit cleanly");
+}

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -740,15 +740,15 @@ fn test_pty_shell_abbreviations_expand_in_shell_mode() {
     // Press Enter — reedline expands the abbreviation and submits the expanded command
     terminal.send_line("").expect("Should press Enter");
 
-    // Search for "\r\nabbr_expanded" to match only the shell output line.
+    // Search for "abbr_expanded\r\n" to match only the shell output line.
     //
     // The raw PTY buffer contains both the reedline repaint ("echo abbr_expanded"
-    // preceded by ANSI escape codes) and the shell output ("abbr_expanded\r\n").
-    // The shell output line is preceded by "\r\n" (the submission newline), while
-    // the repaint text is preceded by escape codes and "echo ". This makes "\r\n"
-    // a reliable anchor that uniquely identifies the command output.
+    // followed by ANSI cursor escape codes) and the shell output ("abbr_expanded\r\n").
+    // In the repaint, "abbr_expanded" is followed by \x1b7 (save-cursor escape),
+    // while in the shell output it is followed by \r\n. The trailing \r\n therefore
+    // uniquely identifies the command output line and avoids matching the repaint.
     terminal
-        .expect("\r\nabbr_expanded")
+        .expect("abbr_expanded\r\n")
         .expect("Shell should execute 'echo abbr_expanded' and produce output on its own line");
 
     terminal.quit().expect("Should quit cleanly");

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -776,11 +776,84 @@ fn test_pty_shell_abbreviations_do_not_expand_in_r_mode() {
         .send_line("abbr_test")
         .expect("Should send abbreviation word at R prompt");
 
-    // R should evaluate `abbr_test` as an R expression (object not found),
-    // NOT expand it to "echo abbr_expanded"
+    // R should evaluate `abbr_test` as an R expression and produce an object-not-found
+    // error — this string can only come from R's evaluator, not from local echo.
+    // If abbreviation expansion were active, R would never see `abbr_test` as an
+    // identifier: the buffer would contain "echo abbr_expanded" instead.
+    terminal.expect("not found").expect(
+        "R should produce object-not-found error, proving no abbreviation expansion occurred",
+    );
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// Test fish-style abbreviation expansion triggered by Space in shell mode.
+///
+/// Abbreviations expand on both Space and Enter. This test exercises the Space
+/// path: type the abbreviation, pause to let reedline process the characters as
+/// a separate event batch, then press Space to trigger expansion, and finally
+/// press Enter to submit the expanded command.
+///
+/// The pause is necessary because reedline fuses consecutive `Edit` events
+/// that arrive in the same read batch into one compound event, and the space
+/// expansion check only fires when `InsertChar(' ')` is the first command in
+/// the event. A brief sleep ensures the abbreviation characters are processed
+/// before the space arrives, so the space appears in its own batch.
+#[test]
+#[cfg(unix)]
+fn test_pty_shell_abbreviations_expand_on_space_in_shell_mode() {
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    let mut config_file = NamedTempFile::new().expect("Failed to create temp config file");
+    writeln!(
+        config_file,
+        r#"
+[experimental.shell_abbreviations]
+"abbr_sp" = "echo space_expanded"
+"#
+    )
+    .expect("Failed to write config file");
+
+    let mut terminal = Terminal::spawn_with_args(&[
+        "--config",
+        config_file.path().to_str().unwrap(),
+        "--no-auto-match",
+        "--no-completion",
+    ])
+    .expect("Failed to spawn arf");
+
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    // Enter shell mode
+    terminal.send_line(":shell").expect("Should send :shell");
     terminal
-        .expect("abbr_test")
-        .expect("R should echo back the identifier name in the error, not expand it");
+        .expect("] $")
+        .expect("Should show shell mode prompt");
+
+    // Type the abbreviation characters
+    terminal.send("abbr_sp").expect("Should type abbreviation");
+
+    // Wait for reedline's poll interval (33 ms) to elapse so the typed
+    // characters are processed as their own event batch before the space
+    // arrives. Without this pause they would be fused with the space into
+    // one compound Edit event, causing the space-expansion check to miss.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Send Space — this lands in a separate event batch, so reedline sees
+    // InsertChar(' ') as the first (and only) command and triggers expansion.
+    terminal
+        .send(" ")
+        .expect("Should press Space to trigger expansion");
+
+    // Small pause for the expansion repaint before sending Enter
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Press Enter to submit the now-expanded command
+    terminal.send_line("").expect("Should press Enter");
+    terminal
+        .expect("space_expanded")
+        .expect("Abbreviation should expand to 'echo space_expanded' on Space and execute");
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -740,20 +740,16 @@ fn test_pty_shell_abbreviations_expand_in_shell_mode() {
     // Press Enter — reedline expands the abbreviation and submits the expanded command
     terminal.send_line("").expect("Should press Enter");
 
-    // Wait for the reedline repaint showing the expanded buffer
+    // Search for "\r\nabbr_expanded" to match only the shell output line.
+    //
+    // The raw PTY buffer contains both the reedline repaint ("echo abbr_expanded"
+    // preceded by ANSI escape codes) and the shell output ("abbr_expanded\r\n").
+    // The shell output line is preceded by "\r\n" (the submission newline), while
+    // the repaint text is preceded by escape codes and "echo ". This makes "\r\n"
+    // a reliable anchor that uniquely identifies the command output.
     terminal
-        .expect("echo abbr_expanded")
-        .expect("Buffer repaint should show expanded text after Enter");
-
-    // Clear accumulated output so the final assertion only matches shell output
-    terminal
-        .clear_buffer()
-        .expect("Should clear accumulated output before checking shell output");
-
-    // The shell executes "echo abbr_expanded" and produces this output
-    terminal
-        .expect("abbr_expanded")
-        .expect("Shell should execute 'echo abbr_expanded' and produce this output");
+        .expect("\r\nabbr_expanded")
+        .expect("Shell should execute 'echo abbr_expanded' and produce output on its own line");
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -790,15 +790,22 @@ fn test_pty_shell_abbreviations_do_not_expand_in_r_mode() {
 /// Test fish-style abbreviation expansion triggered by Space in shell mode.
 ///
 /// Abbreviations expand on both Space and Enter. This test exercises the Space
-/// path: type the abbreviation, pause to let reedline process the characters as
-/// a separate event batch, then press Space to trigger expansion, and finally
-/// press Enter to submit the expanded command.
+/// path: type the abbreviation, wait for the terminal to echo the typed word
+/// (which guarantees reedline has processed it as a separate event batch), then
+/// press Space to trigger expansion, wait for the expanded buffer repaint, and
+/// finally press Enter to submit the expanded command.
 ///
-/// The pause is necessary because reedline fuses consecutive `Edit` events
-/// that arrive in the same read batch into one compound event, and the space
-/// expansion check only fires when `InsertChar(' ')` is the first command in
-/// the event. A brief sleep ensures the abbreviation characters are processed
-/// before the space arrives, so the space appears in its own batch.
+/// Synchronizing on observable terminal state (rather than a fixed sleep) keeps
+/// the test reliable under CI load: each `expect` blocks until the expected
+/// string appears in the PTY output, ensuring the right ordering without
+/// depending on timing assumptions.
+///
+/// Background: reedline fuses consecutive `Edit` events that arrive in the same
+/// read batch into one compound event. The space-expansion check only fires when
+/// `InsertChar(' ')` is the first command in the fused event. By waiting for the
+/// abbreviation echo before sending Space we guarantee they land in separate
+/// batches, so the space check sees exactly `InsertChar(' ')` and triggers
+/// expansion.
 #[test]
 #[cfg(unix)]
 fn test_pty_shell_abbreviations_expand_on_space_in_shell_mode() {
@@ -831,29 +838,37 @@ fn test_pty_shell_abbreviations_expand_on_space_in_shell_mode() {
         .expect("] $")
         .expect("Should show shell mode prompt");
 
-    // Type the abbreviation characters
+    // Type the abbreviation and wait for the terminal to echo it back.
+    // This guarantees reedline has processed `abbr_sp` as its own event batch
+    // before the Space arrives, so they don't get fused into one compound event.
     terminal.send("abbr_sp").expect("Should type abbreviation");
+    terminal
+        .expect("abbr_sp")
+        .expect("Terminal should echo the typed abbreviation");
 
-    // Wait for reedline's poll interval (33 ms) to elapse so the typed
-    // characters are processed as their own event batch before the space
-    // arrives. Without this pause they would be fused with the space into
-    // one compound Edit event, causing the space-expansion check to miss.
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    // Send Space — this lands in a separate event batch, so reedline sees
-    // InsertChar(' ') as the first (and only) command and triggers expansion.
+    // Send Space — now in a separate event batch, reedline sees InsertChar(' ')
+    // as the sole command and fires abbreviation expansion.
     terminal
         .send(" ")
         .expect("Should press Space to trigger expansion");
 
-    // Small pause for the expansion repaint before sending Enter
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    // Wait for the reedline repaint that shows the expanded buffer content.
+    // This also ensures expansion has completed before we send Enter.
+    terminal
+        .expect("echo space_expanded")
+        .expect("Buffer repaint should show expanded text after Space");
 
-    // Press Enter to submit the now-expanded command
+    // Clear accumulated output so the final expect only matches the shell's
+    // command output (not the `space_expanded` substring already in the repaint).
+    terminal
+        .clear_buffer()
+        .expect("Should clear accumulated output before checking shell output");
+
+    // Press Enter to submit the now-expanded command and verify it executes
     terminal.send_line("").expect("Should press Enter");
     terminal
         .expect("space_expanded")
-        .expect("Abbreviation should expand to 'echo space_expanded' on Space and execute");
+        .expect("Shell should execute 'echo space_expanded' and produce this output");
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/crates/arf-console/tests/pty_interactive_tests.rs
+++ b/crates/arf-console/tests/pty_interactive_tests.rs
@@ -729,13 +729,31 @@ fn test_pty_shell_abbreviations_expand_in_shell_mode() {
         .expect("] $")
         .expect("Should show shell mode prompt");
 
-    // Type the abbreviation and press Enter — expansion fires before submission
+    // Type the abbreviation and wait for the terminal to echo it back
     terminal
-        .send_line("abbr_test")
-        .expect("Should send abbreviation");
+        .send("abbr_test")
+        .expect("Should type abbreviation");
+    terminal
+        .expect("abbr_test")
+        .expect("Terminal should echo the typed abbreviation");
+
+    // Press Enter — reedline expands the abbreviation and submits the expanded command
+    terminal.send_line("").expect("Should press Enter");
+
+    // Wait for the reedline repaint showing the expanded buffer
+    terminal
+        .expect("echo abbr_expanded")
+        .expect("Buffer repaint should show expanded text after Enter");
+
+    // Clear accumulated output so the final assertion only matches shell output
+    terminal
+        .clear_buffer()
+        .expect("Should clear accumulated output before checking shell output");
+
+    // The shell executes "echo abbr_expanded" and produces this output
     terminal
         .expect("abbr_expanded")
-        .expect("Abbreviation should expand to 'echo abbr_expanded' and execute");
+        .expect("Shell should execute 'echo abbr_expanded' and produce this output");
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,10 @@ non_vi = "Default"         # Color for non-vi modes (Emacs, etc.)
 [experimental]
 shell_semicolon_shortcut = false  # `;` at empty prompt switches to shell mode
 
+[experimental.shell_abbreviations]
+# Fish-style abbreviations for shell mode (expanded on Space/Enter)
+# "gc" = "git commit"
+
 [experimental.history_forget]
 enabled = false            # Auto-remove failed commands from history
 delay = 2                  # Keep last N failed commands for retry
@@ -774,6 +778,21 @@ shell_semicolon_shortcut = true
 ```
 
 When the buffer is not empty, `;` inserts a semicolon as usual, so normal R expressions like `for (i in 1:10) { ... }` are unaffected.
+
+### Shell Abbreviations
+
+Fish-style abbreviations for the shell editor. When you type an abbreviation and press Space or Enter, it is automatically expanded to the full text. Only applies to shell mode — the R editor is unaffected.
+
+**Disabled by default** (empty map).
+
+```toml
+[experimental.shell_abbreviations]
+"gc" = "git commit"
+"gp" = "git push"
+"gs" = "git status"
+```
+
+Abbreviations are matched against the word immediately to the left of the cursor at the moment you press Space or Enter. The expansion replaces the abbreviation in place.
 
 ## CLI Options Override
 


### PR DESCRIPTION
## Summary

- Adds `experimental.shell_abbreviations` config — a TOML table mapping abbreviations to their expansions
- Abbreviations expand automatically when Space or Enter is pressed in shell mode
- Only applies to the shell editor; the R editor is unaffected
- Wires into reedline's `with_abbreviations()` API
- Updates JSON schema, snapshots, CHANGELOG, and `docs/configuration.md`

## Configuration

```toml
[experimental.shell_abbreviations]
"gc" = "git commit"
"gp" = "git push"
"gs" = "git status"
```

## Test plan

- [x] PTY test: Enter-trigger expansion in shell mode (`test_pty_shell_abbreviations_expand_in_shell_mode`)
- [x] PTY test: abbreviations do NOT expand in R mode (`test_pty_shell_abbreviations_do_not_expand_in_r_mode`)
- [x] PTY test: Space-trigger expansion with observable-state sync (`test_pty_shell_abbreviations_expand_on_space_in_shell_mode`)
- [x] Schema snapshot tests pass (`cargo insta test`)
- [x] Schema artifact updated (`artifacts/arf.schema.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)