### PR TITLE
fix: treat empty `R_PROFILE_USER`/`R_PROFILE` as unset during profile search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `.Rprofile` is now loaded correctly after `:restart!` when `R_PROFILE_USER` is set to an empty string in the environment. An empty value is now treated as unset, matching R's own behavior. This restores profile loading in environments where a parent process resets `R_PROFILE_USER` to `""` after the initial startup.
+
 ## [0.4.1] - 2026-06-13
 
 ### Added

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -385,12 +385,16 @@ unsafe extern "C" fn call_callback(payload: *mut std::ffi::c_void) {
 fn find_site_r_profile(r_home: &Path) -> Option<PathBuf> {
     // 1. Try R_PROFILE environment variable
     if let Ok(path_str) = std::env::var("R_PROFILE") {
-        let path = PathBuf::from(&path_str);
-        if path.exists() {
-            return Some(path);
+        if path_str.is_empty() {
+            // Empty string is treated as unset, matching R's own behavior.
+        } else {
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                return Some(path);
+            }
+            log::warn!("`R_PROFILE` detected but '{path_str}' does not exist");
+            return None;
         }
-        log::warn!("`R_PROFILE` detected but '{path_str}' does not exist");
-        return None;
     }
 
     // 2. Try arch-specific Rprofile.site (typically Windows: etc/x86/Rprofile.site)
@@ -416,12 +420,16 @@ fn find_site_r_profile(r_home: &Path) -> Option<PathBuf> {
 fn find_user_r_profile() -> Option<PathBuf> {
     // 1. Try R_PROFILE_USER environment variable
     if let Ok(path_str) = std::env::var("R_PROFILE_USER") {
-        let path = PathBuf::from(&path_str);
-        if path.exists() {
-            return Some(path);
+        if path_str.is_empty() {
+            // Empty string is treated as unset, matching R's own behavior.
+        } else {
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                return Some(path);
+            }
+            log::warn!("`R_PROFILE_USER` detected but '{path_str}' does not exist");
+            return None;
         }
-        log::warn!("`R_PROFILE_USER` detected but '{path_str}' does not exist");
-        return None;
     }
 
     // 2. Try current directory .Rprofile


### PR DESCRIPTION
## Summary

- `R_PROFILE_USER` or `R_PROFILE` set to an empty string is now treated as unset in `find_user_r_profile()` and `find_site_r_profile()`, matching R's own behavior.
- Previously, an empty value caused the profile search to terminate early with a warning, so `.Rprofile` was never loaded in that startup.

## Background

Some R terminal integrations set `R_PROFILE_USER` to a custom profile script on startup, then reset it to `""` after the script runs. When arf restarts via `exec()` (`:restart!`, `:switch!`), the child process inherits `R_PROFILE_USER=""`. The old code treated any non-error return from `std::env::var` as an explicit path, so the empty string caused the function to warn and return `None` — skipping `.Rprofile` entirely.

See: #221

## Test plan

- [x] `cargo test --package arf-harp` passes
- [x] `cargo clippy --package arf-harp` clean
- [ ] Start arf from a terminal integration that sets `R_PROFILE_USER` to a wrapper script; confirm `.Rprofile` is loaded correctly after `:restart!`