### PR TITLE
fix: install SIGINT handler on Unix to interrupt R instead of exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable.
+- On macOS/Linux, Ctrl+C (SIGINT) during R evaluation no longer risks silently terminating the session. The addresses of R's state variables (`R_Interactive`, `R_SignalHandlers`, `R_running_as_main_program`, `R_interrupts_pending`) were silently failing to resolve on Unix, so R's signal handlers were never disabled as intended and arf itself installed no SIGINT handler. The lookups are fixed and a Ctrl+C handler is now installed on all platforms (previously Windows-only) that requests an R interrupt instead of letting the default action kill the process. A SIGINT delivered while waiting at the prompt is now dropped instead of being carried over or crossing Rust frames via R's `onintr` longjmp.
 
 ## [0.4.3-rc.1] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable.
-- On macOS/Linux, Ctrl+C (SIGINT) during R evaluation no longer risks silently terminating the session. The addresses of R's state variables (`R_Interactive`, `R_SignalHandlers`, `R_running_as_main_program`, `R_interrupts_pending`) were silently failing to resolve on Unix, so R's signal handlers were never disabled as intended and arf itself installed no SIGINT handler. The lookups are fixed and a Ctrl+C handler is now installed on all platforms (previously Windows-only) that requests an R interrupt instead of letting the default action kill the process. A SIGINT delivered while waiting at the prompt is now dropped instead of being carried over or crossing Rust frames via R's `onintr` longjmp.
+- On macOS/Linux, Ctrl+C (SIGINT) delivered during R evaluation could terminate the session instead of cancelling the running computation. Ctrl+C now interrupts the evaluation and returns to the prompt, as on Windows.
 
 ## [0.4.3-rc.1] - 2026-06-30
 

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -551,6 +551,15 @@ fn run() -> Result<()> {
     let r_args_refs: Vec<&str> = r_args.iter().map(|s| s.as_str()).collect();
     log::debug!("R args: {:?}", r_args);
 
+    // Install the Ctrl+C handler before R initialization: startup profiles
+    // run inside setup_Rmainloop, and with R_SignalHandlers = 0 a SIGINT
+    // during a slow .Rprofile would otherwise hit the default action and
+    // kill the process. The handler is a no-op until the interrupt flag
+    // pointer is resolved, which happens early in initialization, before
+    // profiles are evaluated (see install_r_interrupt_handler).
+    #[cfg(unix)]
+    repl::install_r_interrupt_handler();
+
     // Initialize R with CLI-specified flags
     log::info!("Initializing R...");
     #[allow(unused_variables)]
@@ -568,6 +577,31 @@ fn run() -> Result<()> {
             }
         }
     };
+
+    // If the interrupt flag could not be resolved, the handler installed
+    // above can never forward interrupts and would swallow Ctrl+C forever;
+    // fall back to the default disposition (terminate the process).
+    #[cfg(unix)]
+    if !arf_libr::is_r_interrupt_flag_available() {
+        log::warn!(
+            "R interrupt flag not available; restoring default Ctrl+C behavior \
+             (terminates the process)."
+        );
+        repl::restore_default_sigint_handler();
+    }
+
+    // Windows: install the Ctrl+C handler now, before profiles are sourced
+    // below, so a SIGINT during a slow .Rprofile interrupts it instead of
+    // killing the process (STATUS_CONTROL_C_EXIT).
+    #[cfg(windows)]
+    if arf_libr::is_r_interrupt_flag_available() {
+        repl::install_r_interrupt_handler();
+    } else {
+        log::warn!(
+            "R interrupt flag not available; skipping Ctrl+C handler installation. \
+             Default console handler will terminate the process on Ctrl+C."
+        );
+    }
 
     // Source R profile files after R initialization (Windows only)
     // On Windows, R's built-in profile loading is disabled during initialization

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -578,14 +578,18 @@ fn run() -> Result<()> {
         }
     };
 
-    // If the interrupt flag could not be resolved, the handler installed
-    // above can never forward interrupts and would swallow Ctrl+C forever;
-    // fall back to the default disposition (terminate the process).
+    // If R initialization failed or the interrupt flag could not be
+    // resolved, the handler installed above can never forward interrupts to
+    // anything that consumes them and would swallow Ctrl+C forever; fall
+    // back to the default disposition (terminate the process). The
+    // r_initialized check matters even when the flag resolved: the flag
+    // pointer is stored early in initialization, so a later failure would
+    // otherwise leave the forwarding handler active with R disabled.
     #[cfg(unix)]
