### PR TITLE
refactor: make clippy happy under Rust 1.97

### DIFF
--- a/crates/arf-console/src/completion/r_completer.rs
+++ b/crates/arf-console/src/completion/r_completer.rs
@@ -52,10 +52,9 @@ fn parse_namespace_token(line: &str, cursor_pos: usize) -> Option<NamespaceToken
     // Check for `:::` or `::`
     let (triple_colon, before_colons) = if let Some(rest) = before_partial.strip_suffix(":::") {
         (true, rest)
-    } else if let Some(rest) = before_partial.strip_suffix("::") {
-        (false, rest)
     } else {
-        return None;
+        let rest = before_partial.strip_suffix("::")?;
+        (false, rest)
     };
 
     // Extract package name (identifier chars before the colons)

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -213,22 +213,16 @@ impl HistoryBrowser {
                 .filter_map(|(idx, entry)| {
                     // Apply hostname filter
                     if let Some(ref hostname) = self.filter.hostname {
-                        if let Some(ref item_host) = entry.item.hostname {
-                            if !item_host.contains(hostname) {
-                                return None;
-                            }
-                        } else {
+                        let item_host = entry.item.hostname.as_deref()?;
+                        if !item_host.contains(hostname) {
                             return None;
                         }
                     }
 
                     // Apply cwd prefix filter
                     if let Some(ref cwd_prefix) = self.filter.cwd_prefix {
-                        if let Some(ref item_cwd) = entry.item.cwd {
-                            if !item_cwd.starts_with(cwd_prefix) {
-                                return None;
-                            }
-                        } else {
+                        let item_cwd = entry.item.cwd.as_deref()?;
+                        if !item_cwd.starts_with(cwd_prefix) {
                             return None;
                         }
                     }


### PR DESCRIPTION
## Summary

- Fix three `clippy::question_mark` lint failures in `crates/arf-console/src/completion/r_completer.rs` and `crates/arf-console/src/pager/history_browser.rs`, surfaced by the latest Rust stable (1.97.1) that CI runners now use.
- Flatten each nested `if let Some(...) { ... } else { return None; }` into the `?` operator, using `.as_deref()` instead of the `ref` pattern where a `&str` is needed. No behavior change.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` (matches the CI invocation; 0 warnings)
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)