### PR TITLE
feat: populate `more_info` with HistoryExtraInfo on history save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,11 +843,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1631,8 +1631,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201e8e0160cbe7bb5eb2caccf281e178e77fac95115ab31a2c29edc5593603c8"
+source = "git+https://github.com/nushell/reedline?rev=32f80f429e709d2d16fccf23515494e2f0bc525f#32f80f429e709d2d16fccf23515494e2f0bc525f"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1711,6 +1710,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rtoolbox"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
@@ -1732,6 +1741,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -1989,6 +1999,18 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crossterm = "0.29"
 crokey = "1.4"
 nu-ansi-term = { version = "0.50", features = ["derive_serde_style"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
-reedline = { version = "0.48", features = ["sqlite", "idle_callback"] }
+reedline = { git = "https://github.com/nushell/reedline", rev = "32f80f429e709d2d16fccf23515494e2f0bc525f", features = ["sqlite", "idle_callback"] }
 
 # Configuration
 dirs = "6.0"
@@ -49,7 +49,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 
 # Database
-rusqlite = { version = "0.37.0", features = ["bundled"] }
+rusqlite = { version = "0.40.1", features = ["bundled"] }
 
 # Utilities
 anyhow = "1.0"

--- a/crates/arf-console/src/history/search.rs
+++ b/crates/arf-console/src/history/search.rs
@@ -5,9 +5,29 @@
 
 use crate::fuzzy::fuzzy_match;
 use reedline::{
-    History, HistoryItem, HistoryItemId, HistorySessionId, Result, SearchFilter, SearchQuery,
-    SqliteBackedHistory,
+    History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId,
+    IgnoreAllExtraInfo, Result, SearchFilter, SearchQuery, SqliteBackedHistory,
 };
+
+use super::storage::HistoryExtraInfo;
+
+/// Convert a `HistoryItem<A>` to `HistoryItem<B>` by replacing the `more_info` field.
+fn with_extra<A: HistoryItemExtraInfo, B: HistoryItemExtraInfo>(
+    h: HistoryItem<A>,
+    more_info: Option<B>,
+) -> HistoryItem<B> {
+    HistoryItem {
+        id: h.id,
+        start_timestamp: h.start_timestamp,
+        command_line: h.command_line,
+        session_id: h.session_id,
+        hostname: h.hostname,
+        cwd: h.cwd,
+        duration: h.duration,
+        exit_status: h.exit_status,
+        more_info,
+    }
+}
 
 /// A wrapper around `SqliteBackedHistory` that provides fuzzy search capabilities.
 ///
@@ -95,9 +115,6 @@ impl FuzzyHistory {
 
 impl History for FuzzyHistory {
     fn save(&mut self, mut h: HistoryItem) -> Result<HistoryItem> {
-        // TODO: Once reedline's History trait accepts HistoryItem<HistoryExtraInfo>,
-        // populate h.more_info with metadata (meta_command flag, reprex output, etc.).
-        // Populate metadata if not already set
         if h.start_timestamp.is_none() {
             h.start_timestamp = Some(chrono::Utc::now());
         }
@@ -109,7 +126,16 @@ impl History for FuzzyHistory {
         if h.hostname.is_none() {
             h.hostname = Some(gethostname::gethostname().to_string_lossy().into_owned());
         }
-        self.inner.save(h)
+        let is_meta = h.command_line.trim().starts_with(':');
+        let typed = with_extra(
+            h,
+            Some(HistoryExtraInfo {
+                meta_command: is_meta,
+                ..Default::default()
+            }),
+        );
+        let result = self.inner.save_with_extra(typed)?;
+        Ok(with_extra(result, None::<IgnoreAllExtraInfo>))
     }
 
     fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -12,6 +12,7 @@ use super::{
     with_alternate_screen,
 };
 use crate::fuzzy::fuzzy_match;
+use crate::history::HistoryExtraInfo;
 use chrono::TimeZone;
 use crossterm::{
     ExecutableCommand, cursor,
@@ -78,6 +79,9 @@ struct HistoryFilter {
     cwd_prefix: Option<String>,
     /// Exit status filter (from `exit:N`).
     exit_status: Option<i64>,
+    /// Meta command filter (from `meta:no` or `meta:only`).
+    /// None = show all, Some(false) = exclude meta, Some(true) = show only meta.
+    meta: Option<bool>,
     /// Command pattern for fuzzy search (remaining text after prefix filters).
     command_pattern: String,
 }
@@ -104,6 +108,10 @@ impl HistoryFilter {
                 } else {
                     remaining_parts.push(part);
                 }
+            } else if part == "meta:no" {
+                filter.meta = Some(false);
+            } else if part == "meta:only" {
+                filter.meta = Some(true);
             } else {
                 remaining_parts.push(part);
             }
@@ -120,6 +128,7 @@ impl HistoryFilter {
         self.hostname = parsed.hostname;
         self.cwd_prefix = parsed.cwd_prefix;
         self.exit_status = parsed.exit_status;
+        self.meta = parsed.meta;
         self.command_pattern = parsed.command_pattern;
     }
 }
@@ -128,6 +137,8 @@ impl HistoryFilter {
 struct BrowsableHistoryItem {
     /// The actual history item.
     item: HistoryItem,
+    /// Whether this entry was saved as a meta command (`:cd`, `:help`, etc.).
+    is_meta: bool,
     /// Whether this item is selected for deletion.
     selected: bool,
 }
@@ -164,11 +175,12 @@ struct HistoryBrowser {
 
 impl HistoryBrowser {
     /// Create a new history browser.
-    fn new(entries: Vec<HistoryItem>, db_mode: HistoryDbMode, db_path: PathBuf) -> Self {
+    fn new(entries: Vec<(HistoryItem, bool)>, db_mode: HistoryDbMode, db_path: PathBuf) -> Self {
         let browsable: Vec<BrowsableHistoryItem> = entries
             .into_iter()
-            .map(|item| BrowsableHistoryItem {
+            .map(|(item, is_meta)| BrowsableHistoryItem {
                 item,
+                is_meta,
                 selected: false,
             })
             .collect();
@@ -197,6 +209,7 @@ impl HistoryBrowser {
             && self.filter.hostname.is_none()
             && self.filter.cwd_prefix.is_none()
             && self.filter.exit_status.is_none()
+            && self.filter.meta.is_none()
         {
             // No filter - show all entries
             self.filtered = self
@@ -211,6 +224,13 @@ impl HistoryBrowser {
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, entry)| {
+                    // Apply meta command filter
+                    if let Some(want_meta) = self.filter.meta {
+                        if entry.is_meta != want_meta {
+                            return None;
+                        }
+                    }
+
                     // Apply hostname filter
                     if let Some(ref hostname) = self.filter.hostname {
                         if let Some(ref item_host) = entry.item.hostname {
@@ -948,7 +968,8 @@ impl HistoryBrowser {
 
         // Footer line 1: filter syntax help
         stdout.execute(terminal::Clear(ClearType::CurrentLine))?;
-        let syntax_help = "  Filter: host:<name> cwd:<path> exit:<N> <text>  (space = AND)";
+        let syntax_help =
+            "  Filter: host:<name> cwd:<path> exit:<N> meta:no meta:only <text>  (space = AND)";
         println!("\r{}", pad_to_width(syntax_help, width).dark_grey());
 
         // Footer line 2: keybindings or feedback message
@@ -981,16 +1002,15 @@ impl HistoryBrowser {
 /// Using read-only mode avoids WAL (Write-Ahead Logging) conflicts with the
 /// main REPL's history connection. This prevents "database disk image is malformed"
 /// errors when browsing history while the REPL is actively using the database.
-fn load_history(db_path: &Path) -> io::Result<Vec<HistoryItem>> {
+fn load_history(db_path: &Path) -> io::Result<Vec<(HistoryItem, bool)>> {
     // Open in read-only mode to avoid WAL conflicts
     let db = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .map_err(io::Error::other)?;
 
     let mut stmt = db
         .prepare(
-            "SELECT id, command_line, start_timestamp, hostname, cwd, duration_ms, exit_status
+            "SELECT id, command_line, start_timestamp, hostname, cwd, duration_ms, exit_status, more_info
              FROM history
-             WHERE (more_info IS NULL OR json_extract(more_info, '$.meta_command') IS NOT 1)
              ORDER BY id DESC
              LIMIT ?",
         )
@@ -998,22 +1018,31 @@ fn load_history(db_path: &Path) -> io::Result<Vec<HistoryItem>> {
 
     let items = stmt
         .query_map([MAX_ENTRIES], |row| {
-            Ok(HistoryItem {
-                id: Some(HistoryItemId::new(row.get(0)?)),
-                command_line: row.get(1)?,
-                start_timestamp: row
-                    .get::<_, Option<i64>>(2)?
-                    .and_then(|ms| chrono::Utc.timestamp_millis_opt(ms).single()),
-                session_id: None,
-                hostname: row.get(3)?,
-                cwd: row.get(4)?,
-                duration: row
-                    .get::<_, Option<i64>>(5)?
-                    .and_then(|ms| u64::try_from(ms).ok())
-                    .map(std::time::Duration::from_millis),
-                exit_status: row.get(6)?,
-                more_info: None,
-            })
+            let more_info_json: Option<String> = row.get(7)?;
+            let is_meta = more_info_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<HistoryExtraInfo>(s).ok())
+                .map(|e| e.meta_command)
+                .unwrap_or(false);
+            Ok((
+                HistoryItem {
+                    id: Some(HistoryItemId::new(row.get(0)?)),
+                    command_line: row.get(1)?,
+                    start_timestamp: row
+                        .get::<_, Option<i64>>(2)?
+                        .and_then(|ms| chrono::Utc.timestamp_millis_opt(ms).single()),
+                    session_id: None,
+                    hostname: row.get(3)?,
+                    cwd: row.get(4)?,
+                    duration: row
+                        .get::<_, Option<i64>>(5)?
+                        .and_then(|ms| u64::try_from(ms).ok())
+                        .map(std::time::Duration::from_millis),
+                    exit_status: row.get(6)?,
+                    more_info: None,
+                },
+                is_meta,
+            ))
         })
         .map_err(io::Error::other)?
         .collect::<Result<Vec<_>, _>>()
@@ -1075,6 +1104,7 @@ pub fn run_history_browser(
     }
 
     let mut browser = HistoryBrowser::new(entries, mode, db_path.to_path_buf());
+
     browser.run()
 }
 
@@ -1265,12 +1295,12 @@ mod tests {
         let items = load_history(&db_path).unwrap();
         assert_eq!(items.len(), 3);
         // Descending order by id
-        assert_eq!(items[0].command_line, "third_cmd");
-        assert_eq!(items[1].command_line, "second_cmd");
-        assert_eq!(items[2].command_line, "first_cmd");
+        assert_eq!(items[0].0.command_line, "third_cmd");
+        assert_eq!(items[1].0.command_line, "second_cmd");
+        assert_eq!(items[2].0.command_line, "first_cmd");
         // Hostname preserved
-        assert_eq!(items[1].hostname.as_deref(), Some("host2"));
-        assert!(items[0].hostname.is_none());
+        assert_eq!(items[1].0.hostname.as_deref(), Some("host2"));
+        assert!(items[0].0.hostname.is_none());
     }
 
     #[test]
@@ -1281,11 +1311,10 @@ mod tests {
     }
 
     #[test]
-    fn test_load_history_excludes_meta_commands() {
+    fn test_load_history_is_meta_flag() {
         let (_dir, db_path) =
             create_test_db(&[("print(1)", None), (":help", None), ("summary(df)", None)]);
 
-        // Manually set more_info for the meta command entry
         let db = Connection::open(&db_path).unwrap();
         db.execute(
             "UPDATE history SET more_info = '{\"meta_command\":true}' WHERE command_line = ':help'",
@@ -1294,16 +1323,82 @@ mod tests {
         .unwrap();
 
         let items = load_history(&db_path).unwrap();
-        assert_eq!(items.len(), 2);
-        assert!(items.iter().all(|i| i.command_line != ":help"));
+        // All 3 entries are loaded (no SQL-level exclusion)
+        assert_eq!(items.len(), 3);
+        // The :help entry has is_meta = true
+        let meta_entry = items
+            .iter()
+            .find(|(h, _)| h.command_line == ":help")
+            .unwrap();
+        assert!(meta_entry.1);
+        // Other entries have is_meta = false
+        let normal_entry = items
+            .iter()
+            .find(|(h, _)| h.command_line == "print(1)")
+            .unwrap();
+        assert!(!normal_entry.1);
     }
 
     #[test]
-    fn test_load_history_includes_old_entries_without_more_info() {
+    fn test_load_history_old_entries_without_more_info_not_meta() {
         let (_dir, db_path) = create_test_db(&[("old_cmd", None), (":cd /tmp", None)]);
-        // Neither entry has more_info set — both should be included
+        // Neither entry has more_info set — both should load with is_meta = false
         let items = load_history(&db_path).unwrap();
         assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|(_, is_meta)| !is_meta));
+    }
+
+    #[test]
+    fn test_update_filter_meta_no_excludes_meta_commands() {
+        let (_dir, db_path) =
+            create_test_db(&[("print(1)", None), (":help", None), ("summary(df)", None)]);
+
+        let db = Connection::open(&db_path).unwrap();
+        db.execute(
+            "UPDATE history SET more_info = '{\"meta_command\":true}' WHERE command_line = ':help'",
+            [],
+        )
+        .unwrap();
+
+        let entries = load_history(&db_path).unwrap();
+        let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, db_path.clone());
+
+        // Apply meta:no filter
+        browser.filter = HistoryFilter::parse("meta:no");
+        browser.update_filter();
+
+        assert_eq!(browser.filtered.len(), 2);
+        assert!(
+            browser
+                .filtered
+                .iter()
+                .all(|&(idx, _)| browser.entries[idx].item.command_line != ":help")
+        );
+    }
+
+    #[test]
+    fn test_update_filter_meta_only_shows_only_meta() {
+        let (_dir, db_path) =
+            create_test_db(&[("print(1)", None), (":help", None), ("summary(df)", None)]);
+
+        let db = Connection::open(&db_path).unwrap();
+        db.execute(
+            "UPDATE history SET more_info = '{\"meta_command\":true}' WHERE command_line = ':help'",
+            [],
+        )
+        .unwrap();
+
+        let entries = load_history(&db_path).unwrap();
+        let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, db_path.clone());
+
+        browser.filter = HistoryFilter::parse("meta:only");
+        browser.update_filter();
+
+        assert_eq!(browser.filtered.len(), 1);
+        assert_eq!(
+            browser.entries[browser.filtered[0].0].item.command_line,
+            ":help"
+        );
     }
 
     #[test]
@@ -1330,7 +1425,7 @@ mod tests {
         // Verify database state
         let remaining = load_history(&db_path).unwrap();
         assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].command_line, "cmd_b");
+        assert_eq!(remaining[0].0.command_line, "cmd_b");
     }
 
     #[test]

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -990,6 +990,7 @@ fn load_history(db_path: &Path) -> io::Result<Vec<HistoryItem>> {
         .prepare(
             "SELECT id, command_line, start_timestamp, hostname, cwd, duration_ms, exit_status
              FROM history
+             WHERE (more_info IS NULL OR json_extract(more_info, '$.meta_command') IS NOT 1)
              ORDER BY id DESC
              LIMIT ?",
         )
@@ -1277,6 +1278,32 @@ mod tests {
         let (_dir, db_path) = create_test_db(&[]);
         let items = load_history(&db_path).unwrap();
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_load_history_excludes_meta_commands() {
+        let (_dir, db_path) =
+            create_test_db(&[("print(1)", None), (":help", None), ("summary(df)", None)]);
+
+        // Manually set more_info for the meta command entry
+        let db = Connection::open(&db_path).unwrap();
+        db.execute(
+            "UPDATE history SET more_info = '{\"meta_command\":true}' WHERE command_line = ':help'",
+            [],
+        )
+        .unwrap();
+
+        let items = load_history(&db_path).unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| i.command_line != ":help"));
+    }
+
+    #[test]
+    fn test_load_history_includes_old_entries_without_more_info() {
+        let (_dir, db_path) = create_test_db(&[("old_cmd", None), (":cd /tmp", None)]);
+        // Neither entry has more_info set — both should be included
+        let items = load_history(&db_path).unwrap();
+        assert_eq!(items.len(), 2);
     }
 
     #[test]

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -225,10 +225,10 @@ impl HistoryBrowser {
                 .enumerate()
                 .filter_map(|(idx, entry)| {
                     // Apply meta command filter
-                    if let Some(want_meta) = self.filter.meta {
-                        if entry.is_meta != want_meta {
-                            return None;
-                        }
+                    if let Some(want_meta) = self.filter.meta
+                        && entry.is_meta != want_meta
+                    {
+                        return None;
                     }
 
                     // Apply hostname filter


### PR DESCRIPTION
## Summary

- Upgrade reedline to git rev `32f80f4` (pre-release adding `SqliteBackedHistory::save_with_extra` / `search_with_extra`) and rusqlite from 0.37 to 0.40.1 to match
- Add `with_extra<A,B>()` helper to convert `HistoryItem` between `ExtraInfo` types without cloning
- `FuzzyHistory::save()` now calls `save_with_extra::<HistoryExtraInfo>()`, setting `meta_command: true` for commands starting with `:`
- History browser (`load_history`) reads the `more_info` JSON column and parses `is_meta` in Rust (safe fallback to `false` for NULL or malformed JSON)
- Add filter keywords to the history browser: `meta:no` (exclude meta commands) and `meta:only` (show only meta commands)

## Notes

- The reedline git dependency is temporary. Once the upstream PR is released to crates.io, revert to a version dependency.
- Ctrl+R fuzzy search intentionally remains unaffected (uses `IgnoreAllExtraInfo` as before).
- `search_typed()` is out of scope for this PR.

## Test plan

- [x] `cargo test` passes (786+ unit + integration tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] Manual: run arf, execute some `:cd`, `:help` commands, open `:history` browser, verify they appear by default and disappear with `meta:no` filter
- [ ] Manual: verify `meta:only` shows only meta commands