-    if !arf_libr::is_r_interrupt_flag_available() {
+    if !r_initialized || !arf_libr::is_r_interrupt_flag_available() {
         log::warn!(
-            "R interrupt flag not available; restoring default Ctrl+C behavior \
-             (terminates the process)."
+            "R initialization failed or interrupt flag not available; restoring \
+             default Ctrl+C behavior (terminates the process)."
         );
         repl::restore_default_sigint_handler();
     }

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -503,11 +503,15 @@ impl Repl {
         // Set up the ReadConsole callback
         arf_libr::set_read_console_callback(read_console_callback);
 
-        // Windows: Install Ctrl+C handler to interrupt R evaluation.
-        // Without this, Ctrl+C during R eval terminates the process (STATUS_CONTROL_C_EXIT).
-        // The handler sets R's UserBreak flag; R checks it periodically and interrupts.
-        // On Unix, R's mainloop installs its own SIGINT handler, so we don't interfere.
-        #[cfg(windows)]
+        // Install Ctrl+C handler to interrupt R evaluation.
+        // Without this, Ctrl+C during R eval terminates the process: we set
+        // R_SignalHandlers = 0, so R installs no SIGINT handler itself and the
+        // default action kills the process (on Unix, R_SelectEx only installs a
+        // temporary handler while blocked in select(), leaving a fatal window
+        // between calls; on Windows, STATUS_CONTROL_C_EXIT).
+        // The handler sets R's interrupt flag (R_interrupts_pending / UserBreak),
+        // which R checks periodically (R_CheckUserInterrupt, R_SelectEx) and
+        // turns into an interrupt condition via onintr().
         if arf_libr::is_r_interrupt_flag_available() {
             if let Err(e) = ctrlc::set_handler(|| {
                 arf_libr::set_r_interrupt_pending();

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -511,10 +511,47 @@ impl Repl {
         // between calls; on Windows, STATUS_CONTROL_C_EXIT).
         // The handler sets R's interrupt flag (R_interrupts_pending / UserBreak),
         // which R checks periodically (R_CheckUserInterrupt, R_SelectEx) and
-        // turns into an interrupt condition via onintr().
+        // turns into an interrupt condition via onintr() — but only while R is
+        // evaluating: while ReadConsole waits for input there is nothing to
+        // interrupt, and a flag observed by the event polling done from the
+        // input-waiting loops would make onintr() longjmp through their Rust
+        // frames, so the handler drops the signal instead.
         if arf_libr::is_r_interrupt_flag_available() {
+            // Unix: register a SIGINT-only sigaction instead of using ctrlc.
+            // The workspace builds ctrlc with the "termination" feature (for
+            // headless graceful shutdown), so ctrlc::set_handler would also
+            // capture SIGTERM/SIGHUP and an interactive session could no
+            // longer be terminated by them.
+            #[cfg(unix)]
+            {
+                use nix::sys::signal;
+
+                extern "C" fn handle_sigint(_signum: std::ffi::c_int) {
+                    // Async-signal-safe: one atomic load, then an atomic load
+                    // plus a volatile write. Must not panic or allocate.
+                    if !arf_libr::is_r_awaiting_console_input() {
+                        arf_libr::set_r_interrupt_pending();
+                    }
+                }
+
+                // SA_RESTART so blocking syscalls interrupted by the signal
+                // are transparently restarted (as ctrlc does).
+                let action = signal::SigAction::new(
+                    signal::SigHandler::Handler(handle_sigint),
+                    signal::SaFlags::SA_RESTART,
+                    signal::SigSet::empty(),
+                );
+                // SAFETY: handle_sigint is async-signal-safe (see above).
+                if let Err(e) = unsafe { signal::sigaction(signal::Signal::SIGINT, &action) } {
+                    log::warn!("Could not set Ctrl+C handler: {e}");
+                }
+            }
+
+            #[cfg(windows)]
             if let Err(e) = ctrlc::set_handler(|| {
-                arf_libr::set_r_interrupt_pending();
+                if !arf_libr::is_r_awaiting_console_input() {
+                    arf_libr::set_r_interrupt_pending();
+                }
             }) {
                 log::warn!("Could not set Ctrl+C handler: {e}");
             }

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -104,6 +104,91 @@ fn sync_r_width() {
     }
 }
 
+/// Install the Ctrl+C handler that forwards interrupts to R.
+///
+/// Without this, Ctrl+C during R evaluation terminates the process: we set
+/// R_SignalHandlers = 0, so R installs no SIGINT handler itself and the
+/// default action kills the process (on Unix, R_SelectEx only installs a
+/// temporary handler while blocked in select(), leaving a fatal window
+/// between calls; on Windows, STATUS_CONTROL_C_EXIT).
+/// The handler sets R's interrupt flag (R_interrupts_pending / UserBreak),
+/// which R checks periodically (R_CheckUserInterrupt, R_SelectEx) and
+/// turns into an interrupt condition via onintr() — but only while R is
+/// evaluating: while ReadConsole waits for input there is nothing to
+/// interrupt, and a flag observed by the event polling done from the
+/// input-waiting loops would make onintr() longjmp through their Rust
+/// frames, so the handler drops the signal instead.
+///
+/// On Unix, call this BEFORE R initialization: startup profiles run inside
+/// setup_Rmainloop, so installing later leaves a window where Ctrl+C during
+/// a slow .Rprofile kills the process. The interrupt flag pointer is
+/// resolved early in initialization (before profiles are evaluated); until
+/// then the handler is a no-op. If the flag is still unavailable after
+/// initialization, call [`restore_default_sigint_handler`] so Ctrl+C is not
+/// swallowed forever. On Windows, profiles are sourced manually after
+/// initialization, so call this between the two (gated on flag
+/// availability).
+pub(crate) fn install_r_interrupt_handler() {
+    // Unix: register a SIGINT-only sigaction instead of using ctrlc.
+    // The workspace builds ctrlc with the "termination" feature (for
+    // headless graceful shutdown), so ctrlc::set_handler would also
+    // capture SIGTERM/SIGHUP and an interactive session could no
+    // longer be terminated by them.
+    #[cfg(unix)]
+    {
+        use nix::sys::signal;
+
+        extern "C" fn handle_sigint(_signum: std::ffi::c_int) {
+            // Async-signal-safe: one atomic load, then an atomic load
+            // plus a volatile write. Must not panic or allocate.
+            if !arf_libr::is_r_awaiting_console_input() {
+                arf_libr::set_r_interrupt_pending();
+            }
+        }
+
+        // SA_RESTART so blocking syscalls interrupted by the signal
+        // are transparently restarted (as ctrlc does).
+        let action = signal::SigAction::new(
+            signal::SigHandler::Handler(handle_sigint),
+            signal::SaFlags::SA_RESTART,
+            signal::SigSet::empty(),
+        );
+        // SAFETY: handle_sigint is async-signal-safe (see above).
+        if let Err(e) = unsafe { signal::sigaction(signal::Signal::SIGINT, &action) } {
+            log::warn!("Could not set Ctrl+C handler: {e}");
+        }
+    }
+
+    #[cfg(windows)]
+    if let Err(e) = ctrlc::set_handler(|| {
+        if !arf_libr::is_r_awaiting_console_input() {
+            arf_libr::set_r_interrupt_pending();
+        }
+    }) {
+        log::warn!("Could not set Ctrl+C handler: {e}");
+    }
+}
+
+/// Restore the default SIGINT disposition (terminate the process).
+///
+/// Used when R's interrupt flag turns out to be unavailable after R
+/// initialization: the handler installed by [`install_r_interrupt_handler`]
+/// can never forward interrupts then, and would swallow Ctrl+C forever.
+#[cfg(unix)]
+pub(crate) fn restore_default_sigint_handler() {
+    use nix::sys::signal;
+
+    let action = signal::SigAction::new(
+        signal::SigHandler::SigDfl,
+        signal::SaFlags::empty(),
+        signal::SigSet::empty(),
+    );
+    // SAFETY: restores the default disposition; no handler code involved.
+    if let Err(e) = unsafe { signal::sigaction(signal::Signal::SIGINT, &action) } {
+        log::warn!("Could not restore default Ctrl+C handler: {e}");
+    }
+}
+
 /// Prefix for arf messages to distinguish them from R output.
 /// Uses R comment syntax so messages don't interfere with R code.
 pub(crate) const ARF_PREFIX: &str = "# [arf]";
@@ -503,64 +588,9 @@ impl Repl {
         // Set up the ReadConsole callback
         arf_libr::set_read_console_callback(read_console_callback);
 
-        // Install Ctrl+C handler to interrupt R evaluation.
-        // Without this, Ctrl+C during R eval terminates the process: we set
-        // R_SignalHandlers = 0, so R installs no SIGINT handler itself and the
-        // default action kills the process (on Unix, R_SelectEx only installs a
-        // temporary handler while blocked in select(), leaving a fatal window
-        // between calls; on Windows, STATUS_CONTROL_C_EXIT).
-        // The handler sets R's interrupt flag (R_interrupts_pending / UserBreak),
-        // which R checks periodically (R_CheckUserInterrupt, R_SelectEx) and
-        // turns into an interrupt condition via onintr() — but only while R is
-        // evaluating: while ReadConsole waits for input there is nothing to
-        // interrupt, and a flag observed by the event polling done from the
-        // input-waiting loops would make onintr() longjmp through their Rust
-        // frames, so the handler drops the signal instead.
-        if arf_libr::is_r_interrupt_flag_available() {
-            // Unix: register a SIGINT-only sigaction instead of using ctrlc.
-            // The workspace builds ctrlc with the "termination" feature (for
-            // headless graceful shutdown), so ctrlc::set_handler would also
-            // capture SIGTERM/SIGHUP and an interactive session could no
-            // longer be terminated by them.
-            #[cfg(unix)]
-            {
-                use nix::sys::signal;
-
-                extern "C" fn handle_sigint(_signum: std::ffi::c_int) {
-                    // Async-signal-safe: one atomic load, then an atomic load
-                    // plus a volatile write. Must not panic or allocate.
-                    if !arf_libr::is_r_awaiting_console_input() {
-                        arf_libr::set_r_interrupt_pending();
-                    }
-                }
-
-                // SA_RESTART so blocking syscalls interrupted by the signal
-                // are transparently restarted (as ctrlc does).
-                let action = signal::SigAction::new(
-                    signal::SigHandler::Handler(handle_sigint),
-                    signal::SaFlags::SA_RESTART,
-                    signal::SigSet::empty(),
-                );
-                // SAFETY: handle_sigint is async-signal-safe (see above).
-                if let Err(e) = unsafe { signal::sigaction(signal::Signal::SIGINT, &action) } {
-                    log::warn!("Could not set Ctrl+C handler: {e}");
-                }
-            }
-
-            #[cfg(windows)]
-            if let Err(e) = ctrlc::set_handler(|| {
-                if !arf_libr::is_r_awaiting_console_input() {
-                    arf_libr::set_r_interrupt_pending();
-                }
-            }) {
-                log::warn!("Could not set Ctrl+C handler: {e}");
-            }
-        } else {
-            log::warn!(
-                "R interrupt flag not available; skipping Ctrl+C handler installation. \
-                 Default console handler will terminate the process on Ctrl+C."
-            );
-        }
+        // Note: the Ctrl+C handler that forwards interrupts to R is installed
+        // in main() around R initialization (see install_r_interrupt_handler),
+        // so that startup profile evaluation is already covered.
 
         // Run R's main loop - this doesn't return until EOF
         unsafe {

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -143,6 +143,13 @@ pub struct RLibrary {
     #[cfg(windows)]
     pub user_break: *mut c_int,
 
+    // Interrupt suspension flag (R_interrupts_suspended, Rboolean, c_int-sized).
+    // Not part of R's documented API, but exposed by the installed header
+    // R_ext/GraphicsDevice.h (BEGIN_SUSPEND_INTERRUPTS) for third-party use
+    // and relied on by ark and reticulate. May be null if the symbol is
+    // ever removed; callers must handle that by skipping suspension.
+    pub r_interrupts_suspended: *mut c_int,
+
     // Windows CharacterMode global (used to switch from RGui to LinkDLL after init)
     #[cfg(windows)]
     pub character_mode: *mut c_int,
@@ -500,6 +507,13 @@ impl RLibrary {
                 .and_then(|s| s.try_as_raw_ptr())
                 .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
+            #[cfg(unix)]
+            let r_interrupts_suspended: *mut c_int = library
+                .get::<usize>(b"R_interrupts_suspended\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
+                .unwrap_or(std::ptr::null_mut());
 
             // On Windows, library.get::<T>() requires size_of::<T>() == size_of::<FARPROC>()
             // (pointer-sized). Using c_int (4 bytes) fails the size check on 64-bit Windows.
@@ -528,6 +542,13 @@ impl RLibrary {
             #[cfg(windows)]
             let user_break: *mut c_int = library
                 .get::<usize>(b"UserBreak\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
+                .unwrap_or(std::ptr::null_mut());
+            #[cfg(windows)]
+            let r_interrupts_suspended: *mut c_int = library
+                .get::<usize>(b"R_interrupts_suspended\0")
                 .ok()
                 .and_then(|s| s.try_as_raw_ptr())
                 .map(|p| p as *mut c_int)
@@ -632,6 +653,7 @@ impl RLibrary {
                 r_interrupts_pending,
                 #[cfg(windows)]
                 user_break,
+                r_interrupts_suspended,
                 #[cfg(windows)]
                 character_mode,
                 r_processevents,

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -467,26 +467,38 @@ impl RLibrary {
             };
 
             // Load R state variables (as raw pointers - these are global ints, not pointers)
-            // We need to get the address of these symbols, not their values
+            // We need to get the address of these symbols, not their values.
+            // library.get::<T>() requires size_of::<T>() to be pointer-sized
+            // (Symbol<T> transmutes the symbol address into T), so get::<c_int>
+            // always fails with IncompatibleSize on 64-bit targets. Use a
+            // pointer-sized type and try_as_raw_ptr() to get the symbol address.
             #[cfg(unix)]
             let r_interactive: *mut c_int = library
-                .get::<c_int>(b"R_Interactive\0")
-                .map(|s| s.into_raw().into_raw() as *mut c_int)
+                .get::<usize>(b"R_Interactive\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
             #[cfg(unix)]
             let r_signalhandlers: *mut c_int = library
-                .get::<c_int>(b"R_SignalHandlers\0")
-                .map(|s| s.into_raw().into_raw() as *mut c_int)
+                .get::<usize>(b"R_SignalHandlers\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
             #[cfg(unix)]
             let r_running_as_main_program: *mut c_int = library
-                .get::<c_int>(b"R_running_as_main_program\0")
-                .map(|s| s.into_raw().into_raw() as *mut c_int)
+                .get::<usize>(b"R_running_as_main_program\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
             #[cfg(unix)]
             let r_interrupts_pending: *mut c_int = library
-                .get::<c_int>(b"R_interrupts_pending\0")
-                .map(|s| s.into_raw().into_raw() as *mut c_int)
+                .get::<usize>(b"R_interrupts_pending\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
 
             // On Windows, library.get::<T>() requires size_of::<T>() == size_of::<FARPROC>()

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -136,10 +136,14 @@ pub struct RLibrary {
     pub r_signalhandlers: *mut c_int,
     pub r_running_as_main_program: *mut c_int,
 
-    // Interrupt pending flag
-    // Unix: R_interrupts_pending (c_int), Windows: UserBreak (Rboolean, c_int-sized)
-    #[cfg(unix)]
+    // Interrupt pending flag (R_interrupts_pending, c_int).
+    // On Unix this is what R's own SIGINT handler would set. On Windows the
+    // front-end break flag is UserBreak (below), but R_interrupts_pending is
+    // still where onintr() defers an interrupt that arrives while
+    // R_interrupts_suspended is set, so it must be clearable on both platforms.
     pub r_interrupts_pending: *mut c_int,
+    // Windows front-end break flag (UserBreak, Rboolean, c_int-sized).
+    // R_ProcessEvents consumes it and calls onintr().
     #[cfg(windows)]
     pub user_break: *mut c_int,
 
@@ -547,6 +551,13 @@ impl RLibrary {
                 .map(|p| p as *mut c_int)
                 .unwrap_or(std::ptr::null_mut());
             #[cfg(windows)]
+            let r_interrupts_pending: *mut c_int = library
+                .get::<usize>(b"R_interrupts_pending\0")
+                .ok()
+                .and_then(|s| s.try_as_raw_ptr())
+                .map(|p| p as *mut c_int)
+                .unwrap_or(std::ptr::null_mut());
+            #[cfg(windows)]
             let r_interrupts_suspended: *mut c_int = library
                 .get::<usize>(b"R_interrupts_suspended\0")
                 .ok()
@@ -649,7 +660,6 @@ impl RLibrary {
                 r_interactive,
                 r_signalhandlers,
                 r_running_as_main_program,
-                #[cfg(unix)]
                 r_interrupts_pending,
                 #[cfg(windows)]
                 user_break,

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -31,10 +31,10 @@ pub use sys::ensure_ld_library_path_with_pre_exec;
 pub use sys::{
     clear_r_interrupt_pending, clear_write_console_callback, command_had_error,
     ensure_ld_library_path, find_r_library, finish_ipc_capture, flush_reprex_buffer, get_r_home,
-    global_error_handler_code, initialize_r, initialize_r_with_args, is_r_interrupt_flag_available,
-    is_spinner_active, mark_error_condition, mark_global_error_handler_initialized, peek_r_event,
-    polled_events_for_repl, process_r_events, reset_command_error_state, restore_stderr,
-    run_r_mainloop, set_r_interrupt_pending, set_read_console_callback, set_reprex_mode,
-    set_spinner_color, set_spinner_frames, set_write_console_callback, start_ipc_capture,
-    start_spinner, stop_spinner, suppress_stderr,
+    global_error_handler_code, initialize_r, initialize_r_with_args, is_r_awaiting_console_input,
+    is_r_interrupt_flag_available, is_spinner_active, mark_error_condition,
+    mark_global_error_handler_initialized, peek_r_event, polled_events_for_repl, process_r_events,
+    reset_command_error_state, restore_stderr, run_r_mainloop, set_r_interrupt_pending,
+    set_read_console_callback, set_reprex_mode, set_spinner_color, set_spinner_frames,
+    set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
 };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -14,6 +14,16 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 /// - Windows: points to `UserBreak` (Rboolean, c_int-sized)
 static R_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut());
 
+/// Windows only: pointer to `R_interrupts_pending`, set during R initialization.
+///
+/// The Windows front-end break flag is `UserBreak` (stored in
+/// [`R_INTERRUPT_FLAG`]), but when an interrupt arrives while
+/// `R_interrupts_suspended` is set, `onintr()` defers it into
+/// `R_interrupts_pending` — a different variable. Clearing a stale interrupt
+/// on Windows therefore has to reset both.
+#[cfg(windows)]
+static R_DEFERRED_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut());
+
 /// True while `r_read_console` is waiting for console input.
 ///
 /// The Ctrl+C handler consults this to drop interrupts that arrive while no
@@ -35,8 +45,12 @@ static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
 ///
 /// Unlike R's `END_SUSPEND_INTERRUPTS`, the drop deliberately does NOT call
 /// `Rf_onintr()` for an interrupt that arrived while suspended: firing it
-/// would longjmp through the Rust caller. The still-pending flag is dropped
-/// by the next entry clear instead (interrupts make no sense at the prompt).
+/// would longjmp through the Rust caller. Instead, the drop clears the
+/// deferred pending flag while still suspended and only then restores the
+/// previous suspension state, so a deferred interrupt can neither fire here
+/// nor leak into the next R evaluation (interrupts make no sense at the
+/// prompt). On Windows this matters doubly: onintr() defers into
+/// `R_interrupts_pending`, which is a different variable from `UserBreak`.
 ///
 /// `R_interrupts_suspended` is not part of R's documented API (see the
 /// comment on `RLibrary::r_interrupts_suspended`); when the symbol is
@@ -66,6 +80,11 @@ impl SuspendRInterruptsGuard {
 
 impl Drop for SuspendRInterruptsGuard {
     fn drop(&mut self) {
+        // Drop any interrupt deferred while suspended, before lifting the
+        // suspension: after this point no R code runs that could convert or
+        // defer flags, so the clear cannot race with R itself.
+        clear_r_interrupt_pending();
+
         if !self.ptr.is_null() {
             // SAFETY: see SuspendRInterruptsGuard::new.
             unsafe {
@@ -1027,6 +1046,12 @@ unsafe fn initialize_r_windows(lib: &crate::functions::RLibrary, r_args: &[&str]
         // Store the interrupt flag pointer for use by the Ctrl+C handler
         if !lib.user_break.is_null() {
             R_INTERRUPT_FLAG.store(lib.user_break, Ordering::Release);
+        }
+
+        // Store the deferred interrupt flag pointer so stale interrupts
+        // deferred under R_interrupts_suspended can be cleared too
+        if !lib.r_interrupts_pending.is_null() {
+            R_DEFERRED_INTERRUPT_FLAG.store(lib.r_interrupts_pending, Ordering::Release);
         }
 
         // Step 1: Call cmdlineoptions with empty args (ark pattern)
@@ -2336,11 +2361,25 @@ pub fn is_r_awaiting_console_input() -> bool {
 /// Called at the start of every `ReadConsole` invocation (including nested
 /// prompts such as `readline()`, `browser()`, etc.) to prevent stale
 /// interrupt flags from triggering on the next evaluation.
+///
+/// On Windows this clears both `UserBreak` (the front-end break flag) and
+/// `R_interrupts_pending` (where `onintr()` defers an interrupt that arrives
+/// while `R_interrupts_suspended` is set). On Unix they are the same flag.
 pub fn clear_r_interrupt_pending() {
     let ptr = R_INTERRUPT_FLAG.load(Ordering::Acquire);
     if !ptr.is_null() {
         unsafe {
             std::ptr::write_volatile(ptr, 0);
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let ptr = R_DEFERRED_INTERRUPT_FLAG.load(Ordering::Acquire);
+        if !ptr.is_null() {
+            unsafe {
+                std::ptr::write_volatile(ptr, 0);
+            }
         }
     }
 }

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -7,7 +7,7 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
 /// Pointer to R's interrupt pending flag, set during R initialization.
 /// - Unix: points to `R_interrupts_pending` (c_int)
@@ -24,14 +24,19 @@ static R_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut())
 #[cfg(windows)]
 static R_DEFERRED_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut());
 
-/// True while `r_read_console` is waiting for console input.
+/// Number of active `r_read_console` calls waiting for console input.
 ///
 /// The Ctrl+C handler consults this to drop interrupts that arrive while no
 /// R computation is running: if R's interrupt flag were set at that time,
 /// the event polling done from the input-waiting loops (reedline idle
 /// callback, pagers) could observe it and run `onintr()`, which longjmps to
 /// R's top level straight through the Rust frames of those loops.
-static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
+///
+/// A counter rather than a flag because ReadConsole can nest: R code run
+/// from the event polling of an outer read (e.g. a handler calling
+/// `readline()`) enters `r_read_console` again, and the inner guard's drop
+/// must not unmark the still-active outer read.
+static R_AWAITING_CONSOLE_INPUT: AtomicUsize = AtomicUsize::new(0);
 
 /// RAII guard that sets `R_interrupts_suspended = TRUE` and restores the
 /// previous value on drop.
@@ -114,14 +119,14 @@ struct AwaitConsoleInputGuard;
 
 impl AwaitConsoleInputGuard {
     fn new() -> Self {
-        R_AWAITING_CONSOLE_INPUT.store(true, Ordering::Release);
+        R_AWAITING_CONSOLE_INPUT.fetch_add(1, Ordering::AcqRel);
         Self
     }
 }
 
 impl Drop for AwaitConsoleInputGuard {
     fn drop(&mut self) {
-        R_AWAITING_CONSOLE_INPUT.store(false, Ordering::Release);
+        R_AWAITING_CONSOLE_INPUT.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -2373,7 +2378,7 @@ pub fn is_r_interrupt_flag_available() -> bool {
 /// it to drop interrupts that arrive while no R computation is running; see
 /// [`R_AWAITING_CONSOLE_INPUT`] for why setting the flag then is unsafe.
 pub fn is_r_awaiting_console_input() -> bool {
-    R_AWAITING_CONSOLE_INPUT.load(Ordering::Acquire)
+    R_AWAITING_CONSOLE_INPUT.load(Ordering::Acquire) > 0
 }
 
 /// Clear R's interrupt pending flag.

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -1612,11 +1612,6 @@ unsafe extern "C" fn r_read_console(
     // This prevents stale Ctrl+C signals from interrupting the next input read.
     clear_r_interrupt_pending();
 
-    // Mark that R is waiting for console input until this call returns, so
-    // the Ctrl+C handler drops interrupts instead of setting R's flag while
-    // Rust input loops are pumping R events (see R_AWAITING_CONSOLE_INPUT).
-    let _await_input_guard = AwaitConsoleInputGuard::new();
-
     // Safety net: if a previous password read (via rpassword) was interrupted
     // by longjmp (SIGINT), the terminal settings snapshot stored in
     // PENDING_TERMIOS_RESTORE may still need to be reapplied. Recover here at
@@ -1625,6 +1620,12 @@ unsafe extern "C" fn r_read_console(
     recover_pending_termios();
 
     // Askpass mode: detect magic prefix, strip it, read from /dev/tty with echo disabled.
+    // This runs before the input-wait guard on purpose: no Rust loop pumps R
+    // events during the blocking tty read, so the longjmp hazard the guard
+    // prevents does not exist here, and dropping SIGINT would make Ctrl+C at
+    // a password prompt entirely inert. With the flag allowed through,
+    // SA_RESTART resumes the read and the pending interrupt cancels the
+    // requesting operation as soon as the read returns.
     #[cfg(unix)]
     if !prompt.is_null() {
         let prompt_bytes = unsafe { std::ffi::CStr::from_ptr(prompt) }.to_bytes();
@@ -1633,6 +1634,11 @@ unsafe extern "C" fn r_read_console(
             return unsafe { read_password_from_tty(real_prompt, buf, buflen) };
         }
     }
+
+    // Mark that R is waiting for console input until this call returns, so
+    // the Ctrl+C handler drops interrupts instead of setting R's flag while
+    // Rust input loops are pumping R events (see R_AWAITING_CONSOLE_INPUT).
+    let _await_input_guard = AwaitConsoleInputGuard::new();
 
     // In reprex mode, print a blank line between expressions for readability
     // Only print for main prompts (not continuation prompts like "+")

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -7,12 +7,38 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
 /// Pointer to R's interrupt pending flag, set during R initialization.
 /// - Unix: points to `R_interrupts_pending` (c_int)
 /// - Windows: points to `UserBreak` (Rboolean, c_int-sized)
 static R_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut());
+
+/// True while `r_read_console` is waiting for console input.
+///
+/// The Ctrl+C handler consults this to drop interrupts that arrive while no
+/// R computation is running: if R's interrupt flag were set at that time,
+/// the event polling done from the input-waiting loops (reedline idle
+/// callback, pagers) could observe it and run `onintr()`, which longjmps to
+/// R's top level straight through the Rust frames of those loops.
+static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
+
+/// RAII guard that marks [`R_AWAITING_CONSOLE_INPUT`] for the duration of a
+/// `r_read_console` call, covering every return path.
+struct AwaitConsoleInputGuard;
+
+impl AwaitConsoleInputGuard {
+    fn new() -> Self {
+        R_AWAITING_CONSOLE_INPUT.store(true, Ordering::Release);
+        Self
+    }
+}
+
+impl Drop for AwaitConsoleInputGuard {
+    fn drop(&mut self) {
+        R_AWAITING_CONSOLE_INPUT.store(false, Ordering::Release);
+    }
+}
 
 /// Default R library paths by platform.
 #[cfg(target_os = "linux")]
@@ -1495,6 +1521,11 @@ unsafe extern "C" fn r_read_console(
     // This prevents stale Ctrl+C signals from interrupting the next input read.
     clear_r_interrupt_pending();
 
+    // Mark that R is waiting for console input until this call returns, so
+    // the Ctrl+C handler drops interrupts instead of setting R's flag while
+    // Rust input loops are pumping R events (see R_AWAITING_CONSOLE_INPUT).
+    let _await_input_guard = AwaitConsoleInputGuard::new();
+
     // Safety net: if a previous password read (via rpassword) was interrupted
     // by longjmp (SIGINT), the terminal settings snapshot stored in
     // PENDING_TERMIOS_RESTORE may still need to be reapplied. Recover here at
@@ -2227,6 +2258,15 @@ pub fn set_r_interrupt_pending() {
 /// When this returns `false`, [`set_r_interrupt_pending`] is a no-op.
 pub fn is_r_interrupt_flag_available() -> bool {
     !R_INTERRUPT_FLAG.load(Ordering::Acquire).is_null()
+}
+
+/// Returns whether R is currently inside `ReadConsole` waiting for input.
+///
+/// This is async-signal-safe (a single atomic load). The Ctrl+C handler uses
+/// it to drop interrupts that arrive while no R computation is running; see
+/// [`R_AWAITING_CONSOLE_INPUT`] for why setting the flag then is unsafe.
+pub fn is_r_awaiting_console_input() -> bool {
+    R_AWAITING_CONSOLE_INPUT.load(Ordering::Acquire)
 }
 
 /// Clear R's interrupt pending flag.

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -55,6 +55,18 @@ static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
 /// `R_interrupts_suspended` is not part of R's documented API (see the
 /// comment on `RLibrary::r_interrupts_suspended`); when the symbol is
 /// unavailable the guard is a no-op, reverting to the narrowed-race behavior.
+///
+/// Known residual (accepted): a SIGINT handler on another thread that
+/// observed `R_AWAITING_CONSOLE_INPUT == false` just before the transition
+/// can still write the interrupt flag after the drop's clear, leaving a
+/// stale flag that interrupts the start of the next evaluation once. This
+/// is benign (no longjmp through Rust frames — the crash class is gone) and
+/// requires a handler preempted inside a several-instruction window plus
+/// input submitted within one idle tick. Fully eliminating it would mean
+/// blocking SIGINT on all threads and receiving it via sigwait on a
+/// dedicated thread that shares a mutex with the ReadConsole transitions —
+/// a redesign that is not worth it for a benign one-off; see the task
+/// tracker for the design sketch if it ever becomes necessary.
 struct SuspendRInterruptsGuard {
     ptr: *mut c_int,
     old: c_int,

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -23,6 +23,58 @@ static R_INTERRUPT_FLAG: AtomicPtr<c_int> = AtomicPtr::new(std::ptr::null_mut())
 /// R's top level straight through the Rust frames of those loops.
 static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
 
+/// RAII guard that sets `R_interrupts_suspended = TRUE` and restores the
+/// previous value on drop.
+///
+/// While suspended, R's `onintr()` defers the interrupt (it re-sets
+/// `R_interrupts_pending` and returns) instead of longjmping to R's top
+/// level. This makes it safe to call R's event machinery from Rust
+/// input-waiting loops even if a SIGINT handler on another thread sets the
+/// interrupt flag at any point during the call — closing the race that the
+/// [`R_AWAITING_CONSOLE_INPUT`] gate and the entry clears only narrow.
+///
+/// Unlike R's `END_SUSPEND_INTERRUPTS`, the drop deliberately does NOT call
+/// `Rf_onintr()` for an interrupt that arrived while suspended: firing it
+/// would longjmp through the Rust caller. The still-pending flag is dropped
+/// by the next entry clear instead (interrupts make no sense at the prompt).
+///
+/// `R_interrupts_suspended` is not part of R's documented API (see the
+/// comment on `RLibrary::r_interrupts_suspended`); when the symbol is
+/// unavailable the guard is a no-op, reverting to the narrowed-race behavior.
+struct SuspendRInterruptsGuard {
+    ptr: *mut c_int,
+    old: c_int,
+}
+
+impl SuspendRInterruptsGuard {
+    fn new(ptr: *mut c_int) -> Self {
+        let old = if ptr.is_null() {
+            0
+        } else {
+            // SAFETY: ptr points to R's global variable, valid for the
+            // process lifetime. Volatile access matches how the SIGINT
+            // handler touches R globals.
+            unsafe {
+                let old = std::ptr::read_volatile(ptr);
+                std::ptr::write_volatile(ptr, 1);
+                old
+            }
+        };
+        Self { ptr, old }
+    }
+}
+
+impl Drop for SuspendRInterruptsGuard {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: see SuspendRInterruptsGuard::new.
+            unsafe {
+                std::ptr::write_volatile(self.ptr, self.old);
+            }
+        }
+    }
+}
+
 /// RAII guard that marks [`R_AWAITING_CONSOLE_INPUT`] for the duration of a
 /// `r_read_console` call, covering every return path.
 struct AwaitConsoleInputGuard;
@@ -2143,6 +2195,11 @@ pub fn process_r_events() {
     // loop that called us.
     clear_r_interrupt_pending();
 
+    // Suspend interrupts for the duration of the call so that a flag set
+    // concurrently (by a SIGINT handler running on another thread) cannot
+    // trigger that longjmp either. See SuspendRInterruptsGuard.
+    let _suspend_guard = SuspendRInterruptsGuard::new(lib.r_interrupts_suspended);
+
     unsafe {
         // Call R_ProcessEvents - this is the main event processing function
         (lib.r_processevents)();
@@ -2185,6 +2242,11 @@ pub fn peek_r_event() -> bool {
     // frames of the waiting loop (undefined behavior; in practice it leaks
     // a RefCell borrow and the session exits on the next ReadConsole).
     clear_r_interrupt_pending();
+
+    // Suspend interrupts for the duration of the call so that a flag set
+    // concurrently (by a SIGINT handler running on another thread) cannot
+    // trigger that longjmp either. See SuspendRInterruptsGuard.
+    let _suspend_guard = SuspendRInterruptsGuard::new(lib.r_interrupts_suspended);
 
     unsafe {
         #[cfg(windows)]

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -60,9 +60,11 @@ static R_AWAITING_CONSOLE_INPUT: AtomicBool = AtomicBool::new(false);
 /// observed `R_AWAITING_CONSOLE_INPUT == false` just before the transition
 /// can still write the interrupt flag after the drop's clear, leaving a
 /// stale flag that interrupts the start of the next evaluation once. This
-/// is benign (no longjmp through Rust frames — the crash class is gone) and
-/// requires a handler preempted inside a several-instruction window plus
-/// input submitted within one idle tick. Fully eliminating it would mean
+/// is benign as long as suspension is active (no longjmp through Rust
+/// frames; on builds where the symbol is unavailable the no-op guard leaves
+/// the narrowed crash race described above) and requires a handler preempted
+/// inside a several-instruction window plus input submitted within one idle
+/// tick. Fully eliminating it would mean
 /// blocking SIGINT on all threads and receiving it via sigwait on a
 /// dedicated thread that shares a mutex with the ReadConsole transitions —
 /// a redesign that is not worth it for a benign one-off; see the task

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -795,8 +795,12 @@ unsafe fn initialize_r_unix(lib: &crate::functions::RLibrary, r_args: &[&str]) -
         }
 
         // Disable R's signal handlers before initialization.
-        // R's mainloop reinstalls its own SIGINT handler later;
-        // on Windows we install a separate Ctrl+C handler in the REPL.
+        // With R_SignalHandlers = 0, setup_Rmainloop skips init_signal_handlers()
+        // entirely: no SIGINT handler, but also no SIGSEGV/SIGILL/SIGBUS crash
+        // handlers or SIGUSR1/SIGUSR2 save-and-quit handlers, which are
+        // undesirable for an embedded frontend. The REPL installs its own
+        // Ctrl+C handler (see repl/mod.rs) that sets R_interrupts_pending,
+        // replicating R's standard handleInterrupt behavior.
         if !lib.r_signalhandlers.is_null() {
             *lib.r_signalhandlers = 0;
         }
@@ -2101,6 +2105,13 @@ pub fn process_r_events() {
         Err(_) => return,
     };
 
+    // Drop any pending interrupt before calling into R's event machinery.
+    // See peek_r_event() for the rationale: an interrupt observed here
+    // (by R_ProcessEvents on Windows or R_checkActivity/R_runHandlers on
+    // Unix) would longjmp through the Rust frames of the input-waiting
+    // loop that called us.
+    clear_r_interrupt_pending();
+
     unsafe {
         // Call R_ProcessEvents - this is the main event processing function
         (lib.r_processevents)();
@@ -2134,6 +2145,15 @@ pub fn peek_r_event() -> bool {
         Ok(lib) => lib,
         Err(_) => return false,
     };
+
+    // Drop any pending interrupt before calling into R's event machinery.
+    // This function is only called from Rust input-waiting loops (reedline
+    // idle callback, headless loop), where there is no R computation to
+    // interrupt. If the flag were left set, R_checkActivity would call
+    // onintr(), which longjmps to R's top level straight through the Rust
+    // frames of the waiting loop (undefined behavior; in practice it leaks
+    // a RefCell borrow and the session exits on the next ReadConsole).
+    clear_r_interrupt_pending();
 
     unsafe {
         #[cfg(windows)]


### PR DESCRIPTION
## Summary

Pressing Ctrl+C (or receiving SIGINT) while R is evaluating could silently terminate the whole session on macOS/Linux. This PR makes Ctrl+C interrupt the running computation and return to the prompt, matching the existing Windows behavior.

## Root cause

On 64-bit Unix, the addresses of R's state variables (`R_Interactive`, `R_SignalHandlers`, `R_running_as_main_program`, `R_interrupts_pending`) were silently failing to resolve: libloading's `get::<T>()` requires `T` to be pointer-sized (the symbol address is transmuted into `T`), so `get::<c_int>()` always returned `IncompatibleSize` and the fallback left the pointers null.

Consequently:
- `R_SignalHandlers = 0` never took effect, so R kept installing its own signal handlers (SIGINT, but also SIGSEGV/SIGILL/SIGBUS and SIGUSR1/2), contrary to the intended embedded-frontend design. Ctrl+C mostly worked only because R's own handler happened to be present.
- The interrupt flag pointer was null, so arf could not request interrupts itself, and the Ctrl+C handler was only compiled on Windows anyway.

## Changes

- Resolve the four state-variable addresses with pointer-sized `get::<usize>()` + `try_as_raw_ptr()`, the pattern already used on Windows (`crates/arf-libr/src/functions.rs`).
- Install a SIGINT handler on Unix that sets `R_interrupts_pending`, replicating R's standard `handleInterrupt`. Unix registers a SIGINT-only `sigaction` (with `SA_RESTART`) via nix instead of the ctrlc crate: the workspace builds ctrlc with the `termination` feature (needed by headless mode), which would also capture SIGTERM/SIGHUP and make an interactive session unkillable. Windows keeps using ctrlc (`crates/arf-console/src/repl/mod.rs`).
- Install the handler around R initialization instead of in the REPL setup: on Unix before `initialize_r_with_args()` (the flag pointer resolves before `setup_Rmainloop` evaluates startup profiles, so Ctrl+C during a slow `.Rprofile` interrupts it instead of killing the process; the default disposition is restored if the flag turns out to be unavailable), on Windows between initialization and the manual profile sourcing, gated on flag availability as before (`crates/arf-console/src/main.rs`).
- Drop SIGINTs while arf is waiting for user input. If the interrupt flag were observed by R's event machinery during a Rust input-waiting loop (reedline idle callback, headless loop), `onintr()` would longjmp to the R top level straight through the Rust frames, leaking the `REPL_STATE` RefCell borrow and ending the session with EOF on the next ReadConsole. `r_read_console` tracks an input-waiting state (RAII guard) and the handler discards signals while it is set; `peek_r_event()` / `process_r_events()` also clear the flag on entry as defense in depth (`crates/arf-libr/src/sys.rs`).
- Make the input-waiting gate reentrancy-safe: the guard uses a nesting counter instead of a boolean, so a nested ReadConsole (e.g. an event handler calling `readline()` during an outer read) no longer unmarks the still-active outer read on drop.
- Close the remaining gate-vs-flag race structurally by setting `R_interrupts_suspended` around the R event calls in `peek_r_event()` / `process_r_events()` (RAII guard, previous value restored). While suspended, `onintr()` defers instead of longjmping, regardless of signal timing or thread. `R_interrupts_suspended` is not documented API, but it is exposed by the installed header `R_ext/GraphicsDevice.h`, and ark and reticulate rely on it in production; the symbol is resolved dynamically and the guard degrades to a no-op if absent.
- Clear interrupts deferred during suspended polling before restoring the suspension state, so a deferred interrupt can neither fire in Rust frames nor leak into the next evaluation as a stale prompt-time interrupt. On Windows this required also resolving `R_interrupts_pending` (a different variable from `UserBreak`); `clear_r_interrupt_pending()` now clears both.
- Exclude the askpass `/dev/tty` password read from the input-wait guard. No Rust loop pumps R events during that blocking read, so the longjmp hazard does not exist there, and dropping the signal would have made a password prompt uncancellable; the pending interrupt now cancels the requesting operation as soon as the read returns (pre-branch behavior). Immediate Ctrl+C cancellation of the blocking read itself (EINTR path + PTY test) never existed and is tracked separately as a follow-up feature.

## Test plan

- [x] `cargo test --workspace` passes (all suites green)
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual (tmux, Linux): Ctrl+C during `Sys.sleep(60)` interrupts and returns to prompt
- [x] Manual: Ctrl+C during a `.Rprofile` running `Sys.sleep(30)` interrupts the profile and reaches the prompt (previously killed the process)
- [x] Manual: session survives 30 rapid external `kill -INT`s during evaluation and at the prompt, and the next evaluation shows no spurious interrupt
- [x] Manual: `kill -TERM` still terminates the session (ctrlc `termination` feature no longer captures it)
- [x] Manual: Ctrl+C at the prompt prints `^C` only; Ctrl+D exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)