### PR TITLE
chore: prepare release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-27
+
 ### Fixed
 
-- `.Rprofile` is now loaded correctly after `:restart!` when `R_PROFILE_USER` is set to an empty string in the environment. An empty value is now treated as unset, matching R's own behavior. This restores profile loading in environments where a parent process resets `R_PROFILE_USER` to `""` after the initial startup.
+- `.Rprofile` is now loaded correctly after `:restart!` when `R_PROFILE_USER` is set to an empty string in the environment. An empty value is now treated as unset, matching R's own behavior. This restores profile loading in environments where a parent process resets `R_PROFILE_USER` to `""` after the initial startup (#226).
 
 ## [0.4.1] - 2026-06-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "arf-console"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arf-libr",
  "log",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1502,7 +1502,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "htmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.4.1", path = "crates/arf-harp" }
-arf-libr = { version = "0.4.1", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.4.1", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.4.2", path = "crates/arf-harp" }
+arf-libr = { version = "0.4.2", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.4.2", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.1
+# arf console v0.4.2
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.1
+# arf console v0.4.2
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.1
+# arf console v0.4.2
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.1
+# arf console v0.4.2
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.1
+# arf console v0.4.2
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.4.1 to 0.4.2
- Finalize CHANGELOG `[Unreleased]` section as `[0.4.2] - 2026-06-27`
- Update banner snapshots for new version string

## Changelog

### Fixed

- `.Rprofile` is now loaded correctly after `:restart!` when `R_PROFILE_USER` is set to an empty string in the environment. An empty value is now treated as unset, matching R's own behavior. This restores profile loading in environments where a parent process resets `R_PROFILE_USER` to `""` after the initial startup (#226).

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (all 786 tests)
- [x] Banner snapshots updated via `cargo insta test --accept -- banner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)