### PR TITLE
fix: bump rd2qmd-core to 0.3.0 to strip \if{html} content in help browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- The help browser (`:help`) no longer leaks raw HTML tags (e.g. `<div class="asciicast">`, `<span style="...">`) from `\if{html}{\out{...}}` blocks in Rd documentation, which made some help pages (e.g. `pak::FAQ`) unreadable. Fixed by upgrading `rd2qmd-core` to 0.3.0, which now skips `\if{html}` content when converting for terminal display.
+- The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable.
 
 ## [0.4.3-rc.1] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The help browser (`:help`) no longer leaks raw HTML tags (e.g. `<div class="asciicast">`, `<span style="...">`) from `\if{html}{\out{...}}` blocks in Rd documentation, which made some help pages (e.g. `pak::FAQ`) unreadable. Fixed by upgrading `rd2qmd-core` to 0.3.0, which now skips `\if{html}` content when converting for terminal display.
+
 ## [0.4.3-rc.1] - 2026-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ name = "arf-harp"
 version = "0.4.3-rc.1"
 dependencies = [
  "arf-libr",
+ "insta",
  "log",
  "once_cell",
  "r-vignette-to-md",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "rd-parser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7501e3cf45bd0b865452a615ff1fd1a8dec4ea64cbcdf08e99f16d678fa32d"
+checksum = "d84eca374ec208e9a5981ae18ff0d1c716a5d220f8709e345f4c739dcfe6ca9e"
 dependencies = [
  "serde",
  "serde_json",
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c41a610e9703358825d50aca3e67eab2a6bd27a529a57720465b1fcf23b277"
+checksum = "788502351754ac38e83fc4b1919a2702b6785e53bbd5bc3a7cac5a5cd7c6a7e9"
 dependencies = [
  "rd-parser",
  "rd2qmd-mdast",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767ad0400de39d8f73d07229c2472fa20f76c578fac2bda5d4a03a55c2e999a6"
+checksum = "62004656e50ca93c433fdaa93c3cd62abfc71ad952d02dce355eda406f1c3898"
 dependencies = [
  "serde",
 ]
@@ -1752,7 +1752,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
  "testing_table",
@@ -2121,7 +2121,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.2"
 
 # Rd to Markdown conversion
-rd2qmd-core = { version = "0.2.0", features = ["roxygen"] }
+rd2qmd-core = { version = "0.3.0", features = ["roxygen"] }
 
 # Markdown parsing
 pulldown-cmark = "0.13"

--- a/crates/arf-harp/Cargo.toml
+++ b/crates/arf-harp/Cargo.toml
@@ -8,6 +8,7 @@ description = "High-level R abstractions for safe R object manipulation"
 
 [dev-dependencies]
 tempfile.workspace = true
+insta.workspace = true
 
 [dependencies]
 arf-libr.workspace = true

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -566,8 +566,8 @@ More text after.
             .unwrap();
 
         assert!(
-            !qmd.contains("<div") && !qmd.contains("<span"),
-            "expected \\if{{html}} content to be stripped, got: {qmd}"
+            !qmd.contains("asciicast") && !qmd.contains("colored"),
+            "expected entire \\if{{html}} block (tags and text) to be stripped, got: {qmd}"
         );
         assert!(qmd.contains("Some details."));
         assert!(qmd.contains("More text after."));

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -566,7 +566,12 @@ More text after.
             .unwrap();
 
         assert!(
-            !qmd.contains("asciicast") && !qmd.contains("colored"),
+            !qmd.contains("asciicast")
+                && !qmd.contains("colored")
+                && !qmd.contains("<div")
+                && !qmd.contains("<span")
+                && !qmd.contains("</div>")
+                && !qmd.contains("</span>"),
             "expected entire \\if{{html}} block (tags and text) to be stripped, got: {qmd}"
         );
         assert!(qmd.contains("Some details."));

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -548,6 +548,9 @@ mod tests {
     fn test_rd_conversion_strips_if_html_content() {
         // Regression test: `\if{html}{\out{...}}` blocks (e.g. asciicast
         // recordings) must not leak raw HTML into terminal help output.
+        // Snapshotting the full output (rather than asserting individual
+        // substrings) ensures any leaked tag, attribute, or inner text
+        // shows up as a diff.
         let rd_content = r#"
 \name{hello}
 \title{Hello World}
@@ -565,16 +568,6 @@ More text after.
             .convert()
             .unwrap();
 
-        assert!(
-            !qmd.contains("asciicast")
-                && !qmd.contains("colored")
-                && !qmd.contains("<div")
-                && !qmd.contains("<span")
-                && !qmd.contains("</div>")
-                && !qmd.contains("</span>"),
-            "expected entire \\if{{html}} block (tags and text) to be stripped, got: {qmd}"
-        );
-        assert!(qmd.contains("Some details."));
-        assert!(qmd.contains("More text after."));
+        insta::assert_snapshot!("rd_conversion_strips_if_html_content", qmd);
     }
 }

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -543,4 +543,33 @@ mod tests {
         assert_eq!(escape_r_string(r#"he"llo"#), r#"he\"llo"#);
         assert_eq!(escape_r_string("he\\llo"), "he\\\\llo");
     }
+
+    #[test]
+    fn test_rd_conversion_strips_if_html_content() {
+        // Regression test: `\if{html}{\out{...}}` blocks (e.g. asciicast
+        // recordings) must not leak raw HTML into terminal help output.
+        let rd_content = r#"
+\name{hello}
+\title{Hello World}
+\description{A simple function.}
+\details{
+Some details.
+\if{html}{\out{<div class="asciicast"><span style="color: red;">colored</span></div>}}
+More text after.
+}
+"#;
+
+        let qmd = rd2qmd_core::RdConverter::new(rd_content)
+            .quarto_code_blocks(false)
+            .arguments_format(rd2qmd_core::ArgumentsFormat::PipeTable)
+            .convert()
+            .unwrap();
+
+        assert!(
+            !qmd.contains("<div") && !qmd.contains("<span"),
+            "expected \\if{{html}} content to be stripped, got: {qmd}"
+        );
+        assert!(qmd.contains("Some details."));
+        assert!(qmd.contains("More text after."));
+    }
 }

--- a/crates/arf-harp/src/snapshots/arf_harp__help__tests__rd_conversion_strips_if_html_content.snap
+++ b/crates/arf-harp/src/snapshots/arf_harp__help__tests__rd_conversion_strips_if_html_content.snap
@@ -1,0 +1,13 @@
+---
+source: crates/arf-harp/src/help.rs
+expression: qmd
+---
+# Hello World
+
+## Description
+
+A simple function.
+
+## Details
+
+ Some details.  More text after.


### PR DESCRIPTION
## Summary
- Bumps `rd2qmd-core` to 0.3.0, which now excludes `\if{html}{\out{...}}` content (e.g. asciicast recordings) when converting Rd help pages for terminal display. Previously these blocks leaked raw HTML tags into the help browser, making some pages (e.g. `pak::FAQ`) unreadable.
- Adds an insta snapshot regression test covering `\if{html}` stripping.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo fmt --check`
- [x] Manually converted `pak::FAQ`'s Rd file with rd2qmd-core 0.2.0 vs 0.3.0 and confirmed the leaked `<div class="asciicast">` / `<span style="...">` tags are gone in 0.3.0