### PR TITLE
fix: evaluate internal R code in R_BaseEnv to prevent .GlobalEnv pollution

### DIFF
--- a/crates/arf-console/src/ipc/capture.rs
+++ b/crates/arf-console/src/ipc/capture.rs
@@ -72,7 +72,7 @@ pub fn evaluate_with_capture(code: &str, visible: bool) -> EvaluateResult {
     // Start capturing via WriteConsoleEx callback
     arf_libr::start_ipc_capture(visible);
 
-    let eval_result = arf_harp::eval_string(&capture_code);
+    let eval_result = arf_harp::eval_string_in_base(&capture_code);
 
     // Stop capturing and collect stdout/stderr
     let (stdout, stderr) = arf_libr::finish_ipc_capture();

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -1032,7 +1032,7 @@ local({
 })
 "#;
 
-    arf_harp::eval_string(code)
+    arf_harp::eval_string_in_base(code)
         .context("Failed to configure headless R options (pager, browser, graphics device)")?;
     log::info!("Headless R options configured (pager, browser, graphics device)");
     Ok(())

--- a/crates/arf-harp/src/completion.rs
+++ b/crates/arf-harp/src/completion.rs
@@ -332,11 +332,11 @@ fn fetch_installed_packages() -> HarpResult<Vec<String>> {
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 
@@ -417,11 +417,11 @@ pub fn get_namespace_exports(pkg: &str, triple_colon: bool) -> HarpResult<Vec<St
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 
@@ -621,12 +621,12 @@ fn get_r_builtin_completions(
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         // Evaluate using R_ToplevelExec for safe error handling
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 
@@ -693,11 +693,11 @@ pub fn get_token(line: &str, cursor_pos: usize) -> HarpResult<String> {
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -139,11 +139,11 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 
@@ -158,8 +158,6 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
 
         let result = protect.protect(payload.result.unwrap());
 
-        // Extract data from the data.frame
-        // A data.frame in R is a list of columns
         extract_help_topics(result)
     }
 }
@@ -263,11 +261,11 @@ unsafe fn eval_r_to_string(code: &str) -> HarpResult<Option<String>> {
         }
 
         let expr = (lib.vector_elt)(parsed, 0);
-        let global_env = *lib.r_globalenv;
+        let base_env = *lib.r_baseenv;
 
         let mut payload = EvalPayload {
             expr,
-            env: global_env,
+            env: base_env,
             result: None,
         };
 

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -80,10 +80,28 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
         // hsearch_db() returns a list with $Base containing the help index
         // We extract the relevant columns: Package, Topic, Title, Type
         let code = r#"
-            tryCatch({
-                db <- utils::hsearch_db()
-                base <- db$Base
-                if (is.null(base)) {
+            local({
+                tryCatch({
+                    db <- utils::hsearch_db()
+                    base <- db$Base
+                    if (is.null(base)) {
+                        data.frame(
+                            Package = character(0),
+                            Topic = character(0),
+                            Title = character(0),
+                            Type = character(0),
+                            stringsAsFactors = FALSE
+                        )
+                    } else {
+                        data.frame(
+                            Package = base$Package,
+                            Topic = base$Topic,
+                            Title = base$Title,
+                            Type = base$Type,
+                            stringsAsFactors = FALSE
+                        )
+                    }
+                }, error = function(e) {
                     data.frame(
                         Package = character(0),
                         Topic = character(0),
@@ -91,23 +109,7 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
                         Type = character(0),
                         stringsAsFactors = FALSE
                     )
-                } else {
-                    data.frame(
-                        Package = base$Package,
-                        Topic = base$Topic,
-                        Title = base$Title,
-                        Type = base$Type,
-                        stringsAsFactors = FALSE
-                    )
-                }
-            }, error = function(e) {
-                data.frame(
-                    Package = character(0),
-                    Topic = character(0),
-                    Title = character(0),
-                    Type = character(0),
-                    stringsAsFactors = FALSE
-                )
+                })
             })
         "#;
 

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -80,11 +80,11 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
         // hsearch_db() returns a list with $Base containing the help index
         // We extract the relevant columns: Package, Topic, Title, Type
         let code = r#"
-            base::local({
+            local({
                 tryCatch({
                     db <- utils::hsearch_db()
-                    base <- db$Base
-                    if (is.null(base)) {
+                    base_entries <- db$Base
+                    if (is.null(base_entries)) {
                         data.frame(
                             Package = character(0),
                             Topic = character(0),
@@ -94,10 +94,10 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
                         )
                     } else {
                         data.frame(
-                            Package = base$Package,
-                            Topic = base$Topic,
-                            Title = base$Title,
-                            Type = base$Type,
+                            Package = base_entries$Package,
+                            Topic = base_entries$Topic,
+                            Title = base_entries$Title,
+                            Type = base_entries$Type,
                             stringsAsFactors = FALSE
                         )
                     }

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -80,7 +80,7 @@ pub fn get_help_topics() -> HarpResult<Vec<HelpTopic>> {
         // hsearch_db() returns a list with $Base containing the help index
         // We extract the relevant columns: Package, Topic, Title, Type
         let code = r#"
-            local({
+            base::local({
                 tryCatch({
                     db <- utils::hsearch_db()
                     base <- db$Base

--- a/crates/arf-harp/src/object.rs
+++ b/crates/arf-harp/src/object.rs
@@ -84,10 +84,26 @@ impl RObject {
 /// Parse and evaluate an R expression string, printing visible results.
 pub fn eval_string(code: &str) -> HarpResult<RObject> {
     let lib = r_library()?;
+    let eval_env = unsafe { *lib.r_globalenv };
+    eval_string_in_env(code, eval_env)
+}
+
+/// Parse and evaluate an R expression string in `R_BaseEnv`, printing visible results.
+///
+/// Evaluating in the base environment prevents user bindings in `.GlobalEnv` from
+/// masking base functions. Use this for all internal infrastructure code that should
+/// not be affected by the user's workspace.
+pub fn eval_string_in_base(code: &str) -> HarpResult<RObject> {
+    let lib = r_library()?;
+    let eval_env = unsafe { *lib.r_baseenv };
+    eval_string_in_env(code, eval_env)
+}
+
+fn eval_string_in_env(code: &str, eval_env: SEXP) -> HarpResult<RObject> {
+    let lib = r_library()?;
     let mut protect = RProtect::new();
 
     unsafe {
-        // Create R string from code
         let code_cstring = CString::new(code).map_err(|_| HarpError::TypeMismatch {
             expected: "valid UTF-8".to_string(),
             actual: "string with null byte".to_string(),
@@ -135,18 +151,12 @@ pub fn eval_string(code: &str) -> HarpResult<RObject> {
             }
         }
 
-        // Get the number of expressions
         let n_expr = (lib.rf_length)(parsed);
-        let global_env = *lib.r_globalenv;
-
         let mut last_result = r_nil_value()?;
 
-        // Evaluate each expression and print visible results
         for i in 0..n_expr as isize {
             let expr = (lib.vector_elt)(parsed, i);
-
-            // Use withVisible() to evaluate and get visibility information
-            let with_visible_result = eval_with_visible(expr, global_env, &mut protect)?;
+            let with_visible_result = eval_with_visible(expr, eval_env, &mut protect)?;
 
             if let Some((value, visible)) = with_visible_result {
                 last_result = value;

--- a/crates/arf-harp/src/startup.rs
+++ b/crates/arf-harp/src/startup.rs
@@ -58,7 +58,7 @@ pub fn override_platform_gui() {
         if (locked) lockBinding(".Platform", e)
     })"##;
 
-    match crate::eval_string(code) {
+    match crate::eval_string_in_base(code) {
         Ok(_) => log::info!(r#"[WINDOWS] .Platform$GUI set to "arf-console""#),
         Err(err) => log::error!("[WINDOWS] Failed to override .Platform$GUI: {err}"),
     }


### PR DESCRIPTION
## Summary

- `:help` was assigning `db` and `base` into `.GlobalEnv`, silently overwriting any user variables with the same name (reported in #229)
- Root cause: all internal R snippets were evaluated in `R_GlobalEnv`, so temporary bindings leaked into the user's workspace
- Fix: evaluate all internal infrastructure R code in `R_BaseEnv`, cutting the `.GlobalEnv` parent chain entirely — matching the approach used by ark (`parse_eval_base` / `new.env(parent = baseenv())`)
- `local({...})` wrappers are retained where needed to prevent assignments from leaking into `R_BaseEnv` itself

## Changes

- `object.rs`: extract `eval_string_in_env()`; add `eval_string_in_base()` for internal use
- `help.rs`: `get_help_topics()` and `eval_r_to_string()` now evaluate in `R_BaseEnv`; rename temporary variable `base` → `base_entries`
- `completion.rs`: `fetch_installed_packages()`, `get_namespace_exports()`, `get_r_builtin_completions()`, `get_token()` now evaluate in `R_BaseEnv`; `check_if_functions()` retains `R_GlobalEnv` (needs to resolve user-defined objects)
- `startup.rs`, `main.rs`, `capture.rs`: switch to `eval_string_in_base()`

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)