### PR TITLE
fix: update raw string incomplete-input detection for tree-sitter-r 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable.
 - On macOS/Linux, Ctrl+C (SIGINT) delivered during R evaluation could terminate the session instead of cancelling the running computation. Ctrl+C now interrupts the evaluation and returns to the prompt, as on Windows.
+- Updated to tree-sitter-r 1.3.0 and adjusted the input validator so unclosed raw strings (e.g. `r"(...`) are still correctly detected as incomplete input rather than being sent to R prematurely.
 
 ## [0.4.3-rc.1] - 2026-06-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,9 +2304,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-r"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429133cbda9f8a46e03ef3aae6abb6c3d22875f8585cad472138101bfd517255"
+checksum = "ffc9954ec870dcad6cffdd302b405306c68cf031ed79a78cd9746f6740d9fe20"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ toml = "1.1"
 
 # Tree-sitter parsing
 tree-sitter = "0.24"
-tree-sitter-r = "1.2"
+tree-sitter-r = "1.3"
 
 # Rd to Markdown conversion
 rd2qmd-core = { version = "0.3.0", features = ["roxygen"] }

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -95,70 +95,53 @@ impl RValidator {
         false
     }
 
-    /// Detect misparsed raw strings.
+    /// Detect unclosed raw strings.
     ///
-    /// Tree-sitter may parse incomplete raw strings like `r"(\n"` as:
-    ///   (program (identifier) (string ...))
-    /// where `r` is an identifier and `"(\n"` is a regular string.
-    ///
-    /// This function detects this pattern:
-    /// 1. First child is identifier "r" or "R"
-    /// 2. Second child is a string that starts with a raw string delimiter
-    ///
-    /// Raw string delimiters in R: `(`, `[`, `{`, or `-` followed by one of these
+    /// With tree-sitter-r 1.3.0, an unclosed raw string like `r"(hello` no
+    /// longer parses with a MISSING close, or with an ERROR that extends to
+    /// the end of input. Instead the parser gives up right after the open
+    /// delimiter, producing an `ERROR` node that contains only the
+    /// `string_open` token (e.g. `r"(`), and re-tokenizes whatever follows
+    /// as ordinary R tokens (e.g. `hello` becomes a sibling `identifier`).
+    /// Since that trailing content sits next to the `ERROR` node rather than
+    /// inside it, `check_incomplete`'s "ERROR reaches end of content" rule
+    /// below never sees it. This function detects that specific pattern.
     ///
     /// TODO: This is a workaround for a tree-sitter-r parsing issue.
     /// When tree-sitter-r is fixed to properly recognize incomplete raw strings,
     /// this function can be removed. See: https://github.com/r-lib/tree-sitter-r
     fn is_misparsed_raw_string(&self, root: &tree_sitter::Node, source: &[u8]) -> bool {
-        // Need at least 2 children
-        if root.child_count() < 2 {
-            return false;
-        }
+        let mut cursor = root.walk();
+        self.contains_unclosed_raw_string_open(&mut cursor, source)
+    }
 
