### PR TITLE
chore: update rd2qmd and r-documentation dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "rd-ast"
-version = "0.0.1"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa5a549cda19d85723d7f7e2f4713224daa6b6aada7f9d0359a7006bdb0daaa"
+checksum = "03a90f843c732928497c9633c0e53836d09dc5b184226fa52ca023f79b9028dd"
 dependencies = [
  "rd-rds",
  "serde",
@@ -1651,8 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "rd-helpdb"
-version = "0.0.1"
-source = "git+https://github.com/eitsupi/r-documentation-rs?rev=632e7c35f640814785238ca87ff8bf70b5a2f0cd#632e7c35f640814785238ca87ff8bf70b5a2f0cd"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690a16f3bfe77e82863180e3dcd0df6e6fc537e35b11e9f9d408f6f4e8a5352d"
 dependencies = [
  "flate2",
  "rd-rds",
@@ -1661,8 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "rd-rds"
-version = "0.0.1"
-source = "git+https://github.com/eitsupi/r-documentation-rs?rev=632e7c35f640814785238ca87ff8bf70b5a2f0cd#632e7c35f640814785238ca87ff8bf70b5a2f0cd"
+version = "0.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e085779f77d443991c2ac8d5fb0263958b037035e840e5d8f6bede993b7df9"
 dependencies = [
  "bzip2",
  "flate2",
@@ -1673,18 +1675,18 @@ dependencies = [
 
 [[package]]
 name = "rd-source"
-version = "0.0.1"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4eead470493d660bf3c23f6e6bb9d15e433b8f944f8cb2989897bf7f7e109"
+checksum = "99f11c13c76965e24666211487409ee08ef55638cf713894a4f5063208847370"
 dependencies = [
  "rd-ast",
 ]
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.0-alpha.1"
+version = "0.5.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d631d0cf54cb15009f50272e3eae380042872517bd0893a7e22d27dcddd7c"
+checksum = "2cfa387c53a0f0c2ea94452c8bb90bd6b0a201d20ef93c930d6c7406205d2319"
 dependencies = [
  "rd-ast",
  "rd2qmd-mdast",
@@ -1696,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.0-alpha.1"
+version = "0.5.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54757b76b971c3da6a8bc45298d544338f8ec60519f4db97cdf890e33e4dd57"
+checksum = "e6c9b31d2174e2c95d8ea8d653cfe13dede3dbbdead0827d9956e2f1d04d4e4c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.3"
 
 # Rd to Markdown conversion
-rd2qmd-core = "=0.5.0-alpha.1"
-rd-source = "=0.0.1"
-rd-helpdb = "=0.0.1"
-rd-rds = "=0.0.1"
-rd-ast = { version = "=0.0.1", features = ["serde"] }
+rd2qmd-core = "=0.5.0-beta.1"
+rd-source = "=0.1.0-rc.1"
+rd-helpdb = "=0.1.0-rc.1"
+rd-rds = "=0.1.0-rc.1"
+rd-ast = { version = "=0.1.0-rc.1", features = ["serde"] }
 
 # Markdown parsing
 pulldown-cmark = "0.13"
@@ -100,8 +100,6 @@ vt100 = "0.16"
 # https://github.com/crossterm-rs/crossterm/pull/1030
 [patch.crates-io]
 crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "03bb4f26610a5904b8e875fcb610d16bf7d00814" }
-rd-helpdb = { git = "https://github.com/eitsupi/r-documentation-rs", rev = "632e7c35f640814785238ca87ff8bf70b5a2f0cd" }
-rd-rds = { git = "https://github.com/eitsupi/r-documentation-rs", rev = "632e7c35f640814785238ca87ff8bf70b5a2f0cd" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary
- update rd2qmd-core to =0.5.0-beta.1
- update rd-ast, rd-source, rd-rds, and rd-helpdb to =0.1.0-rc.1
- remove the rd-helpdb and rd-rds crates.io patches now that the releases are published
- refresh Cargo.lock, including rd2qmd-mdast 0.5.0-beta.1

All pre-release dependencies remain exactly pinned.

## Checks
- cargo fmt --all -- --check
- cargo check --workspace --locked
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --locked