### PR TITLE
test: add tests for empty `R_PROFILE`/`R_PROFILE_USER` fallback behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "once_cell",
  "r-vignette-to-md",
  "rd2qmd-core",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/arf-harp/Cargo.toml
+++ b/crates/arf-harp/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "High-level R abstractions for safe R object manipulation"
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [dependencies]
 arf-libr.workspace = true
 r-vignette-to-md.workspace = true

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -470,6 +470,52 @@ fn r_user_home() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_find_site_r_profile_empty_r_profile_falls_through() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let etc_dir = tmp.path().join("etc");
+        std::fs::create_dir_all(&etc_dir).unwrap();
+        let site_profile = etc_dir.join("Rprofile.site");
+        std::fs::write(&site_profile, "").unwrap();
+
+        let prev = std::env::var("R_PROFILE").ok();
+        unsafe { std::env::set_var("R_PROFILE", "") };
+        let result = find_site_r_profile(tmp.path());
+        match prev {
+            Some(v) => unsafe { std::env::set_var("R_PROFILE", v) },
+            None => unsafe { std::env::remove_var("R_PROFILE") },
+        }
+
+        assert_eq!(result, Some(site_profile));
+    }
+
+    #[test]
+    fn test_find_user_r_profile_empty_r_profile_user_falls_through() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home_profile = tmp.path().join(".Rprofile");
+        std::fs::write(&home_profile, "").unwrap();
+
+        let prev_user = std::env::var("R_PROFILE_USER").ok();
+        let prev_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("R_PROFILE_USER", "") };
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let result = find_user_r_profile();
+        match prev_user {
+            Some(v) => unsafe { std::env::set_var("R_PROFILE_USER", v) },
+            None => unsafe { std::env::remove_var("R_PROFILE_USER") },
+        }
+        match prev_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert_eq!(result, Some(home_profile));
+    }
+
     #[test]
     fn test_should_ignore_site_r_profile() {
         // Should ignore with --no-site-file

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -499,18 +499,19 @@ mod tests {
         let home_profile = tmp.path().join(".Rprofile");
         std::fs::write(&home_profile, "").unwrap();
 
+        let home_var = if cfg!(windows) { "R_USER" } else { "HOME" };
         let prev_user = std::env::var("R_PROFILE_USER").ok();
-        let prev_home = std::env::var("HOME").ok();
+        let prev_home = std::env::var(home_var).ok();
         unsafe { std::env::set_var("R_PROFILE_USER", "") };
-        unsafe { std::env::set_var("HOME", tmp.path()) };
+        unsafe { std::env::set_var(home_var, tmp.path()) };
         let result = find_user_r_profile();
         match prev_user {
             Some(v) => unsafe { std::env::set_var("R_PROFILE_USER", v) },
             None => unsafe { std::env::remove_var("R_PROFILE_USER") },
         }
         match prev_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
+            Some(v) => unsafe { std::env::set_var(home_var, v) },
+            None => unsafe { std::env::remove_var(home_var) },
         }
 
         assert_eq!(result, Some(home_profile));


### PR DESCRIPTION
A follow up for #226

## Summary

- Add unit tests verifying that setting `R_PROFILE` or `R_PROFILE_USER` to an empty string is treated as unset, allowing lookup to continue through the standard fallback locations (`Rprofile.site` / `.Rprofile`)
- Use a `static Mutex` to serialize env-var-mutating tests and avoid races under parallel test execution
- Use `cfg!(windows)` to select `R_USER` on Windows and `HOME` on Unix, matching `r_user_home()` platform behavior

## Test plan

- [x] `cargo test -p arf-harp -- startup::tests` passes all 4 tests
- [x] `cargo fmt --check -p arf-harp` clean
- [x] `cargo clippy -p arf-harp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)