### PR TITLE
fix: use upstream rd2qmd whitespace fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,8 +1685,7 @@ dependencies = [
 [[package]]
 name = "rd2qmd-core"
 version = "0.5.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa387c53a0f0c2ea94452c8bb90bd6b0a201d20ef93c930d6c7406205d2319"
+source = "git+https://github.com/eitsupi/rd2qmd?rev=2dce12b6b41f74a02e68a1514c4be500f6f841fc#2dce12b6b41f74a02e68a1514c4be500f6f841fc"
 dependencies = [
  "rd-ast",
  "rd2qmd-mdast",
@@ -1699,8 +1698,7 @@ dependencies = [
 [[package]]
 name = "rd2qmd-mdast"
 version = "0.5.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c9b31d2174e2c95d8ea8d653cfe13dede3dbbdead0827d9956e2f1d04d4e4c"
+source = "git+https://github.com/eitsupi/rd2qmd?rev=2dce12b6b41f74a02e68a1514c4be500f6f841fc#2dce12b6b41f74a02e68a1514c4be500f6f841fc"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ vt100 = "0.16"
 # https://github.com/crossterm-rs/crossterm/pull/1030
 [patch.crates-io]
 crossterm = { git = "https://github.com/crossterm-rs/crossterm", rev = "03bb4f26610a5904b8e875fcb610d16bf7d00814" }
+rd2qmd-core = { git = "https://github.com/eitsupi/rd2qmd", rev = "2dce12b6b41f74a02e68a1514c4be500f6f841fc" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -403,7 +403,9 @@ pub fn get_package_help_markdown(topic: &str, package: &str) -> HarpResult<Strin
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
     options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
-    Ok(rd2qmd_core::convert_rd_document(&doc, &options))
+    Ok(normalize_markdown_whitespace(
+        rd2qmd_core::convert_rd_document(&doc, &options),
+    ))
 }
 
 fn get_help_markdown_via_r(topic: &str) -> HarpResult<String> {
@@ -437,10 +439,73 @@ fn get_help_markdown_via_r(topic: &str) -> HarpResult<String> {
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
     options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
-    Ok(rd2qmd_core::convert_rd_document(
-        parsed.document(),
-        &options,
+    Ok(normalize_markdown_whitespace(
+        rd2qmd_core::convert_rd_document(parsed.document(), &options),
     ))
+}
+
+/// Remove duplicated prose spaces introduced when the Rd AST converter joins
+/// adjacent text nodes. Two spaces are retained because Markdown uses them for
+/// a hard line break; code spans and fenced code blocks are left untouched.
+fn normalize_markdown_whitespace(markdown: String) -> String {
+    let mut normalized = String::with_capacity(markdown.len());
+    let mut in_fenced_code = false;
+
+    for line in markdown.split_inclusive('\n') {
+        let content_end = line.strip_suffix('\n').map_or(line.len(), str::len);
+        let content = &line[..content_end];
+        let is_fence =
+            content.trim_start().starts_with("```") || content.trim_start().starts_with("~~~");
+
+        if is_fence {
+            in_fenced_code = !in_fenced_code;
+            normalized.push_str(line);
+        } else if in_fenced_code {
+            normalized.push_str(line);
+        } else {
+            normalized.push_str(&normalize_markdown_line(content));
+            normalized.push_str(&line[content_end..]);
+        }
+    }
+
+    normalized
+}
+
+fn normalize_markdown_line(line: &str) -> String {
+    let mut normalized = String::with_capacity(line.len());
+    let mut inline_code_delimiter = None;
+    let mut chars = line.char_indices().peekable();
+
+    while let Some((index, character)) = chars.next() {
+        if character == '`' {
+            let mut delimiter_length = 1;
+            while chars.peek().is_some_and(|(_, next)| *next == '`') {
+                chars.next();
+                delimiter_length += 1;
+            }
+            if inline_code_delimiter == Some(delimiter_length) {
+                inline_code_delimiter = None;
+            } else if inline_code_delimiter.is_none() {
+                inline_code_delimiter = Some(delimiter_length);
+            }
+            normalized.push_str(&line[index..index + delimiter_length]);
+        } else if character == ' '
+            && inline_code_delimiter.is_none()
+            && chars
+                .clone()
+                .find(|(_, next)| *next != ' ')
+                .is_some_and(|(next_index, _)| next_index - index >= 3)
+        {
+            normalized.push(' ');
+            while chars.peek().is_some_and(|(_, next)| *next == ' ') {
+                chars.next();
+            }
+        } else {
+            normalized.push(character);
+        }
+    }
+
+    normalized
 }
 
 /// Sentinel value returned by R when a vignette is in PDF format.
@@ -623,5 +688,14 @@ More text after.
         let qmd = rd2qmd_core::convert_rd_document(parsed.document(), &options);
 
         insta::assert_snapshot!("rd_conversion_strips_if_html_content", qmd);
+    }
+
+    #[test]
+    fn test_normalize_markdown_whitespace_preserves_code_and_hard_breaks() {
+        let markdown = "prose   spaces  stay\n`code   spaces`\n```r\ncode   spaces\n```\n";
+        assert_eq!(
+            normalize_markdown_whitespace(markdown.to_string()),
+            "prose spaces  stay\n`code   spaces`\n```r\ncode   spaces\n```\n"
+        );
     }
 }

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -403,9 +403,7 @@ pub fn get_package_help_markdown(topic: &str, package: &str) -> HarpResult<Strin
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
     options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
-    Ok(normalize_markdown_whitespace(
-        rd2qmd_core::convert_rd_document(&doc, &options),
-    ))
+    Ok(rd2qmd_core::convert_rd_document(&doc, &options))
 }
 
 fn get_help_markdown_via_r(topic: &str) -> HarpResult<String> {
@@ -439,73 +437,10 @@ fn get_help_markdown_via_r(topic: &str) -> HarpResult<String> {
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
     options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
-    Ok(normalize_markdown_whitespace(
-        rd2qmd_core::convert_rd_document(parsed.document(), &options),
+    Ok(rd2qmd_core::convert_rd_document(
+        parsed.document(),
+        &options,
     ))
-}
-
-/// Remove duplicated prose spaces introduced when the Rd AST converter joins
-/// adjacent text nodes. Two spaces are retained because Markdown uses them for
-/// a hard line break; code spans and fenced code blocks are left untouched.
-fn normalize_markdown_whitespace(markdown: String) -> String {
-    let mut normalized = String::with_capacity(markdown.len());
-    let mut in_fenced_code = false;
-
-    for line in markdown.split_inclusive('\n') {
-        let content_end = line.strip_suffix('\n').map_or(line.len(), str::len);
-        let content = &line[..content_end];
-        let is_fence =
-            content.trim_start().starts_with("```") || content.trim_start().starts_with("~~~");
-
-        if is_fence {
-            in_fenced_code = !in_fenced_code;
-            normalized.push_str(line);
-        } else if in_fenced_code {
-            normalized.push_str(line);
-        } else {
-            normalized.push_str(&normalize_markdown_line(content));
-            normalized.push_str(&line[content_end..]);
-        }
-    }
-
-    normalized
-}
-
-fn normalize_markdown_line(line: &str) -> String {
-    let mut normalized = String::with_capacity(line.len());
-    let mut inline_code_delimiter = None;
-    let mut chars = line.char_indices().peekable();
-
-    while let Some((index, character)) = chars.next() {
-        if character == '`' {
-            let mut delimiter_length = 1;
-            while chars.peek().is_some_and(|(_, next)| *next == '`') {
-                chars.next();
-                delimiter_length += 1;
-            }
-            if inline_code_delimiter == Some(delimiter_length) {
-                inline_code_delimiter = None;
-            } else if inline_code_delimiter.is_none() {
-                inline_code_delimiter = Some(delimiter_length);
-            }
-            normalized.push_str(&line[index..index + delimiter_length]);
-        } else if character == ' '
-            && inline_code_delimiter.is_none()
-            && chars
-                .clone()
-                .find(|(_, next)| *next != ' ')
-                .is_some_and(|(next_index, _)| next_index - index >= 3)
-        {
-            normalized.push(' ');
-            while chars.peek().is_some_and(|(_, next)| *next == ' ') {
-                chars.next();
-            }
-        } else {
-            normalized.push(character);
-        }
-    }
-
-    normalized
 }
 
 /// Sentinel value returned by R when a vignette is in PDF format.
@@ -688,14 +623,5 @@ More text after.
         let qmd = rd2qmd_core::convert_rd_document(parsed.document(), &options);
 
         insta::assert_snapshot!("rd_conversion_strips_if_html_content", qmd);
-    }
-
-    #[test]
-    fn test_normalize_markdown_whitespace_preserves_code_and_hard_breaks() {
-        let markdown = "prose   spaces  stay\n`code   spaces`\n```r\ncode   spaces\n```\n";
-        assert_eq!(
-            normalize_markdown_whitespace(markdown.to_string()),
-            "prose spaces  stay\n`code   spaces`\n```r\ncode   spaces\n```\n"
-        );
     }
 }

--- a/crates/arf-harp/tests/help.rs
+++ b/crates/arf-harp/tests/help.rs
@@ -67,6 +67,29 @@ fn test_help_package_alias_and_exact_key() {
 }
 
 #[test]
+fn test_help_package_embed_fonts_does_not_have_excessive_prose_spaces() {
+    if !ld_library_path_is_set() {
+        eprintln!(
+            "Skipping test_help_package_embed_fonts_does_not_have_excessive_prose_spaces: \
+             LD_LIBRARY_PATH not set."
+        );
+        return;
+    }
+
+    with_r(|| {
+        let markdown = get_package_help_markdown("embedFonts", "grDevices")
+            .expect("grDevices::embedFonts help should be available");
+        assert!(
+            markdown.contains("and embed all fonts"),
+            "unexpected markdown:\n{markdown}"
+        );
+        assert!(markdown.contains("as the name of a Ghostscript"));
+        assert!(!markdown.contains("and   embed"));
+        assert!(!markdown.contains("as     the"));
+    });
+}
+
+#[test]
 fn test_help_package_and_topic_not_found() {
     if !ld_library_path_is_set() {
         eprintln!("Skipping test_help_package_and_topic_not_found: LD_LIBRARY_PATH not set.");


### PR DESCRIPTION
## Context

The help output for topics such as grDevices::embedFonts contained excessive spaces in ordinary prose. The issue was reproducible through both the help database path and the R Rd-source path, and the minimal reproduction showed that rd2qmd-core 0.5.0-beta.1 emitted the extra spaces when adjacent prose Text nodes were joined.

## Changes

- Patch rd2qmd-core to upstream commit 2dce12b6b41f74a02e68a1514c4be500f6f841fc via patch.crates-io.
- Update Cargo.lock to record the Git revision.
- Add a grDevices::embedFonts regression test.

The final application code does not perform generic Markdown whitespace rewriting. An earlier commit in this branch contained a temporary arf-side normalizer while the upstream fix was being prepared; the following commit removed it after the upstream fix was available. This keeps indentation, hard line breaks, inline code, and fenced code semantics under rd2qmd-core rather than reinterpreting Markdown in arf.

## Verification

- cargo test -p arf-harp --all-targets (74 passed)
- cargo clippy -p arf-harp --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Upstream: eitsupi/rd2qmd commit 2dce12b6b41f74a02e68a1514c4be500f6f841fc