### PR TITLE
feat: render Arguments section as a Markdown list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Tab completion of package names and the `:help` browser (search and rendering) are now noticeably faster, especially with many installed packages, since they read R's on-disk package metadata directly instead of evaluating R code for most lookups (#257).
+- The `:help` browser now renders the Arguments section as a list instead of a table, so argument descriptions containing bullet lists or multiple paragraphs are shown in full rather than squashed onto one line.
 
 ## [0.4.3] - 2026-07-04
 

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -402,7 +402,7 @@ pub fn get_package_help_markdown(topic: &str, package: &str) -> HarpResult<Strin
     })?;
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
-    options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
+    options.arguments_format = rd2qmd_core::ArgumentsFormat::List;
     Ok(rd2qmd_core::convert_rd_document(&doc, &options))
 }
 
@@ -436,7 +436,7 @@ fn get_help_markdown_via_r(topic: &str) -> HarpResult<String> {
     })?;
     let mut options = rd2qmd_core::RdConvertOptions::default();
     options.code.quarto_code_blocks = false;
-    options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
+    options.arguments_format = rd2qmd_core::ArgumentsFormat::List;
     Ok(rd2qmd_core::convert_rd_document(
         parsed.document(),
         &options,
@@ -619,9 +619,36 @@ More text after.
         let parsed = rd_source::parse(rd_content.as_bytes()).unwrap();
         let mut options = rd2qmd_core::RdConvertOptions::default();
         options.code.quarto_code_blocks = false;
-        options.arguments_format = rd2qmd_core::ArgumentsFormat::PipeTable;
+        options.arguments_format = rd2qmd_core::ArgumentsFormat::List;
         let qmd = rd2qmd_core::convert_rd_document(parsed.document(), &options);
 
         insta::assert_snapshot!("rd_conversion_strips_if_html_content", qmd);
+    }
+
+    #[test]
+    fn test_rd_conversion_arguments_preserves_blocks() {
+        let rd_content = r#"
+\name{arguments}
+\title{Arguments}
+\arguments{
+    \item{value}{
+        Description before the list.
+        \itemize{
+            \item First nested item.
+            \item Second nested item.
+        }
+
+        A second paragraph after the list.
+    }
+}
+"#;
+
+        let parsed = rd_source::parse(rd_content.as_bytes()).unwrap();
+        let mut options = rd2qmd_core::RdConvertOptions::default();
+        options.code.quarto_code_blocks = false;
+        options.arguments_format = rd2qmd_core::ArgumentsFormat::List;
+        let qmd = rd2qmd_core::convert_rd_document(parsed.document(), &options);
+
+        insta::assert_snapshot!("rd_conversion_arguments_preserves_blocks", qmd);
     }
 }

--- a/crates/arf-harp/src/snapshots/arf_harp__help__tests__rd_conversion_arguments_preserves_blocks.snap
+++ b/crates/arf-harp/src/snapshots/arf_harp__help__tests__rd_conversion_arguments_preserves_blocks.snap
@@ -1,0 +1,17 @@
+---
+source: crates/arf-harp/src/help.rs
+assertion_line: 652
+expression: qmd
+---
+# Arguments
+
+## Arguments
+
+- **`value`**
+
+  Description before the list.
+
+  - First nested item.
+  - Second nested item.
+
+  A second paragraph after the list.


### PR DESCRIPTION
## Summary

The `:help` browser rendered an R help page's Arguments section as a Markdown **pipe table**. Pipe table cells cannot hold block content, so rd2qmd's `convert_arguments_pipe` had to flatten `\itemize` / `\enumerate` lists and multiple paragraphs into `<br>`-joined text — argument descriptions that are structured lists in the original Rd were squashed onto one line.

This switches the two conversion call sites to `rd2qmd_core::ArgumentsFormat::List`, which emits a Markdown loose list. Nested lists and paragraphs now survive into the rendered help page.

## Before / after

`?cli::cli_progress_bar`, whose `type` argument documents its values as a bullet list:

**Before** — the nested list is flattened into the table cell:

```
| Argument | Description |
| type | Type of the progress bar. ... Currently supported types:<br>- iterator: ...<br>- tasks: ... |
```

**After**:

```
- type

  Type of the progress bar. It is used to select a default display if format is not specified.
  Currently supported types:
  - iterator: e.g. a for loop or a mapping function,
  - tasks: a (typically small) number of tasks,
```

## Changes

- `crates/arf-harp/src/help.rs`: `ArgumentsFormat::PipeTable` → `ArgumentsFormat::List` in `get_package_help_markdown` (helpdb path) and `get_help_markdown_via_r` (R fallback path).
- Added `test_rd_conversion_arguments_preserves_blocks` with an insta snapshot: an Rd fixture whose `\arguments` item description contains an `\itemize` list plus a second paragraph, asserting both survive the conversion.

No change was needed in the pager's Markdown renderer — it already handles nested lists, paragraph separation inside list items, and continuation-line indentation.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p arf-harp --lib` (30 passed)
- [x] `cargo build`
- [x] Verified the rendered output in the real TUI: opened `?cli::cli_progress_bar` in the help browser and confirmed the nested bullet list under `type` renders with correct indentation.

Note: `crates/arf-harp/tests/help.rs`'s `test_help_topics_reads_installed_indexes` fails in my environment, but it fails identically on `main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