-        let first = match root.child(0) {
-            Some(n) => n,
-            None => return false,
-        };
-        let second = match root.child(1) {
-            Some(n) => n,
-            None => return false,
-        };
+    /// Recursively search for an `ERROR` node whose first child is the
+    /// `string_open` of a raw string (i.e. its text starts with `r` or `R`).
+    fn contains_unclosed_raw_string_open(
+        &self,
+        cursor: &mut tree_sitter::TreeCursor,
+        source: &[u8],
+    ) -> bool {
+        let node = cursor.node();
 
-        // First child must be identifier "r" or "R"
-        if first.kind() != "identifier" {
-            return false;
-        }
-        let id_text = &source[first.start_byte()..first.end_byte()];
-        if id_text != b"r" && id_text != b"R" {
-            return false;
-        }
-
-        // Second child must be a string
-        if second.kind() != "string" {
-            return false;
-        }
-
-        // Get the string content (after the opening quote)
-        let string_start = second.start_byte();
-        if string_start + 1 >= source.len() {
-            return false;
-        }
-
-        // Check if string starts with quote followed by raw string delimiter
-        // The string node starts with ", so check the char after "
-        let after_quote = source.get(string_start + 1).copied();
-        let is_raw_delimiter = matches!(
-            after_quote,
-            Some(b'(') | Some(b'[') | Some(b'{') | Some(b'-')
-        );
-
-        if is_raw_delimiter {
-            // This looks like a misparsed raw string
-            // Check if the raw string is properly closed
-            // A complete raw string would be parsed as a single (string) node, not (identifier)(string)
-            // So if we got here, it's incomplete
+        if node.kind() == "ERROR"
+            && let Some(first) = node.child(0)
+            && first.kind() == "string_open"
+            && matches!(source.get(first.start_byte()), Some(b'r') | Some(b'R'))
+        {
             return true;
+        }
+
+        if cursor.goto_first_child() {
+            loop {
+                if self.contains_unclosed_raw_string_open(cursor, source) {
+                    return true;
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+            cursor.goto_parent();
         }
 
         false
@@ -444,6 +427,42 @@ mod tests {
         assert!(is_complete(
             validator.validate(concat!(r#"r"(""#, "\n", r#")""#))
         ));
+
+        // Uppercase R and single-quoted variants
+        assert!(is_incomplete(validator.validate(r#"R"(hello"#)));
+        assert!(is_incomplete(validator.validate("r'(hello")));
+        assert!(is_incomplete(validator.validate("R'[hello")));
+
+        // Bracket/brace delimiter variants
+        assert!(is_incomplete(validator.validate(r#"r"[hello"#)));
+        assert!(is_incomplete(validator.validate(r#"r"{hello"#)));
+
+        // Unclosed raw string nested inside an unclosed call/brace/paren
+        assert!(is_incomplete(validator.validate(r#"foo(r"(hello"#)));
+        assert!(is_incomplete(
+            validator.validate(concat!("{ ", r#"r"(hello"#))
+        ));
+        assert!(is_incomplete(
+            validator.validate(concat!("(", r#"r"(hello"#))
+        ));
+
+        // A genuine syntax error earlier in the input, with an unclosed raw
+        // string trailing after it, should still be treated the same as any
+        // other unclosed-paren input (Incomplete) rather than newly regressing
+        // to Complete because of the raw-string workaround.
+        assert!(is_incomplete(validator.validate(r#"fn(a b, r"(hello"#)));
+
+        // Raw-string-like text that is actually just content of an ordinary
+        // unclosed double-quoted string must not be misdetected here; it's
+        // still correctly caught as Incomplete by the generic MISSING-close check.
+        assert!(is_incomplete(validator.validate("\"foo r'(bar")));
+
+        // Malformed non-raw forms (missing quote/delimiter) are not raw
+        // strings at all and must not spuriously match this workaround;
+        // they're still Incomplete for unrelated reasons (unclosed bracket/string).
+        assert!(is_incomplete(validator.validate("r[foo")));
+        assert!(is_incomplete(validator.validate("r{foo")));
+        assert!(is_incomplete(validator.validate(r#"r"---foo"#)));
     }
 
     #[test]

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -437,14 +437,18 @@ mod tests {
         assert!(is_incomplete(validator.validate(r#"r"[hello"#)));
         assert!(is_incomplete(validator.validate(r#"r"{hello"#)));
 
-        // Unclosed raw string nested inside an unclosed call/brace/paren
-        assert!(is_incomplete(validator.validate(r#"foo(r"(hello"#)));
-        assert!(is_incomplete(
-            validator.validate(concat!("{ ", r#"r"(hello"#))
-        ));
-        assert!(is_incomplete(
-            validator.validate(concat!("(", r#"r"(hello"#))
-        ));
+        // Unclosed raw string nested inside an otherwise-*closed* call/brace.
+        // The outer construct has no MISSING node here (the trailing `)`/`}`
+        // is consumed as its own close), so these only come out Incomplete
+        // because `contains_unclosed_raw_string_open` finds the nested
+        // `ERROR(string_open)` — unlike a nested-but-also-unclosed variant,
+        // which would pass via the generic MISSING/ERROR-at-end check alone.
+        assert!(is_incomplete(validator.validate(r#"foo(r"(hello)"#)));
+        assert!(is_incomplete(validator.validate(concat!(
+            "{ ",
+            r#"r"(hello"#,
+            " }"
+        ))));
 
         // A genuine syntax error earlier in the input, with an unclosed raw
         // string trailing after it, should still be treated the same as any

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -418,7 +418,15 @@ mod tests {
         ));
 
         // Raw strings with quotes inside (reported issue)
-        // r"( on first line, then quotes on second line - all should be incomplete
+        // r"( on first line, then quotes on second line - all should be incomplete.
+        // Note: the "one quote" and "text + quote" cases below happen to produce
+        // an ERROR node that already extends to the end of input, so they'd pass
+        // even without contains_unclosed_raw_string_open's multi-child support;
+        // only the "two quotes" case (ERROR ends mid-input, followed by a separate
+        // sibling `string` node) is discriminating on its own. Kept all three since
+        // this area is easy to regress and cheap to keep covered; see the
+        // `foo(r"(...)` case below for a test that specifically requires
+        // multi-child ERROR matching.
         assert!(is_incomplete(
             validator.validate(concat!(r#"r"("#, "\n", r#"""#))
         )); // one quote
@@ -428,6 +436,19 @@ mod tests {
         assert!(is_incomplete(
             validator.validate(concat!(r#"r"("#, "\nhello", r#"""#))
         )); // text + quote
+
+        // Nested inside a call whose parens DO close (last `)` is consumed as
+        // the call's own close, no MISSING anywhere), with a comma-separated
+        // argument after the unclosed raw string. The ERROR node here has 3
+        // children (string_open, identifier, string_open) and ends well before
+        // the end of input, so this is only caught because
+        // contains_unclosed_raw_string_open checks the ERROR's first child
+        // regardless of how many children follow it.
+        assert!(is_incomplete(validator.validate(concat!(
+            r#"foo(r"("#,
+            "\nhello",
+            r#"", 1)"#
+        ))));
 
         // Complete: r"( followed by )" closes it
         assert!(is_complete(

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -105,12 +105,15 @@ impl RValidator {
     /// as ordinary R tokens (e.g. `hello` becomes a sibling `identifier`).
     /// Since that trailing content sits next to the `ERROR` node rather than
     /// inside it, `check_incomplete`'s "ERROR reaches end of content" rule
-    /// below never sees it. This function detects that specific pattern.
+    /// (above) never sees it. This function detects that specific pattern.
     ///
     /// TODO: This is a workaround for a tree-sitter-r parsing issue.
     /// When tree-sitter-r is fixed to properly recognize incomplete raw strings,
     /// this function can be removed. See: https://github.com/r-lib/tree-sitter-r
-    fn is_misparsed_raw_string(&self, root: &tree_sitter::Node, source: &[u8]) -> bool {
+    fn is_unclosed_raw_string(&self, root: &tree_sitter::Node, source: &[u8]) -> bool {
+        if !root.has_error() {
+            return false;
+        }
         let mut cursor = root.walk();
         self.contains_unclosed_raw_string_open(&mut cursor, source)
     }
@@ -222,10 +225,10 @@ impl Validator for RValidator {
             root.to_sexp()
         ));
 
-        // Check for incomplete raw strings that tree-sitter misparses
-        if self.is_misparsed_raw_string(&root, source) {
+        // Check for unclosed raw strings that tree-sitter can't otherwise flag
+        if self.is_unclosed_raw_string(&root, source) {
             debug_log(&format!(
-                "[Validator] {:?} -> Incomplete (misparsed raw string)",
+                "[Validator] {:?} -> Incomplete (unclosed raw string)",
                 escaped
             ));
             return ValidationResult::Incomplete;

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -100,12 +100,17 @@ impl RValidator {
     /// With tree-sitter-r 1.3.0, an unclosed raw string like `r"(hello` no
     /// longer parses with a MISSING close, or with an ERROR that extends to
     /// the end of input. Instead the parser gives up right after the open
-    /// delimiter, producing an `ERROR` node that contains only the
-    /// `string_open` token (e.g. `r"(`), and re-tokenizes whatever follows
-    /// as ordinary R tokens (e.g. `hello` becomes a sibling `identifier`).
-    /// Since that trailing content sits next to the `ERROR` node rather than
-    /// inside it, `check_incomplete`'s "ERROR reaches end of content" rule
-    /// (above) never sees it. This function detects that specific pattern.
+    /// delimiter and emits an `ERROR` node whose *first* child is the
+    /// `string_open` token (e.g. `r"(`); everything after that gets
+    /// re-tokenized as ordinary R tokens (e.g. `hello` becomes a sibling
+    /// `identifier`), and in some cases additional tokens end up as further
+    /// children of the same `ERROR` node (e.g. a second `string_open` from a
+    /// stray quote on a later line). Since the misparsed trailing content
+    /// doesn't extend the `ERROR` node's own byte range to the end of input,
+    /// `check_incomplete`'s "ERROR reaches end of content" rule (above) never
+    /// sees it. This function detects the pattern directly: an `ERROR` node
+    /// that *starts* with a raw string's open token, regardless of what
+    /// other children (if any) follow it.
     ///
     /// TODO: This is a workaround for a tree-sitter-r parsing issue.
     /// When tree-sitter-r is fixed to properly recognize incomplete raw strings,
@@ -118,8 +123,9 @@ impl RValidator {
         self.contains_unclosed_raw_string_open(&mut cursor, source)
     }
 
-    /// Recursively search for an `ERROR` node whose first child is the
-    /// `string_open` of a raw string (i.e. its text starts with `r` or `R`).
+    /// Recursively search for an `ERROR` node whose first child (regardless
+    /// of what other children it may also have) is the `string_open` of a
+    /// raw string (i.e. its text starts with `r` or `R`).
     fn contains_unclosed_raw_string_open(
         &self,
         cursor: &mut tree_sitter::TreeCursor,


### PR DESCRIPTION
## Summary

- tree-sitter-r 1.3.0 restructured string parsing so all string kinds (single/double/raw) share a common `open`/`content`/`close` node shape. As a side effect, an unclosed raw string (e.g. `r"(hello`) no longer misparses as `(identifier "r")(string ...)`; it now produces an `ERROR` node whose first child is the open delimiter, with the rest of the input re-tokenized as sibling/further-child tokens instead of being absorbed into the error. The existing workaround in the R input validator targeted the old shape and stopped detecting these as incomplete input.
- Rewrote the workaround (`is_unclosed_raw_string` / `contains_unclosed_raw_string_open`) to recognize the new pattern and bumped the `tree-sitter-r` dependency to 1.3.0.
- Filed r-lib/tree-sitter-r#203 upstream requesting that unclosed raw strings recover the same way unclosed quoted strings already do (a `string` node with `MISSING string_close`), which would let this workaround be removed entirely.

## Review history

- roborev flagged that some nested-in-unclosed-container regression tests didn't actually exercise the new detection code (they'd pass via the generic MISSING-close check alone regardless); replaced with closed-outer-container variants that only pass because of the new logic.
- GitHub Copilot's automated review made three suggestions, addressed as follows:
  - Renamed `is_misparsed_raw_string` to `is_unclosed_raw_string` to match its actual behavior.
  - Added a `root.has_error()` short-circuit so complete inputs skip the tree walk.
  - A suggestion to narrow the `ERROR` match to nodes containing *only* the open token was evaluated and not applied — it would regress several already-passing cases where the `ERROR` node legitimately has more than one child. Reworded the doc comments instead to describe the actual pattern accurately, and added a regression test (verified by temporarily reintroducing the suggested narrowing and confirming only that test fails) proving the "first child, not exact-only-child" behavior is load-bearing.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo fmt` / `cargo clippy --all-targets` clean
- [x] Regression tests cover uppercase/single-quoted/bracket/brace raw string variants, nesting inside otherwise-closed constructs (call args, braces), a genuine-syntax-error-plus-unclosed-raw-string case, malformed non-raw forms that must not false-positive, and a multi-child `ERROR` case that only the new detection logic catches