### PR TITLE
fix: preserve IPC echo line when R produces no output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Tab completion of package names and the `:help` browser (search and rendering) are now noticeably faster, especially with many installed packages, since they read R's on-disk package metadata directly instead of evaluating R code for most lookups (#257).
 - The `:help` browser now renders the Arguments section as a list instead of a table, so argument descriptions containing bullet lists or multiple paragraphs are shown in full rather than squashed onto one line.
 
+### Fixed
+
+- `arf ipc send` input that produced no R output (e.g. assignments) could vanish from the REPL instead of being echoed, while inputs that produced output were shown reliably (#265).
+
 ## [0.4.3] - 2026-07-04
 
 ### Fixed

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1244,6 +1244,13 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
 
                         clear_and_show_agent_prompt(&op.code);
 
+                        // ExternalBreak leaves reedline's previous prompt position suspended.
+                        // Its saved row range includes the line after a single-line prompt, so
+                        // leave the cursor one row beyond that range. Otherwise, when R produces
+                        // no output, the next repaint reuses the old prompt origin and clears the
+                        // echoed agent line.
+                        println!();
+
                         if !op.code.is_empty() {
                             let entry = reedline::HistoryItem::from_command_line(&op.code);
                             let _ = editor.history_mut().save(entry);

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -457,12 +457,60 @@ mod ipc_tests {
             .expect("should see R output");
         terminal.wait_for_prompt().expect("should return to prompt");
 
+        let screen = terminal.screen().expect("should get terminal screen");
+        assert!(
+            screen
+                .lines
+                .iter()
+                .any(|line| line.contains("agent> cat('marker_output\\n')")),
+            "IPC echo should remain visible when the expression produces output; screen:\n{}",
+            screen.lines.join("\n")
+        );
+
         // The line immediately above the prompt should be the R output,
         // not a blank line.
         terminal
             .previous_line(1)
             .assert_contains("marker_output")
             .expect("line above prompt should be R output, not a blank line");
+
+        terminal.quit().expect("Should quit cleanly");
+    }
+
+    /// Test that an IPC user_input echo remains visible when R produces no output.
+    #[test]
+    fn test_ipc_user_input_silent_expression_keeps_echo() {
+        let (mut terminal, socket_path) = spawn_ipc_session();
+
+        let response = send_ipc_request(
+            &socket_path,
+            "user_input",
+            serde_json::json!({ "code": "ipc_silent_echo <- 1" }),
+        )
+        .expect("IPC request should succeed");
+
+        assert!(
+            response
+                .get("result")
+                .and_then(|r| r.get("accepted"))
+                .and_then(|a| a.as_bool())
+                == Some(true),
+            "user_input should be accepted, got: {response:?}"
+        );
+
+        // The IPC response is sent as soon as the input is accepted, before R
+        // evaluates it. Wait for the no-output expression and prompt repaint.
+        std::thread::sleep(Duration::from_millis(500));
+
+        let screen = terminal.screen().expect("should get terminal screen");
+        assert!(
+            screen
+                .lines
+                .iter()
+                .any(|line| line.contains("agent> ipc_silent_echo <- 1")),
+            "IPC echo should remain visible after a silent expression; screen:\n{}",
+            screen.lines.join("\n")
+        );
 
         terminal.quit().expect("Should quit cleanly");
     }

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -499,8 +499,20 @@ mod ipc_tests {
         );
 
         // The IPC response is sent as soon as the input is accepted, before R
-        // evaluates it. Wait for the no-output expression and prompt repaint.
-        std::thread::sleep(Duration::from_millis(500));
+        // evaluates it. Wait for the echo to appear, then synchronize on the
+        // next fresh prompt so the post-evaluation repaint has definitely
+        // happened before inspecting the screen — a fixed sleep would let the
+        // test pass by inspecting the echo before the repaint that used to
+        // erase it.
+        terminal
+            .expect("ipc_silent_echo <- 1")
+            .expect("should see the echoed code in the output stream");
+        terminal
+            .clear_buffer()
+            .expect("should clear the output buffer");
+        terminal
+            .wait_for_prompt()
+            .expect("should return to a fresh prompt after evaluation");
 
         let screen = terminal.screen().expect("should get terminal screen");
         assert!(

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -499,19 +499,19 @@ mod ipc_tests {
         );
 
         // The IPC response is sent as soon as the input is accepted, before R
-        // evaluates it. Wait for the echo to appear, then synchronize on the
-        // next fresh prompt so the post-evaluation repaint has definitely
-        // happened before inspecting the screen — a fixed sleep would let the
+        // evaluates it. `expect()` matches against the whole accumulated
+        // buffer, so the echo and the post-evaluation prompt can arrive in
+        // the same PTY read — clearing the buffer between two separate
+        // `expect()` calls would risk discarding the prompt bytes and
+        // timing out. Instead, match a single regex requiring a "> " prompt
+        // AFTER the echoed code; the only such prompt is the real one
+        // redrawn once evaluation completes (the "agent> " echo itself
+        // precedes the code, not follows it). A fixed sleep would let the
         // test pass by inspecting the echo before the repaint that used to
-        // erase it.
+        // erase it — this waits for a definitive post-evaluation signal
+        // instead.
         terminal
-            .expect("ipc_silent_echo <- 1")
-            .expect("should see the echoed code in the output stream");
-        terminal
-            .clear_buffer()
-            .expect("should clear the output buffer");
-        terminal
-            .wait_for_prompt()
+            .expect_regex(r"ipc_silent_echo <- 1[\s\S]*> ")
             .expect("should return to a fresh prompt after evaluation");
 
         let screen = terminal.screen().expect("should get terminal screen");


### PR DESCRIPTION
## Summary

- `arf ipc send` input that produced no R output (e.g. plain assignments) could vanish from the REPL instead of being echoed, while inputs that produced output (e.g. errors) were shown reliably. Fixes #265.
- Root cause: after echoing the `agent> ...` line, the `ExternalBreak` code path left the cursor within reedline's previously saved prompt row range. When the expression produced no output, the next repaint reused that stale origin and erased the echoed line.
- Fix: advance the cursor one row past the old prompt range right after echoing, so the subsequent repaint no longer clears it.
- Added a PTY regression test (`test_ipc_user_input_silent_expression_keeps_echo`) that synchronizes on a definitive post-evaluation signal (a prompt appearing after the echoed code, matched via regex) rather than a fixed sleep, to reliably catch this regression.

## Test plan

- [x] `cargo build`
- [x] `cargo test -p arf-console` (all `pty_ipc_tests` pass, including the new regression test)
- [x] `cargo fmt --all -- --check`
- [x] Verified the new test fails when the fix in `repl/mod.rs` is reverted, and passes once restored
- [x] Manual verification in tmux with a real `arf --with-ipc` session: repeated `arf ipc send` of no-output assignments reliably keep the echo visible after the fix (previously flaky, ~1/3 of attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)