### PR TITLE
fix: suppress startup terminal input echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Experimental:** Fish-style abbreviations for shell mode (`experimental.shell_abbreviations`). Abbreviations are expanded automatically when you press Space or Enter. Only applies to the shell editor, not the R editor. Example: `"gc" = "git commit"`.
 
+### Fixed
+
+- Bracketed paste sequences sent before the first R prompt (e.g. by the vscode-R extension with `r.bracketedPaste: true`) are no longer visibly echoed to the terminal. The fix disables terminal input echo early in the startup sequence, before reedline's first `read_line()` call, and restores the original terminal mode on exit.
+
 ## [0.4.0] - 2026-05-31
 
 ### Added

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -221,4 +221,4 @@ mod imp {
     }
 }
 
-pub(crate) use imp::ConsoleModeGuard;
+pub(crate) use imp::{ConsoleModeGuard, restore_original_input_mode};

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -106,13 +106,18 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use windows_sys::Win32::System::Console::ENABLE_LINE_INPUT;
 
         #[test]
         fn echo_input_is_cleared() {
-            let mode_with_echo = ENABLE_ECHO_INPUT | 0x100;
+            let mode_with_echo = ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT;
             let new_mode = mode_with_echo & !ENABLE_ECHO_INPUT;
             assert_eq!(0, new_mode & ENABLE_ECHO_INPUT, "echo bit must be cleared");
-            assert_ne!(0, new_mode & 0x100, "other bits must be preserved");
+            assert_ne!(
+                0,
+                new_mode & ENABLE_LINE_INPUT,
+                "other bits must be preserved"
+            );
         }
     }
 }

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -109,11 +109,10 @@ mod imp {
 
         #[test]
         fn echo_input_is_cleared() {
-            assert_eq!(0, ENABLE_ECHO_INPUT & !ENABLE_ECHO_INPUT);
-            assert_eq!(
-                0,
-                (ENABLE_ECHO_INPUT | 0x100) & !ENABLE_ECHO_INPUT & ENABLE_ECHO_INPUT
-            );
+            let mode_with_echo = ENABLE_ECHO_INPUT | 0x100;
+            let new_mode = mode_with_echo & !ENABLE_ECHO_INPUT;
+            assert_eq!(0, new_mode & ENABLE_ECHO_INPUT, "echo bit must be cleared");
+            assert_ne!(0, new_mode & 0x100, "other bits must be preserved");
         }
     }
 }

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -99,6 +99,7 @@ mod imp {
 
         let mode = ORIGINAL_INPUT_MODE.load(Ordering::Acquire);
         if unsafe { SetConsoleMode(handle, mode) } == 0 {
+            HAS_ORIGINAL_INPUT_MODE.store(true, Ordering::Release);
             log::warn!("Failed to restore original console input mode");
         }
     }

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -196,11 +196,13 @@ mod imp {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let Some(mode) = original.take() else {
+        let Some(mode) = original.as_ref() else {
             return;
         };
 
-        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &mode) } != 0 {
+        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, mode) } == 0 {
+            *original = None;
+        } else {
             log::warn!(
                 "Failed to restore terminal input mode: {}",
                 std::io::Error::last_os_error()

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -88,7 +88,7 @@ mod imp {
     }
 
     pub(crate) fn restore_original_input_mode() {
-        if !HAS_ORIGINAL_INPUT_MODE.load(Ordering::Acquire) {
+        if !HAS_ORIGINAL_INPUT_MODE.swap(false, Ordering::AcqRel) {
             return;
         }
 
@@ -191,16 +191,16 @@ mod imp {
     }
 
     pub(crate) fn restore_original_input_mode() {
-        let original = match ORIGINAL_TERMIOS.lock() {
+        let mut original = match ORIGINAL_TERMIOS.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let Some(mode) = original.as_ref() else {
+        let Some(mode) = original.take() else {
             return;
         };
 
-        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, mode) } != 0 {
+        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &mode) } != 0 {
             log::warn!(
                 "Failed to restore terminal input mode: {}",
                 std::io::Error::last_os_error()
@@ -221,4 +221,6 @@ mod imp {
     }
 }
 
-pub(crate) use imp::{ConsoleModeGuard, restore_original_input_mode};
+pub(crate) use imp::ConsoleModeGuard;
+#[cfg(unix)]
+pub(crate) use imp::restore_original_input_mode;

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -7,7 +7,9 @@ mod imp {
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use windows_sys::Win32::{
         Foundation::{HANDLE, INVALID_HANDLE_VALUE},
-        System::Console::{GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE, SetConsoleMode},
+        System::Console::{
+            ENABLE_ECHO_INPUT, GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE, SetConsoleMode,
+        },
     };
 
     static ORIGINAL_INPUT_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
@@ -16,6 +18,9 @@ mod imp {
     static ATEXIT_REGISTERED: AtomicBool = AtomicBool::new(false);
 
     /// Restores the original console input mode when dropped.
+    ///
+    /// `install()` disables input echo immediately so bracketed-paste payloads
+    /// sent before the first reedline `read_line()` are not visibly echoed.
     ///
     /// R's `quit()` can terminate the process before Rust destructors run, so
     /// `install()` also registers an `atexit` handler using the same restore
@@ -32,6 +37,7 @@ mod imp {
                     ORIGINAL_INPUT_HANDLE.store(handle, Ordering::Release);
                     ORIGINAL_INPUT_MODE.store(mode, Ordering::Release);
                     HAS_ORIGINAL_INPUT_MODE.store(true, Ordering::Release);
+                    disable_echo_input(handle, mode);
                 }
             }
 
@@ -70,6 +76,13 @@ mod imp {
         }
     }
 
+    fn disable_echo_input(handle: HANDLE, mode: u32) {
+        let new_mode = mode & !ENABLE_ECHO_INPUT;
+        if new_mode != mode && unsafe { SetConsoleMode(handle, new_mode) } == 0 {
+            log::warn!("Failed to disable console input echo");
+        }
+    }
+
     extern "C" fn restore_original_input_mode_at_exit() {
         restore_original_input_mode();
     }
@@ -89,15 +102,121 @@ mod imp {
             log::warn!("Failed to restore original console input mode");
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn echo_input_is_cleared() {
+            assert_eq!(0, ENABLE_ECHO_INPUT & !ENABLE_ECHO_INPUT);
+            assert_eq!(
+                0,
+                (ENABLE_ECHO_INPUT | 0x100) & !ENABLE_ECHO_INPUT & ENABLE_ECHO_INPUT
+            );
+        }
+    }
 }
 
 #[cfg(not(windows))]
 mod imp {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static ORIGINAL_TERMIOS: Mutex<Option<libc::termios>> = Mutex::new(None);
+    static ATEXIT_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+    /// Restores the original terminal mode when dropped.
+    ///
+    /// `install()` disables input echo immediately so bracketed-paste payloads
+    /// sent before the first reedline `read_line()` are not visibly echoed.
     pub(crate) struct ConsoleModeGuard;
 
     impl ConsoleModeGuard {
         pub(crate) fn install() -> Self {
+            let mut original = match ORIGINAL_TERMIOS.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+
+            if original.is_none() {
+                let mut mode: libc::termios = unsafe { std::mem::zeroed() };
+                if unsafe { libc::tcgetattr(libc::STDIN_FILENO, &mut mode) } == 0 {
+                    *original = Some(mode);
+                    disable_echo_input(&mode);
+                }
+            }
+
+            if original.is_some() {
+                register_atexit_restore();
+            }
+
             Self
+        }
+    }
+
+    impl Drop for ConsoleModeGuard {
+        fn drop(&mut self) {
+            restore_original_input_mode();
+        }
+    }
+
+    fn register_atexit_restore() {
+        if ATEXIT_REGISTERED.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let result = unsafe { libc::atexit(restore_original_input_mode_at_exit) };
+        if result != 0 {
+            ATEXIT_REGISTERED.store(false, Ordering::Release);
+            log::warn!("Failed to register terminal mode restore with atexit");
+        }
+    }
+
+    fn disable_echo_input(mode: &libc::termios) {
+        let mut new_mode = *mode;
+        new_mode.c_lflag &= !libc::ECHO;
+        if new_mode.c_lflag != mode.c_lflag
+            && unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &new_mode) } != 0
+        {
+            log::warn!(
+                "Failed to disable terminal input echo: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    extern "C" fn restore_original_input_mode_at_exit() {
+        restore_original_input_mode();
+    }
+
+    pub(crate) fn restore_original_input_mode() {
+        let original = match ORIGINAL_TERMIOS.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let Some(mode) = original.as_ref() else {
+            return;
+        };
+
+        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, mode) } != 0 {
+            log::warn!(
+                "Failed to restore terminal input mode: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn echo_flag_is_cleared() {
+            let flags = libc::ECHO | libc::ICANON | libc::ISIG;
+            let cleared = flags & !libc::ECHO;
+            assert_eq!(0, cleared & libc::ECHO);
+            assert_ne!(0, cleared & libc::ICANON);
+            assert_ne!(0, cleared & libc::ISIG);
         }
     }
 }

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -535,6 +535,10 @@ fn run() -> Result<()> {
         arf_libr::ensure_ld_library_path_with_pre_exec(console_mode::restore_original_input_mode)
     {
         log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
+        // Drop old guard before calling install(): assignment evaluates the RHS
+        // first (capturing and disabling echo), then drops the old guard, which
+        // would call restore and re-enable echo. Explicit drop avoids that.
+        drop(_console_mode_guard);
         _console_mode_guard = console_mode::ConsoleModeGuard::install();
     }
     #[cfg(not(unix))]

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -457,6 +457,11 @@ fn run() -> Result<()> {
 
     log::info!("Starting arf");
 
+    // Disable terminal input echo before startup work can receive extension
+    // input, and restore the original mode on exit. R's quit() may bypass Rust
+    // destructors, so the guard also registers an atexit fallback.
+    let _console_mode_guard = console_mode::ConsoleModeGuard::install();
+
     // Ensure XDG directories exist
     ensure_directories()?;
 
@@ -519,14 +524,14 @@ fn run() -> Result<()> {
 
     // Ensure LD_LIBRARY_PATH includes R library directory.
     // This may re-exec the current process if the path needs updating.
-    if let Err(e) = arf_libr::ensure_ld_library_path() {
+    #[cfg(unix)]
+    let ensure_ld_library_path_result =
+        arf_libr::ensure_ld_library_path_with_pre_exec(console_mode::restore_original_input_mode);
+    #[cfg(not(unix))]
+    let ensure_ld_library_path_result = arf_libr::ensure_ld_library_path();
+    if let Err(e) = ensure_ld_library_path_result {
         log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
     }
-
-    // Disable terminal input echo before R initialization can receive
-    // extension input, and restore the original mode on exit. This must run
-    // after ensure_ld_library_path(), which may re-exec the process.
-    let _console_mode_guard = console_mode::ConsoleModeGuard::install();
 
     // Generate R initialization arguments from CLI flags
     let r_args = cli.r_args();

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -457,9 +457,9 @@ fn run() -> Result<()> {
 
     log::info!("Starting arf");
 
-    // Save the parent shell's console input mode before reedline/crossterm can
-    // enable Windows VT input. R's quit() may bypass Rust destructors, so the
-    // guard also registers an atexit fallback on Windows.
+    // Disable terminal input echo before startup work can receive extension
+    // input, and restore the original mode on exit. R's quit() may bypass Rust
+    // destructors, so the guard also registers an atexit fallback.
     let _console_mode_guard = console_mode::ConsoleModeGuard::install();
 
     // Ensure XDG directories exist

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -460,6 +460,9 @@ fn run() -> Result<()> {
     // Disable terminal input echo before startup work can receive extension
     // input, and restore the original mode on exit. R's quit() may bypass Rust
     // destructors, so the guard also registers an atexit fallback.
+    #[cfg(unix)]
+    let mut _console_mode_guard = console_mode::ConsoleModeGuard::install();
+    #[cfg(not(unix))]
     let _console_mode_guard = console_mode::ConsoleModeGuard::install();
 
     // Ensure XDG directories exist
@@ -524,12 +527,18 @@ fn run() -> Result<()> {
 
     // Ensure LD_LIBRARY_PATH includes R library directory.
     // This may re-exec the current process if the path needs updating.
+    // On Unix, the pre-exec hook restores the terminal mode before exec so the
+    // replacement process starts with the original mode. If exec fails (rare),
+    // re-install the guard to re-disable echo for the rest of startup.
     #[cfg(unix)]
-    let ensure_ld_library_path_result =
-        arf_libr::ensure_ld_library_path_with_pre_exec(console_mode::restore_original_input_mode);
+    if let Err(e) =
+        arf_libr::ensure_ld_library_path_with_pre_exec(console_mode::restore_original_input_mode)
+    {
+        log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
+        _console_mode_guard = console_mode::ConsoleModeGuard::install();
+    }
     #[cfg(not(unix))]
-    let ensure_ld_library_path_result = arf_libr::ensure_ld_library_path();
-    if let Err(e) = ensure_ld_library_path_result {
+    if let Err(e) = arf_libr::ensure_ld_library_path() {
         log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
     }
 

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -457,11 +457,6 @@ fn run() -> Result<()> {
 
     log::info!("Starting arf");
 
-    // Disable terminal input echo before startup work can receive extension
-    // input, and restore the original mode on exit. R's quit() may bypass Rust
-    // destructors, so the guard also registers an atexit fallback.
-    let _console_mode_guard = console_mode::ConsoleModeGuard::install();
-
     // Ensure XDG directories exist
     ensure_directories()?;
 
@@ -527,6 +522,11 @@ fn run() -> Result<()> {
     if let Err(e) = arf_libr::ensure_ld_library_path() {
         log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
     }
+
+    // Disable terminal input echo before R initialization can receive
+    // extension input, and restore the original mode on exit. This must run
+    // after ensure_ld_library_path(), which may re-exec the process.
+    let _console_mode_guard = console_mode::ConsoleModeGuard::install();
 
     // Generate R initialization arguments from CLI flags
     let r_args = cli.r_args();

--- a/crates/arf-console/tests/common/mod.rs
+++ b/crates/arf-console/tests/common/mod.rs
@@ -100,8 +100,23 @@ impl Terminal {
         Self::spawn_with_size(args, DEFAULT_ROWS, DEFAULT_COLS)
     }
 
+    /// Spawn arf with additional arguments and environment variables.
+    pub fn spawn_with_args_and_env(args: &[&str], envs: &[(&str, &str)]) -> Result<Self, String> {
+        Self::spawn_with_size_and_env(args, envs, DEFAULT_ROWS, DEFAULT_COLS)
+    }
+
     /// Spawn arf with additional arguments and a custom terminal size.
     pub fn spawn_with_size(args: &[&str], rows: u16, cols: u16) -> Result<Self, String> {
+        Self::spawn_with_size_and_env(args, &[], rows, cols)
+    }
+
+    /// Spawn arf with additional arguments, environment variables, and a custom terminal size.
+    pub fn spawn_with_size_and_env(
+        args: &[&str],
+        envs: &[(&str, &str)],
+        rows: u16,
+        cols: u16,
+    ) -> Result<Self, String> {
         assert!(rows > 0 && cols > 0, "PTY size must be non-zero");
         let bin_path = env!("CARGO_BIN_EXE_arf");
 
@@ -125,6 +140,9 @@ impl Terminal {
         }
         for arg in args {
             cmd.arg(*arg);
+        }
+        for (key, value) in envs {
+            cmd.env(key, value);
         }
 
         // Spawn the process

--- a/crates/arf-console/tests/pty_input_tests.rs
+++ b/crates/arf-console/tests/pty_input_tests.rs
@@ -256,7 +256,7 @@ fn test_pty_bracketed_paste() {
 fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
     let temp_dir = tempfile::tempdir().expect("Should create temp dir");
     let rprofile_path = temp_dir.path().join(".Rprofile");
-    std::fs::write(&rprofile_path, "Sys.sleep(1)\n").expect("Should write R profile");
+    std::fs::write(&rprofile_path, "Sys.sleep(2)\n").expect("Should write R profile");
     let rprofile = rprofile_path
         .to_str()
         .expect("R profile path should be valid UTF-8");
@@ -265,13 +265,13 @@ fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
         Terminal::spawn_with_args_and_env(&["--no-auto-match"], &[("R_PROFILE_USER", rprofile)])
             .expect("Failed to spawn arf");
 
-    // Sleep long enough that ConsoleModeGuard::install() (the first thing main()
-    // does) has certainly run, while staying well inside the 1-second Sys.sleep()
-    // in the R profile.  There is no synchronisation signal from the child
-    // process, so this window is inherently timing-dependent; the window is tiny
-    // in practice because guard installation completes in the first few
-    // instructions of main().
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    // Sleep long enough that ConsoleModeGuard::install() — which runs early in
+    // main() before R is initialized, and therefore before .Rprofile is sourced —
+    // has certainly run, while staying well inside the 2-second Sys.sleep() in
+    // the R profile.  There is no synchronisation signal from the child process,
+    // so this window is inherently timing-dependent; 500ms provides comfortable
+    // headroom on loaded CI machines.
+    std::thread::sleep(std::time::Duration::from_millis(500));
 
     terminal
         .send("\x1b[200~x <- 42\x1b[201~\r")

--- a/crates/arf-console/tests/pty_input_tests.rs
+++ b/crates/arf-console/tests/pty_input_tests.rs
@@ -285,11 +285,12 @@ fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
         "bracketed paste end was echoed before first prompt; output:\n{output:?}"
     );
 
+    terminal.clear_buffer().expect("Should clear buffer");
     terminal
         .send_line("x")
         .expect("Should send variable inspection");
     terminal
-        .clear_and_expect("[1] 42")
+        .expect("[1] 42")
         .expect("Queued input should execute once REPL is ready");
 
     terminal.quit().expect("Should quit cleanly");

--- a/crates/arf-console/tests/pty_input_tests.rs
+++ b/crates/arf-console/tests/pty_input_tests.rs
@@ -254,12 +254,22 @@ fn test_pty_bracketed_paste() {
 #[test]
 #[cfg(unix)]
 fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
+    let temp_dir = tempfile::tempdir().expect("Should create temp dir");
+    let rprofile_path = temp_dir.path().join(".Rprofile");
+    std::fs::write(&rprofile_path, "Sys.sleep(1)\n").expect("Should write R profile");
+    let rprofile = rprofile_path
+        .to_str()
+        .expect("R profile path should be valid UTF-8");
+
     let mut terminal =
-        Terminal::spawn_with_args(&["--no-auto-match"]).expect("Failed to spawn arf");
+        Terminal::spawn_with_args_and_env(&["--no-auto-match"], &[("R_PROFILE_USER", rprofile)])
+            .expect("Failed to spawn arf");
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
     terminal
         .send("\x1b[200~x <- 42\x1b[201~\r")
-        .expect("Should send bracketed paste immediately after spawn");
+        .expect("Should send bracketed paste before the first prompt");
 
     terminal
         .wait_for_prompt()

--- a/crates/arf-console/tests/pty_input_tests.rs
+++ b/crates/arf-console/tests/pty_input_tests.rs
@@ -265,6 +265,12 @@ fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
         Terminal::spawn_with_args_and_env(&["--no-auto-match"], &[("R_PROFILE_USER", rprofile)])
             .expect("Failed to spawn arf");
 
+    // Sleep long enough that ConsoleModeGuard::install() (the first thing main()
+    // does) has certainly run, while staying well inside the 1-second Sys.sleep()
+    // in the R profile.  There is no synchronisation signal from the child
+    // process, so this window is inherently timing-dependent; the window is tiny
+    // in practice because guard installation completes in the first few
+    // instructions of main().
     std::thread::sleep(std::time::Duration::from_millis(200));
 
     terminal

--- a/crates/arf-console/tests/pty_input_tests.rs
+++ b/crates/arf-console/tests/pty_input_tests.rs
@@ -246,6 +246,45 @@ fn test_pty_bracketed_paste() {
     terminal.quit().expect("Should quit cleanly");
 }
 
+/// Regression test for vscode-R sending bracketed paste before the first prompt.
+///
+/// vscode-R wraps code in bracketed-paste delimiters itself and VS Code then
+/// sends the payload as terminal input. If this arrives before reedline enters
+/// raw mode, the terminal driver can echo the escape sequence visibly.
+#[test]
+#[cfg(unix)]
+fn test_pty_bracketed_paste_before_first_prompt_not_echoed() {
+    let mut terminal =
+        Terminal::spawn_with_args(&["--no-auto-match"]).expect("Failed to spawn arf");
+
+    terminal
+        .send("\x1b[200~x <- 42\x1b[201~\r")
+        .expect("Should send bracketed paste immediately after spawn");
+
+    terminal
+        .wait_for_prompt()
+        .expect("Should eventually show prompt");
+
+    let output = terminal.get_output().expect("Should get terminal output");
+    assert!(
+        !output.contains("\x1b[200~") && !output.contains("^[[200~"),
+        "bracketed paste start was echoed before first prompt; output:\n{output:?}"
+    );
+    assert!(
+        !output.contains("\x1b[201~") && !output.contains("^[[201~"),
+        "bracketed paste end was echoed before first prompt; output:\n{output:?}"
+    );
+
+    terminal
+        .send_line("x")
+        .expect("Should send variable inspection");
+    terminal
+        .clear_and_expect("[1] 42")
+        .expect("Queued input should execute once REPL is ready");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
 /// Test bracketed paste mode with very long strings.
 ///
 /// This is a regression test for handling very long strings that may exceed

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -26,6 +26,8 @@ pub use types::{Rstart, SaType, UImode};
 // sys
 #[cfg(unix)]
 pub use sys::askpass_handler_code;
+#[cfg(unix)]
+pub use sys::ensure_ld_library_path_with_pre_exec;
 pub use sys::{
     clear_r_interrupt_pending, clear_write_console_callback, command_had_error,
     ensure_ld_library_path, find_r_library, finish_ipc_capture, flush_reprex_buffer, get_r_home,

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -649,6 +649,14 @@ fn decode_windows_native(bytes: &[u8]) -> std::borrow::Cow<'_, str> {
 /// Ok(false) if no re-exec needed.
 #[cfg(unix)]
 pub fn ensure_ld_library_path() -> RResult<bool> {
+    ensure_ld_library_path_with_pre_exec(|| {})
+}
+
+#[cfg(unix)]
+pub fn ensure_ld_library_path_with_pre_exec<F>(pre_exec: F) -> RResult<bool>
+where
+    F: FnOnce(),
+{
     let lib_path = find_r_library()?;
     let Some(lib_dir) = lib_path.parent() else {
         return Ok(false);
@@ -678,6 +686,8 @@ pub fn ensure_ld_library_path() -> RResult<bool> {
     let exe = env::current_exe().map_err(|e| RError::LibraryNotFound(e.to_string()))?;
 
     log::info!("Re-executing with LD_LIBRARY_PATH={}", new_path);
+
+    pre_exec();
 
     use std::os::unix::process::CommandExt;
     let err = Command::new(&exe).args(args).exec();


### PR DESCRIPTION
Fix #213

## Summary

- Bracketed paste sequences sent before the first R prompt are no longer visibly echoed to the terminal
- Root cause: arf startup runs in cooked mode with echo enabled until reedline's first `read_line()` call; vscode-R sends `\x1b[200~...\x1b[201~` within ~200ms of terminal creation (fixed delay), racing with startup
- Fix: disable terminal input echo early in startup, before `setup_r()`, and restore original terminal mode on exit via RAII guard + `atexit` handler
  - Unix: `tcgetattr` + clear `ECHO` flag only (preserves `OPOST`, `ICANON`, etc. so `println!` output is unaffected)
  - Windows: `GetConsoleMode` + clear `ENABLE_ECHO_INPUT`

## Test plan

- [x] Added PTY regression test: spawns arf with `Sys.sleep(1)` in `.Rprofile` to create a pre-prompt window, sends bracketed paste payload during that window, asserts no echo in output and that the queued input executes after the prompt appears (`pty_input_tests::test_pty_bracketed_paste_before_first_prompt_not_echoed`)
- [x] `cargo test -p arf-console --test pty_input_tests` — 11 passed
- [x] `cargo test -p arf-console console_mode` — passed
- [x] `cargo fmt --check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)