### PR TITLE
chore: prepare release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable.
-- On macOS/Linux, Ctrl+C (SIGINT) delivered during R evaluation could terminate the session instead of cancelling the running computation. Ctrl+C now interrupts the evaluation and returns to the prompt, as on Windows.
-- Updated to tree-sitter-r 1.3.0 and adjusted the input validator so unclosed raw strings (e.g. `r"(...`) are still correctly detected as incomplete input rather than being sent to R prematurely.
-
-## [0.4.3-rc.1] - 2026-06-30
+## [0.4.3] - 2026-07-04
 
 ### Fixed
 
 - The help browser (`:help`), tab completion, and object inspection no longer silently overwrite user variables in `.GlobalEnv` (e.g. variables named `db` or `base` were at risk) (#233).
 - Support R installations on RHEL and AlmaLinux by checking `/usr/lib64/R/lib/libR.so` and using lazy symbol resolution when loading libR (#232).
 - Fixed `.Rprofile` not being loaded after `:restart!` on macOS/Linux when `R_PROFILE_USER` is set to an empty string in the environment. The fix from #226 applied only to Windows; this extends the same behaviour to Unix where R handles profile loading internally (#234).
+- The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable (#244).
+- On macOS/Linux, Ctrl+C (SIGINT) delivered during R evaluation could terminate the session instead of cancelling the running computation. Ctrl+C now interrupts the evaluation and returns to the prompt, as on Windows (#245).
+- Updated to tree-sitter-r 1.3.0 and adjusted the input validator so unclosed raw strings (e.g. `r"(...`) are still correctly detected as incomplete input rather than being sent to R prematurely (#247).
 
 ## [0.4.2] - 2026-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "arf-console"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "arf-libr",
  "insta",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1503,7 +1503,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 dependencies = [
  "htmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.4.3-rc.1"
+version = "0.4.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.4.3-rc.1", path = "crates/arf-harp" }
-arf-libr = { version = "0.4.3-rc.1", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.4.3-rc.1", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.4.3", path = "crates/arf-harp" }
+arf-libr = { version = "0.4.3", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.4.3", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.3-rc.1
+# arf console v0.4.3
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.3-rc.1
+# arf console v0.4.3
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.3-rc.1
+# arf console v0.4.3
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.3-rc.1
+# arf console v0.4.3
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.3-rc.1
+# arf console v0.4.3
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.4.3-rc.1 to 0.4.3
- Finalize CHANGELOG `[Unreleased]` and `[0.4.3-rc.1]` sections into `[0.4.3] - 2026-07-04`
- Update banner snapshots for new version string

## Changelog

## [0.4.3] - 2026-07-04

### Fixed

- The help browser (`:help`), tab completion, and object inspection no longer silently overwrite user variables in `.GlobalEnv` (e.g. variables named `db` or `base` were at risk) (#233).
- Support R installations on RHEL and AlmaLinux by checking `/usr/lib64/R/lib/libR.so` and using lazy symbol resolution when loading libR (#232).
- Fixed `.Rprofile` not being loaded after `:restart!` on macOS/Linux when `R_PROFILE_USER` is set to an empty string in the environment. The fix from #226 applied only to Windows; this extends the same behaviour to Unix where R handles profile loading internally (#234).
- The help browser (`:help`) no longer leaks raw HTML tags from some Rd documentation, which made pages like `pak::FAQ` unreadable (#244).
- On macOS/Linux, Ctrl+C (SIGINT) delivered during R evaluation could terminate the session instead of cancelling the running computation. Ctrl+C now interrupts the evaluation and returns to the prompt, as on Windows (#245).
- Updated to tree-sitter-r 1.3.0 and adjusted the input validator so unclosed raw strings (e.g. `r"(...`) are still correctly detected as incomplete input rather than being sent to R prematurely (#247).