### PR TITLE
fix: unset empty `R_PROFILE_USER` before `Rf_initialize_R` on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Support R installations on RHEL and AlmaLinux by checking `/usr/lib64/R/lib/libR.so` and using lazy symbol resolution when loading libR.
+- Fixed `.Rprofile` not being loaded after `:restart!` on macOS/Linux when `R_PROFILE_USER` is set to an empty string in the environment. The fix from #226 applied only to Windows; this extends the same behaviour to Unix where R handles profile loading internally.
 
 ## [0.4.2] - 2026-06-27
 

--- a/crates/arf-console/tests/cli_tests.rs
+++ b/crates/arf-console/tests/cli_tests.rs
@@ -760,6 +760,34 @@ fn test_eval_sources_user_rprofile() {
     );
 }
 
+/// Test that an empty `R_PROFILE_USER` falls back to the working-directory
+/// `.Rprofile` on Unix.
+#[cfg(unix)]
+#[test]
+fn test_eval_empty_r_profile_user_sources_default_rprofile() {
+    let working_dir = tempfile::tempdir().expect("Failed to create working directory");
+    let rprofile_path = working_dir.path().join(".Rprofile");
+    std::fs::write(&rprofile_path, "cat('ARF_RPROFILE_MARKER\\n')\n")
+        .expect("Failed to write .Rprofile");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+        .current_dir(working_dir.path())
+        .env("R_PROFILE_USER", "")
+        .args(["-e", "1"])
+        .output()
+        .expect("Failed to run arf -e");
+
+    assert!(output.status.success(), "arf -e should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("ARF_RPROFILE_MARKER") || stderr.contains("ARF_RPROFILE_MARKER"),
+        "default .Rprofile should be sourced when R_PROFILE_USER is empty. \
+         stdout={stdout}, stderr={stderr}"
+    );
+}
+
 /// Test that `arf --vanilla -e` does NOT source the user's `.Rprofile`.
 ///
 /// `--vanilla` implies `--no-init-file`, which must suppress .Rprofile

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -786,6 +786,8 @@ pub unsafe fn initialize_r_with_args(r_args: &[&str]) -> RResult<()> {
 /// Unix-specific R initialization.
 #[cfg(unix)]
 unsafe fn initialize_r_unix(lib: &crate::functions::RLibrary, r_args: &[&str]) -> RResult<()> {
+    normalize_empty_r_profile_user();
+
     unsafe {
         // Set R_running_as_main_program before initialization (like ark does)
         if !lib.r_running_as_main_program.is_null() {
@@ -849,6 +851,20 @@ unsafe fn initialize_r_unix(lib: &crate::functions::RLibrary, r_args: &[&str]) -
     }
 
     Ok(())
+}
+
+/// Unset an empty `R_PROFILE_USER` so R uses its normal user-profile search.
+///
+/// Some R terminal integrations set `R_PROFILE_USER` to a wrapper script on
+/// startup, then reset it to `""` after the script runs. An exec-based restart
+/// inherits that value, and R treats it as an explicit instruction to skip user
+/// profiles instead of falling back to `.Rprofile`.
+#[cfg(unix)]
+fn normalize_empty_r_profile_user() {
+    if env::var("R_PROFILE_USER").as_deref() == Ok("") {
+        // SAFETY: R initialization is single-threaded.
+        unsafe { env::remove_var("R_PROFILE_USER") };
+    }
 }
 
 /// Enable virtual terminal processing on Windows.


### PR DESCRIPTION
## Summary

- Fixes `.Rprofile` not being loaded after `:restart!` on macOS/Linux when `R_PROFILE_USER` is set to an empty string in the environment.
- Adds a regression test that verifies `.Rprofile` is sourced when `R_PROFILE_USER=""` on Unix.

## Background

Some R terminal integrations set `R_PROFILE_USER` to a wrapper script on startup, then reset it to `""` after the script runs. When arf restarts via `exec()` (`:restart!`, `:switch!`), the child process inherits `R_PROFILE_USER=""`.

On **Windows**, this was already fixed in #226 via `find_user_r_profile()` in `arf-harp`, which treats an empty value as unset. However, on **Unix/macOS**, R handles profile loading internally via `Rf_initialize_R()`. R's own `startup.c` returns early when `R_PROFILE_USER` is set to any value (including `""`), skipping `.Rprofile` entirely with no fallback.

Fix: call `normalize_empty_r_profile_user()` before `Rf_initialize_R()` to unset `R_PROFILE_USER` when it is empty, allowing R to fall back to its normal search (`./.Rprofile` → `~/.Rprofile`).

See: #221

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --package arf-libr --package arf-console` clean
- [x] `cargo test --package arf-libr --package arf-harp` passes
- [x] New test `test_eval_empty_r_profile_user_sources_default_rprofile` passes on Unix

🤖 Generated with [Claude Code](https://claude.com/claude-code)