### PR TITLE
fix: try to support R on RHEL/AlmaLinux (RTLD_LAZY + lib64 path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Support R installations on RHEL and AlmaLinux by checking `/usr/lib64/R/lib/libR.so` and using lazy symbol resolution when loading libR.
+
 ## [0.4.2] - 2026-06-27
 
 ### Fixed

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -187,10 +187,10 @@ impl RLibrary {
             #[cfg(unix)]
             let library = {
                 use libloading::os::unix::Library as UnixLibrary;
-                // RTLD_NOW = 0x2, RTLD_GLOBAL = 0x100
-                const RTLD_NOW: libc::c_int = 0x2;
+                // RTLD_LAZY = 0x1, RTLD_GLOBAL = 0x100
+                const RTLD_LAZY: libc::c_int = 0x1;
                 const RTLD_GLOBAL: libc::c_int = 0x100;
-                let unix_lib = UnixLibrary::open(Some(library_path), RTLD_NOW | RTLD_GLOBAL)
+                let unix_lib = UnixLibrary::open(Some(library_path), RTLD_LAZY | RTLD_GLOBAL)
                     .map_err(|e| RError::LibraryNotFound(e.to_string()))?;
                 Library::from(unix_lib)
             };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -19,6 +19,7 @@ static R_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut())
 const R_LIB_PATHS: &[&str] = &[
     "/opt/R/current/lib/R/lib/libR.so",
     "/usr/lib/R/lib/libR.so",
+    "/usr/lib64/R/lib/libR.so",
     "/usr/local/lib/R/lib/libR.so",
 ];
 


### PR DESCRIPTION
## Summary

Fixes R initialization failure on RHEL/AlmaLinux 9 (reported in #231).

- Switch from `RTLD_NOW` to `RTLD_LAZY` when loading `libR.so` on Unix, matching the approach used by ark. `RTLD_NOW` caused `dlopen` to fail immediately if any transitive dependency (e.g. FlexiBLAS) could not be resolved at load time; `RTLD_LAZY` defers symbol resolution until the symbol is actually called.
- Add `/usr/lib64/R/lib/libR.so` to the fallback `R_LIB_PATHS` list. RHEL/Fedora/AlmaLinux install R under `/usr/lib64/R` rather than `/usr/lib/R`, so the auto-detection fallback now covers that layout when `R_HOME` is not set and `R` is not on `PATH`.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] Manually verify on AlmaLinux 9 that `arf` starts successfully (needs reporter confirmation in #231)

🤖 Generated with [Claude Code](https://claude.com/claude-code)