### PR TITLE
fix(ipc): record commands sent over IPC in the history database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived.
+- IPC requests containing incomplete R expressions are now rejected before they can enter the continuation prompt.
 
 ## [0.4.4] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived.
+
 ## [0.4.4] - 2026-07-26
 
 ### Changed

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -28,6 +28,11 @@ impl RValidator {
         self
     }
 
+    /// Check whether an R expression is complete without synchronizing editor state.
+    pub fn is_complete(&self, line: &str) -> bool {
+        matches!(self.validate(line), ValidationResult::Complete)
+    }
+
     fn create_parser() -> tree_sitter::Parser {
         let mut parser = tree_sitter::Parser::new();
         parser

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -115,6 +115,10 @@ fn rpc_error_info(code: i32) -> (&'static str, Option<&'static str>) {
                  their input.",
             ),
         ),
+        INCOMPLETE_INPUT => (
+            "INCOMPLETE_INPUT",
+            Some("Complete the R expression before sending it over IPC."),
+        ),
         PARSE_ERROR => ("PARSE_ERROR", None),
         INVALID_REQUEST => ("INVALID_REQUEST", None),
         METHOD_NOT_FOUND => ("METHOD_NOT_FOUND", None),

--- a/crates/arf-console/src/ipc/protocol.rs
+++ b/crates/arf-console/src/ipc/protocol.rs
@@ -71,6 +71,7 @@ pub const R_BUSY: i32 = -32000;
 pub const R_NOT_AT_PROMPT: i32 = -32001;
 pub const INPUT_ALREADY_PENDING: i32 = -32002;
 pub const USER_IS_TYPING: i32 = -32003;
+pub const INCOMPLETE_INPUT: i32 = -32004;
 
 /// Parameters for the `evaluate` method.
 #[derive(Debug, Deserialize)]

--- a/crates/arf-console/src/ipc/server.rs
+++ b/crates/arf-console/src/ipc/server.rs
@@ -4,10 +4,11 @@
 //! Each connection is handled as a simple HTTP-like JSON-RPC endpoint:
 //! read one request, dispatch via mpsc channel, await oneshot reply, respond.
 
+use crate::editor::validator::RValidator;
 use crate::ipc::protocol::{
-    EvaluateParams, HistoryParams, INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST, IpcMethod,
-    IpcRequest, IpcResponse, JsonRpcRequest, JsonRpcResponse, METHOD_NOT_FOUND, PARSE_ERROR,
-    ShutdownResult, UserInputParams,
+    EvaluateParams, HistoryParams, INCOMPLETE_INPUT, INTERNAL_ERROR, INVALID_PARAMS,
+    INVALID_REQUEST, IpcMethod, IpcRequest, IpcResponse, JsonRpcRequest, JsonRpcResponse,
+    METHOD_NOT_FOUND, PARSE_ERROR, ShutdownResult, UserInputParams,
 };
 use crate::ipc::session::{SessionInfo, remove_session, write_session};
 use std::sync::mpsc;
@@ -746,6 +747,9 @@ async fn dispatch_request(
                     );
                 }
             };
+            if let Some(response) = incomplete_input_response(id.clone(), &params.code) {
+                return response;
+            }
             IpcMethod::Evaluate {
                 code: params.code,
                 visible: params.visible,
@@ -779,6 +783,9 @@ async fn dispatch_request(
                     );
                 }
             };
+            if let Some(response) = incomplete_input_response(id.clone(), &params.code) {
+                return response;
+            }
             IpcMethod::UserInput { code: params.code }
         }
         "session" => IpcMethod::Session,
@@ -905,6 +912,19 @@ async fn dispatch_request(
             JsonRpcResponse::error(id, INTERNAL_ERROR, "Request timed out".to_string())
         }
     }
+}
+
+/// Reject code that would make R wait for continuation input.
+fn incomplete_input_response(id: Option<serde_json::Value>, code: &str) -> Option<JsonRpcResponse> {
+    if RValidator::new().is_complete(code) {
+        return None;
+    }
+
+    Some(JsonRpcResponse::error(
+        id,
+        INCOMPLETE_INPUT,
+        "R code is syntactically incomplete".to_string(),
+    ))
 }
 
 /// Find the position of the end of HTTP headers (`\r\n\r\n`).

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1110,9 +1110,14 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                     // For non-standard prompts (menus, etc.), pass input directly to R
                     // without any processing (meta commands, shell mode, reprex, autoformat)
                     if is_menu_prompt {
-                        if !line.trim().is_empty() {
-                            state.pending_history_context = PendingHistoryContext::Reedline;
-                        }
+                        // Deliberately leave pending_history_context alone. This
+                        // input was requested by R during an evaluation that is
+                        // already in progress (readline(), menu(), browser()),
+                        // so the outer command still owns the result. Claiming
+                        // the context here would strand the outer entry without
+                        // an exit status, which matters most when that entry
+                        // came from IPC and cannot be recovered from reedline's
+                        // own last-command context.
                         return Some(line);
                     }
 

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -46,7 +46,7 @@ use meta_command::{MetaCommandResult, process_meta_command};
 use prompt::RPrompt;
 use reprex::{clear_input_lines, strip_reprex_output};
 use shell::{execute_shell_command, restart_process};
-use state::{PromptRuntimeConfig, ReplState};
+use state::{PendingHistoryContext, PromptRuntimeConfig, ReplState};
 
 // Thread-local storage for the REPL state.
 // This allows the ReadConsole callback to access the line editor.
@@ -548,7 +548,7 @@ impl Repl {
                 } else {
                     None
                 },
-                skip_next_command_context_update: false,
+                pending_history_context: PendingHistoryContext::None,
             });
         });
 
@@ -943,44 +943,66 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
         crate::ipc::set_r_at_prompt(is_r_command_prompt(r_prompt));
 
         if is_r_command_prompt(r_prompt) && !state.prompt_config.is_shell_enabled() {
-            let had_error = if state.skip_next_command_context_update {
-                state.skip_next_command_context_update = false;
-                false
-            } else if state.line_editor.has_last_command_context() {
-                let had_error = arf_libr::command_had_error();
-                let exit_status = if had_error { 1i64 } else { 0i64 };
+            let pending_history_context = std::mem::take(&mut state.pending_history_context);
+            let had_error = match pending_history_context {
+                PendingHistoryContext::Reedline => {
+                    if state.line_editor.has_last_command_context() {
+                        let had_error = arf_libr::command_had_error();
+                        let exit_status = if had_error { 1i64 } else { 0i64 };
 
-                // Use Cell to capture the history item ID through the immutable closure
-                let captured_id: std::cell::Cell<Option<reedline::HistoryItemId>> =
-                    std::cell::Cell::new(None);
-                let _ = state.line_editor.update_last_command_context(&|mut item| {
-                    item.exit_status = Some(exit_status);
-                    captured_id.set(item.id);
-                    item
-                });
+                        // Use Cell to capture the history item ID through the immutable closure
+                        let captured_id: std::cell::Cell<Option<reedline::HistoryItemId>> =
+                            std::cell::Cell::new(None);
+                        let _ = state.line_editor.update_last_command_context(&|mut item| {
+                            item.exit_status = Some(exit_status);
+                            captured_id.set(item.id);
+                            item
+                        });
 
-                // Sponge feature: track all commands and purge old failed ones.
-                // See SpongeQueue for the algorithm details.
-                if state.forget_config.enabled {
-                    // Determine effective delay: use configured delay normally,
-                    // or usize::MAX for on_exit_only (defer all deletions until exit)
-                    let effective_delay = if state.forget_config.on_exit_only {
-                        usize::MAX
+                        // Sponge feature: track all commands and purge old failed ones.
+                        // See SpongeQueue for the algorithm details.
+                        if state.forget_config.enabled {
+                            // Determine effective delay: use configured delay normally,
+                            // or usize::MAX for on_exit_only (defer all deletions until exit)
+                            let effective_delay = if state.forget_config.on_exit_only {
+                                usize::MAX
+                            } else {
+                                state.forget_config.delay
+                            };
+
+                            if let Some(id_to_delete) = state.sponge_queue.record_command(
+                                had_error,
+                                captured_id.get(),
+                                effective_delay,
+                            ) {
+                                let _ = state.line_editor.history_mut().delete(id_to_delete);
+                            }
+                        }
+                        had_error
                     } else {
-                        state.forget_config.delay
-                    };
-
-                    if let Some(id_to_delete) = state.sponge_queue.record_command(
-                        had_error,
-                        captured_id.get(),
-                        effective_delay,
-                    ) {
-                        let _ = state.line_editor.history_mut().delete(id_to_delete);
+                        false
                     }
                 }
-                had_error
-            } else {
-                false
+                PendingHistoryContext::Ipc { history_id } => {
+                    // IPC history is saved before evaluation. Reedline's
+                    // History::update API accepts that saved ID, so update the
+                    // IPC entry directly instead of touching the previous
+                    // interactive entry. This also preserves the error status
+                    // for IPC commands in the history database.
+                    let had_error = arf_libr::command_had_error();
+                    if let Some(history_id) = history_id {
+                        let exit_status = if had_error { 1i64 } else { 0i64 };
+                        let _ = state
+                            .line_editor
+                            .history_mut()
+                            .update(history_id, &|mut item| {
+                                item.exit_status = Some(exit_status);
+                                item
+                            });
+                    }
+                    had_error
+                }
+                PendingHistoryContext::None => false,
             };
 
             // Update prompt status indicator for the next prompt
@@ -1013,6 +1035,14 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                 }
                 PendingIpcKind::VisibleEvaluate { reply, timeout } => {
                     setup_visible_eval(reply, timeout);
+                    let history_id = save_ipc_history(
+                        &mut state.line_editor,
+                        &op.code,
+                        state.history_session_id,
+                    );
+                    if !op.code.trim().is_empty() {
+                        state.pending_history_context = PendingHistoryContext::Ipc { history_id };
+                    }
                     let prompt_str = "agent> ";
                     println!("{}{}", prompt_str.dark_cyan(), op.code);
                     if !op.code.is_empty() {
@@ -1024,9 +1054,13 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                 }
                 PendingIpcKind::UserInput { reply } => {
                     accept_user_input(reply);
-                    save_ipc_history(&mut state.line_editor, &op.code, state.history_session_id);
-                    if !op.code.is_empty() {
-                        state.skip_next_command_context_update = true;
+                    let history_id = save_ipc_history(
+                        &mut state.line_editor,
+                        &op.code,
+                        state.history_session_id,
+                    );
+                    if !op.code.trim().is_empty() {
+                        state.pending_history_context = PendingHistoryContext::Ipc { history_id };
                     }
                     let prompt_str = "agent> ";
                     println!("{}{}", prompt_str.dark_cyan(), op.code);
@@ -1076,6 +1110,9 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                     // For non-standard prompts (menus, etc.), pass input directly to R
                     // without any processing (meta commands, shell mode, reprex, autoformat)
                     if is_menu_prompt {
+                        if !line.trim().is_empty() {
+                            state.pending_history_context = PendingHistoryContext::Reedline;
+                        }
                         return Some(line);
                     }
 
@@ -1165,6 +1202,9 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                     crate::ipc::set_r_at_prompt(false);
 
                     // Return the (possibly formatted) code to R
+                    if !code.trim().is_empty() {
+                        state.pending_history_context = PendingHistoryContext::Reedline;
+                    }
                     return Some(code);
                 }
                 Ok(Signal::CtrlC) => {
@@ -1250,9 +1290,11 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                             PendingIpcKind::SilentEvaluate { .. } => unreachable!(),
                         }
 
-                        save_ipc_history(editor, &op.code, state.history_session_id);
-                        if !op.code.is_empty() {
-                            state.skip_next_command_context_update = true;
+                        let history_id =
+                            save_ipc_history(editor, &op.code, state.history_session_id);
+                        if !op.code.trim().is_empty() {
+                            state.pending_history_context =
+                                PendingHistoryContext::Ipc { history_id };
                         }
 
                         clear_and_show_agent_prompt(&op.code);
@@ -1483,9 +1525,13 @@ fn setup_history(
 ///
 /// A history failure is deliberately non-fatal: the injected code must still
 /// be evaluated and its IPC response must still be delivered.
-fn save_ipc_history(editor: &mut Reedline, code: &str, session_id: Option<HistorySessionId>) {
-    if code.is_empty() {
-        return;
+fn save_ipc_history(
+    editor: &mut Reedline,
+    code: &str,
+    session_id: Option<HistorySessionId>,
+) -> Option<reedline::HistoryItemId> {
+    if code.trim().is_empty() {
+        return None;
     }
 
     let mut item = reedline::HistoryItem::from_command_line(code);
@@ -1496,8 +1542,61 @@ fn save_ipc_history(editor: &mut Reedline, code: &str, session_id: Option<Histor
         .map(|path| path.to_string_lossy().into_owned());
     item.session_id = session_id;
 
-    if let Err(e) = editor.history_mut().save(item) {
-        log::warn!("Failed to save IPC history: {}", e);
+    match editor.history_mut().save(item) {
+        Ok(item) => item.id,
+        Err(e) => {
+            log::warn!("Failed to save IPC history: {}", e);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod ipc_history_tests {
+    use super::save_ipc_history;
+    use reedline::{Reedline, SearchDirection, SearchQuery, SqliteBackedHistory};
+
+    fn everything_query() -> SearchQuery {
+        SearchQuery::everything(SearchDirection::Forward, None)
+    }
+
+    #[test]
+    fn save_ipc_history_ignores_whitespace_only_code() {
+        let temp_dir = tempfile::tempdir().expect("create temporary history directory");
+        let history = SqliteBackedHistory::with_file(temp_dir.path().join("r.db"), None, None)
+            .expect("create SQLite history");
+        let mut editor = Reedline::create().with_history(Box::new(history));
+
+        assert!(save_ipc_history(&mut editor, " \t\n ", None).is_none());
+        assert_eq!(
+            editor
+                .history()
+                .count(everything_query())
+                .expect("count history entries"),
+            0
+        );
+    }
+
+    #[test]
+    fn save_ipc_history_returns_id_for_later_status_update() {
+        let temp_dir = tempfile::tempdir().expect("create temporary history directory");
+        let history = SqliteBackedHistory::with_file(temp_dir.path().join("r.db"), None, None)
+            .expect("create SQLite history");
+        let mut editor = Reedline::create().with_history(Box::new(history));
+
+        let id = save_ipc_history(&mut editor, "ipc_history_test <- 1", None)
+            .expect("saved IPC history should have an ID");
+        editor
+            .history_mut()
+            .update(id, &|mut item| {
+                item.exit_status = Some(1);
+                item
+            })
+            .expect("saved IPC history should be updateable by ID");
+
+        let item = editor.history().load(id).expect("load saved IPC history");
+        assert_eq!(item.command_line, "ipc_history_test <- 1");
+        assert_eq!(item.exit_status, Some(1));
     }
 }
 

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1207,7 +1207,10 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                     crate::ipc::set_r_at_prompt(false);
 
                     // Return the (possibly formatted) code to R
-                    if !code.trim().is_empty() {
+                    // Only a top-level command starts a new Reedline history
+                    // context. Continuation prompts remain part of the outer
+                    // command, so preserve its context until evaluation ends.
+                    if is_r_command_prompt(r_prompt) && !code.trim().is_empty() {
                         state.pending_history_context = PendingHistoryContext::Reedline;
                     }
                     return Some(code);

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -544,10 +544,11 @@ impl Repl {
                 dir_stack: Vec::new(),
                 // Only expose session ID if at least one history DB was opened
                 history_session_id: if r_history_ok || shell_history_ok {
-                    self.history_session_id_raw()
+                    self.session_id
                 } else {
                     None
                 },
+                skip_next_command_context_update: false,
             });
         });
 
@@ -942,7 +943,10 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
         crate::ipc::set_r_at_prompt(is_r_command_prompt(r_prompt));
 
         if is_r_command_prompt(r_prompt) && !state.prompt_config.is_shell_enabled() {
-            let had_error = if state.line_editor.has_last_command_context() {
+            let had_error = if state.skip_next_command_context_update {
+                state.skip_next_command_context_update = false;
+                false
+            } else if state.line_editor.has_last_command_context() {
                 let had_error = arf_libr::command_had_error();
                 let exit_status = if had_error { 1i64 } else { 0i64 };
 
@@ -1020,6 +1024,10 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                 }
                 PendingIpcKind::UserInput { reply } => {
                     accept_user_input(reply);
+                    save_ipc_history(&mut state.line_editor, &op.code, state.history_session_id);
+                    if !op.code.is_empty() {
+                        state.skip_next_command_context_update = true;
+                    }
                     let prompt_str = "agent> ";
                     println!("{}{}", prompt_str.dark_cyan(), op.code);
                     if !op.code.is_empty() {
@@ -1079,7 +1087,7 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                         &state.shell_history_path,
                         &state.r_source_status,
                         &mut state.dir_stack,
-                        state.history_session_id,
+                        state.history_session_id.map(i64::from),
                     ) {
                         // Clear duration so the previous R command's time
                         // does not persist in the prompt after a meta command.
@@ -1242,6 +1250,11 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                             PendingIpcKind::SilentEvaluate { .. } => unreachable!(),
                         }
 
+                        save_ipc_history(editor, &op.code, state.history_session_id);
+                        if !op.code.is_empty() {
+                            state.skip_next_command_context_update = true;
+                        }
+
                         clear_and_show_agent_prompt(&op.code);
 
                         // ExternalBreak leaves reedline's previous prompt position suspended.
@@ -1250,11 +1263,6 @@ fn read_console_callback(r_prompt: &str) -> Option<String> {
                         // no output, the next repaint reuses the old prompt origin and clears the
                         // echoed agent line.
                         println!();
-
-                        if !op.code.is_empty() {
-                            let entry = reedline::HistoryItem::from_command_line(&op.code);
-                            let _ = editor.history_mut().save(entry);
-                        }
 
                         if !op.code.is_empty() {
                             state.prompt_config.set_command_start();
@@ -1468,6 +1476,28 @@ fn setup_history(
             log::warn!("Failed to open history database {}: {}", path.display(), e);
             (line_editor, false)
         }
+    }
+}
+
+/// Save an IPC-injected command using the same metadata as headless history.
+///
+/// A history failure is deliberately non-fatal: the injected code must still
+/// be evaluated and its IPC response must still be delivered.
+fn save_ipc_history(editor: &mut Reedline, code: &str, session_id: Option<HistorySessionId>) {
+    if code.is_empty() {
+        return;
+    }
+
+    let mut item = reedline::HistoryItem::from_command_line(code);
+    item.start_timestamp = Some(chrono::Utc::now());
+    item.hostname = Some(gethostname::gethostname().to_string_lossy().into_owned());
+    item.cwd = std::env::current_dir()
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned());
+    item.session_id = session_id;
+
+    if let Err(e) = editor.history_mut().save(item) {
+        log::warn!("Failed to save IPC history: {}", e);
     }
 }
 

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -1484,6 +1484,11 @@ fn handle_meta_command_result(
 /// Reference: This approach is used by ark (Positron's R kernel).
 fn is_r_command_prompt(prompt: &str) -> bool {
     // Continuation prompts (starting with '+') are NOT command prompts
+    //
+    // TODO: R lets users change this prefix with options(continue = "..."),
+    // and a custom value is then misread as a command prompt. Compare against
+    // R's configured continuation string instead. Every caller of this
+    // function is affected, including IPC request admission.
     if prompt.starts_with('+') {
         return false;
     }

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -29,6 +29,26 @@ pub struct SpongeQueue {
     queue: VecDeque<Option<HistoryItemId>>,
 }
 
+/// Identifies which history entry should receive the result of the command
+/// that just finished evaluating.
+///
+/// IPC entries are saved before R evaluates them, so they cannot use
+/// reedline's internal last-command context. Keep their ID explicitly and
+/// update that entry when the next prompt is built instead.
+#[derive(Debug, Default)]
+pub enum PendingHistoryContext {
+    /// The last command was submitted through reedline and its context should
+    /// be updated through `update_last_command_context`.
+    Reedline,
+    /// The last command was injected through IPC. The ID is absent when the
+    /// history backend rejected the save, but the command status still needs
+    /// to be reflected in the prompt.
+    Ipc { history_id: Option<HistoryItemId> },
+    /// No command needs a history context update.
+    #[default]
+    None,
+}
+
 impl SpongeQueue {
     /// Create a new empty sponge queue.
     pub fn new() -> Self {
@@ -124,8 +144,8 @@ pub struct ReplState {
     pub dir_stack: Vec<PathBuf>,
     /// History session ID for R history entries and IPC metadata.
     pub history_session_id: Option<HistorySessionId>,
-    /// Skip updating reedline's last interactive command after an IPC entry.
-    pub skip_next_command_context_update: bool,
+    /// History context for the command whose evaluation just completed.
+    pub pending_history_context: PendingHistoryContext,
 }
 
 /// Runtime configuration for prompts that can be modified during the session.

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -7,7 +7,7 @@ use crate::config::{
 use crate::editor::prompt::PromptFormatter;
 use crate::external::formatter;
 use nu_ansi_term::Color;
-use reedline::{HistoryItemId, Reedline};
+use reedline::{HistoryItemId, HistorySessionId, Reedline};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -122,8 +122,10 @@ pub struct ReplState {
     pub sponge_queue: SpongeQueue,
     /// Directory stack for :pushd/:popd navigation.
     pub dir_stack: Vec<PathBuf>,
-    /// History session ID as raw i64 (for IPC).
-    pub history_session_id: Option<i64>,
+    /// History session ID for R history entries and IPC metadata.
+    pub history_session_id: Option<HistorySessionId>,
+    /// Skip updating reedline's last interactive command after an IPC entry.
+    pub skip_next_command_context_update: bool,
 }
 
 /// Runtime configuration for prompts that can be modified during the session.

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -104,6 +104,42 @@ mod ipc_tests {
         serde_json::from_str(json_body).map_err(|e| format!("Parse failed: {e}: {json_body}"))
     }
 
+    /// Query the interactive session's history for a command marker.
+    fn query_history(socket_path: &str, marker: &str) -> serde_json::Value {
+        let response = send_ipc_request(
+            socket_path,
+            "history",
+            serde_json::json!({
+                "all_sessions": true,
+                "grep": marker,
+                "limit": 10
+            }),
+        )
+        .expect("history request should succeed");
+        response
+            .get("result")
+            .cloned()
+            .expect("history response should have a result")
+    }
+
+    /// Assert that a user_input command has been persisted with the expected
+    /// session metadata, rather than only being evaluated in R.
+    fn assert_ipc_history_entry(socket_path: &str, marker: &str) {
+        let result = query_history(socket_path, marker);
+        let entries = result
+            .get("entries")
+            .and_then(|entries| entries.as_array())
+            .expect("history result should contain entries");
+        let entry = entries
+            .iter()
+            .find(|entry| entry.get("command").and_then(|v| v.as_str()) == Some(marker))
+            .unwrap_or_else(|| panic!("history should contain {marker}: {result}"));
+
+        assert!(entry.get("timestamp").and_then(|v| v.as_str()).is_some());
+        assert!(entry.get("cwd").and_then(|v| v.as_str()).is_some());
+        assert!(entry.get("session_id").and_then(|v| v.as_i64()).is_some());
+    }
+
     /// Helper to spawn arf with IPC and return (terminal, socket_path).
     fn spawn_ipc_session() -> (Terminal, String) {
         let mut terminal =
@@ -363,6 +399,72 @@ mod ipc_tests {
             .wait_for_prompt()
             .expect("Should return to prompt after IPC input execution");
 
+        terminal.quit().expect("Should quit cleanly");
+    }
+
+    /// Test that an IPC request arriving while reedline is already waiting
+    /// persists the user_input command through the ExternalBreak path.
+    #[test]
+    fn test_ipc_user_input_history_external_break() {
+        let tmp = tempfile::TempDir::new().expect("create history dir");
+        let history_dir = tmp.path().to_str().expect("history dir should be UTF-8");
+        let (mut terminal, socket_path) = {
+            let mut terminal =
+                Terminal::spawn_with_args(&["--with-ipc", "--history-dir", history_dir])
+                    .expect("Failed to spawn arf with IPC");
+            terminal
+                .wait_for_prompt()
+                .expect("Should show prompt after startup");
+            std::thread::sleep(Duration::from_millis(500));
+            let socket_path = find_socket_path(terminal.process_id(), Duration::from_secs(1))
+                .expect("find socket");
+            (terminal, socket_path)
+        };
+
+        let marker = "ipc_external_history_marker <- 1";
+        let response = send_ipc_request(
+            &socket_path,
+            "user_input",
+            serde_json::json!({ "code": marker }),
+        )
+        .expect("IPC request should succeed");
+        assert_eq!(response["result"]["accepted"], true);
+        terminal
+            .wait_for_prompt()
+            .expect("Should return to prompt after IPC input");
+
+        assert_ipc_history_entry(&socket_path, marker);
+        terminal.quit().expect("Should quit cleanly");
+    }
+
+    /// Test the fast-path timing window by sending immediately after the
+    /// prompt is displayed, before reedline has necessarily entered its input
+    /// loop. The same assertion also protects against route-dependent saves.
+    #[test]
+    fn test_ipc_user_input_history_fast_path() {
+        let tmp = tempfile::TempDir::new().expect("create history dir");
+        let history_dir = tmp.path().to_str().expect("history dir should be UTF-8");
+        let mut terminal = Terminal::spawn_with_args(&["--with-ipc", "--history-dir", history_dir])
+            .expect("Failed to spawn arf with IPC");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after startup");
+        let socket_path = find_socket_path(terminal.process_id(), Duration::from_secs(10))
+            .expect("Should find IPC socket path");
+
+        let marker = "ipc_fast_history_marker <- 1";
+        let response = send_ipc_request(
+            &socket_path,
+            "user_input",
+            serde_json::json!({ "code": marker }),
+        )
+        .expect("IPC request should succeed");
+        assert_eq!(response["result"]["accepted"], true);
+        terminal
+            .wait_for_prompt()
+            .expect("Should return to prompt after IPC input");
+
+        assert_ipc_history_entry(&socket_path, marker);
         terminal.quit().expect("Should quit cleanly");
     }
 

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -439,6 +439,76 @@ mod ipc_tests {
         terminal.quit().expect("Should quit cleanly");
     }
 
+    /// Test that incomplete user_input is rejected before it can enter R's
+    /// continuation prompt.
+    #[test]
+    fn test_ipc_user_input_rejects_incomplete_code() {
+        let (mut terminal, socket_path) = spawn_ipc_session();
+        clear_before_ipc_request(&mut terminal);
+
+        let response = send_ipc_request(
+            &socket_path,
+            "user_input",
+            serde_json::json!({ "code": "foo(" }),
+        )
+        .expect("IPC request should succeed");
+
+        assert_eq!(response["error"]["code"], -32004);
+        assert_eq!(
+            response["error"]["message"],
+            "R code is syntactically incomplete"
+        );
+
+        let screen = terminal.screen().expect("should get terminal screen");
+        assert!(
+            screen.lines.iter().any(|line| line.contains("> ")),
+            "REPL should remain at the normal prompt; screen:\n{}",
+            screen.lines.join("\n")
+        );
+        assert!(
+            !screen.lines.iter().any(|line| line.contains("+ ")),
+            "REPL should not enter the continuation prompt; screen:\n{}",
+            screen.lines.join("\n")
+        );
+
+        terminal.quit().expect("Should quit cleanly");
+    }
+
+    /// Test that silent evaluate rejects incomplete code before it can make R
+    /// wait for continuation input.
+    #[test]
+    fn test_ipc_evaluate_rejects_incomplete_code() {
+        let (mut terminal, socket_path) = spawn_ipc_session();
+        clear_before_ipc_request(&mut terminal);
+
+        let response = send_ipc_request(
+            &socket_path,
+            "evaluate",
+            serde_json::json!({ "code": "function(x) {" }),
+        )
+        .expect("IPC request should succeed");
+
+        assert_eq!(response["error"]["code"], -32004);
+        assert_eq!(
+            response["error"]["message"],
+            "R code is syntactically incomplete"
+        );
+
+        let screen = terminal.screen().expect("should get terminal screen");
+        assert!(
+            screen.lines.iter().any(|line| line.contains("> ")),
+            "REPL should remain at the normal prompt; screen:\n{}",
+            screen.lines.join("\n")
+        );
+        assert!(
+            !screen.lines.iter().any(|line| line.contains("+ ")),
+            "REPL should not enter the continuation prompt; screen:\n{}",
+            screen.lines.join("\n")
+        );
+
+        terminal.quit().expect("Should quit cleanly");
+    }
+
     /// Test that an IPC request arriving while reedline is already waiting
     /// persists the user_input command through the ExternalBreak path.
     #[test]

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -10,6 +10,7 @@ mod common;
 #[cfg(unix)]
 mod ipc_tests {
     use super::common::Terminal;
+    use regex::escape;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
     use std::time::{Duration, Instant};
@@ -138,6 +139,42 @@ mod ipc_tests {
         assert!(entry.get("timestamp").and_then(|v| v.as_str()).is_some());
         assert!(entry.get("cwd").and_then(|v| v.as_str()).is_some());
         assert!(entry.get("session_id").and_then(|v| v.as_i64()).is_some());
+        assert!(entry.get("exit_status").and_then(|v| v.as_i64()).is_some());
+    }
+
+    /// Assert that a saved IPC command has the expected exit status.
+    fn assert_ipc_history_exit_status(socket_path: &str, marker: &str, expected: i64) {
+        let result = query_history(socket_path, marker);
+        let entries = result
+            .get("entries")
+            .and_then(|entries| entries.as_array())
+            .expect("history result should contain entries");
+        let entry = entries
+            .iter()
+            .find(|entry| entry.get("command").and_then(|v| v.as_str()) == Some(marker))
+            .unwrap_or_else(|| panic!("history should contain {marker}: {result}"));
+        assert_eq!(
+            entry.get("exit_status").and_then(|v| v.as_i64()),
+            Some(expected),
+            "IPC history entry should contain the evaluated exit status"
+        );
+    }
+
+    /// Clear accumulated PTY output before sending an IPC request.
+    fn clear_before_ipc_request(terminal: &mut Terminal) {
+        terminal.clear_buffer().expect("clear PTY output buffer");
+    }
+
+    /// Wait for the prompt that follows a specific IPC command.
+    ///
+    /// The caller must clear the PTY output buffer before sending the request.
+    /// Requiring the echoed command to precede the next prompt waits until the
+    /// command has been evaluated, rather than merely until the early
+    /// `user_input` acceptance reply has arrived.
+    fn wait_for_ipc_prompt(terminal: &mut Terminal, marker: &str) {
+        terminal
+            .expect_regex(&format!(r"{}[\s\S]*> ", escape(marker)))
+            .unwrap_or_else(|e| panic!("Should return to prompt after IPC input: {e}"));
     }
 
     /// Helper to spawn arf with IPC and return (terminal, socket_path).
@@ -422,6 +459,7 @@ mod ipc_tests {
         };
 
         let marker = "ipc_external_history_marker <- 1";
+        clear_before_ipc_request(&mut terminal);
         let response = send_ipc_request(
             &socket_path,
             "user_input",
@@ -429,19 +467,19 @@ mod ipc_tests {
         )
         .expect("IPC request should succeed");
         assert_eq!(response["result"]["accepted"], true);
-        terminal
-            .wait_for_prompt()
-            .expect("Should return to prompt after IPC input");
+        wait_for_ipc_prompt(&mut terminal, marker);
 
         assert_ipc_history_entry(&socket_path, marker);
         terminal.quit().expect("Should quit cleanly");
     }
 
-    /// Test the fast-path timing window by sending immediately after the
-    /// prompt is displayed, before reedline has necessarily entered its input
-    /// loop. The same assertion also protects against route-dependent saves.
+    /// Test that history is persisted for a request sent immediately after
+    /// startup. The prompt has already been rendered by reedline at this
+    /// point, so this test intentionally makes no claim about which dispatch
+    /// path handled the request; the fast-path save is covered by the shared
+    /// `save_ipc_history` unit tests.
     #[test]
-    fn test_ipc_user_input_history_fast_path() {
+    fn test_ipc_user_input_history_after_startup() {
         let tmp = tempfile::TempDir::new().expect("create history dir");
         let history_dir = tmp.path().to_str().expect("history dir should be UTF-8");
         let mut terminal = Terminal::spawn_with_args(&["--with-ipc", "--history-dir", history_dir])
@@ -453,6 +491,7 @@ mod ipc_tests {
             .expect("Should find IPC socket path");
 
         let marker = "ipc_fast_history_marker <- 1";
+        clear_before_ipc_request(&mut terminal);
         let response = send_ipc_request(
             &socket_path,
             "user_input",
@@ -460,11 +499,47 @@ mod ipc_tests {
         )
         .expect("IPC request should succeed");
         assert_eq!(response["result"]["accepted"], true);
-        terminal
-            .wait_for_prompt()
-            .expect("Should return to prompt after IPC input");
+        wait_for_ipc_prompt(&mut terminal, marker);
 
         assert_ipc_history_entry(&socket_path, marker);
+        terminal.quit().expect("Should quit cleanly");
+    }
+
+    /// Test that an IPC evaluation error still reaches the prompt status and
+    /// the pre-saved IPC history entry receives exit_status=1.
+    #[test]
+    fn test_ipc_user_input_error_status_and_history() {
+        let tmp = tempfile::TempDir::new().expect("create history dir");
+        let history_dir = tmp.path().to_str().expect("history dir should be UTF-8");
+        let mut terminal = Terminal::spawn_with_args(&["--with-ipc", "--history-dir", history_dir])
+            .expect("Failed to spawn arf with IPC");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after startup");
+        let socket_path = find_socket_path(terminal.process_id(), Duration::from_secs(10))
+            .expect("Should find IPC socket path");
+
+        let marker = "stop('ipc_history_error_marker')";
+        clear_before_ipc_request(&mut terminal);
+        let response = send_ipc_request(
+            &socket_path,
+            "user_input",
+            serde_json::json!({ "code": marker }),
+        )
+        .expect("IPC request should succeed");
+        assert_eq!(response["result"]["accepted"], true);
+
+        terminal
+            .expect_regex(r"[\s\S]*✗ [\s\S]*> ")
+            .expect("Should show a failed prompt after IPC input");
+        let screen = terminal.screen().expect("should get terminal screen");
+        assert!(
+            screen.lines.iter().any(|line| line.contains("✗ ")),
+            "IPC evaluation error should be reflected in the next prompt; screen:\n{}",
+            screen.lines.join("\n")
+        );
+        assert_ipc_history_exit_status(&socket_path, marker, 1);
+
         terminal.quit().expect("Should quit cleanly");
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -753,6 +753,9 @@ package_functions = ["library", "require", "box::use"]
 
 Automatically removes commands that produced errors from history. Similar to fish's [sponge](https://github.com/meaningful-ooo/sponge) plugin.
 
+> [!NOTE]
+> History forget only applies to commands typed interactively by the user in the REPL. It does not apply to headless mode or commands sent via IPC, because agent-sent commands are valuable as an execution log and should not be silently pruned just because they failed.
+
 ```toml
 [experimental.history_forget]
 enabled = true

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -123,6 +123,7 @@ Error code strings:
 | `R_NOT_AT_PROMPT` | 4 | R is in browser/menu mode |
 | `INPUT_ALREADY_PENDING` | 4 | Another IPC request is already queued |
 | `USER_IS_TYPING` | 4 | User is typing in the REPL (see `data` fields below) |
+| `INCOMPLETE_INPUT` | 4 | R code is syntactically incomplete and would enter the continuation prompt |
 | `EMPTY_RESPONSE` | 4 | Server returned no result |
 | `PARSE_ERROR` | 4 | Invalid JSON in request |
 | `INVALID_REQUEST` | 4 | Not a valid JSON-RPC request |
@@ -374,6 +375,7 @@ Within a running session, you can start and stop the IPC server:
 When both a human and an external tool use the same session, arf prevents conflicts:
 
 - If you are typing when an IPC `eval` or `send` request arrives, the request is rejected with a `USER_IS_TYPING` error
+- If an IPC `eval` or `send` request contains syntactically incomplete R code, it is rejected with an `INCOMPLETE_INPUT` error
 - If R is busy (not at the prompt), `evaluate` requests are rejected immediately with `R_BUSY`
 - If R is not at the prompt, `user_input` / `send` requests are rejected with `R_NOT_AT_PROMPT`
 - Clients are expected to handle these errors by retrying later (for example, with backoff). In interactive/REPL mode, the server accepts at most one pending request — additional requests are rejected with `INPUT_ALREADY_PENDING`. In headless mode, requests are queued and processed sequentially

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -544,6 +544,7 @@ The result fields in the JSON response are already properly escaped strings — 
 | -32001 | R Not At Prompt | R has not returned to the prompt |
 | -32002 | Input Already Pending | Another IPC request is already queued |
 | -32003 | User Is Typing | User is typing in the REPL (interactive mode only) |
+| -32004 | Incomplete Input | R code is syntactically incomplete |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Commands sent with `arf ipc send` were echoed and evaluated but were not reliably written to the history database, so they could not be recalled with Ctrl+R, the history browser, or the up arrow. From the REPL user's point of view an expression was visibly executed yet left no trace.

## Root cause

`read_console_callback()` dispatches an IPC `user_input` through one of two paths: a fast path taken before reedline enters its input loop, and an `ExternalBreak` path taken when reedline is already waiting. Only the `ExternalBreak` path saved to history. The fast path was added later, and the save was not carried over, so whether a command was recorded depended on when the request happened to arrive.

## Changes

**Persist IPC commands on both paths.** The save moved into a shared `save_ipc_history()` helper called from both dispatch points, populating the same metadata the headless path already records (timestamp, hostname, cwd, session id). Save failures are logged rather than discarded. Whitespace-only code is skipped, matching headless behaviour.

**Record each command's result against the right history entry.** IPC entries are saved before R evaluates them, so they are not covered by reedline's last-command context — updating that context after an IPC command would have overwritten the preceding interactive entry instead. `PendingHistoryContext::{Reedline, Ipc, None}` now tracks which entry owns the pending result: IPC entries keep the id returned by `save()` and update themselves at the next prompt. This also means a failed IPC command sets the prompt failure indicator and stores `exit_status`, neither of which happened before.

Nested prompts (`readline()`, `menu()`, `browser()`) and continuation prompts leave the pending context untouched, since the outer command still owns the result. That decision is made once, from `is_r_command_prompt()`.

**Reject incomplete R code at the IPC entry point.** Incomplete code sent over IPC put R at a continuation prompt the user could not escape: reedline validates each continuation line on its own, so the rest of the expression was never submitted, and Ctrl+C does not raise R's interrupt flag while R awaits console input. The only way out was to end the session. Interactively typed code is already checked for completeness, so the same check now applies to `eval` and `send`, rejecting incomplete requests with a new `INCOMPLETE_INPUT` (-32004) error. The check reuses `RValidator`, which relies on tree-sitter alone and is therefore safe to run off the main R thread.

**Documentation.** `docs/configuration.md` now states that history-forget applies to interactively typed commands only, not to headless mode or IPC — this is intended behaviour, since agent-sent commands are valuable as an execution log. `docs/ipc.md` documents the new error code.

## Known limitations

`is_r_command_prompt()` classifies continuations by the `+` prefix, so a custom `options(continue = "...")` value is still misread as a top-level prompt. This predates these changes and affects every caller of that function; a TODO marks the site and it is tracked separately.

Ctrl+C still cannot escape a continuation prompt or a `readline()` wait. This change closes the IPC entry point but not other routes into that state, such as an incomplete expression inside `source()`. Also tracked separately.

## Test plan

- [x] `cargo test -p arf-console --test pty_ipc_tests` — 16 passed, including new coverage for history persistence, error status recording, and rejection of incomplete `eval` / `send`
- [x] `cargo test -p arf-console --bins` — 784 passed, including unit tests for `save_ipc_history()` covering the id round-trip and whitespace handling
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] `cargo fmt --all -- --check`
- [x] Manual check in a real session: send a command over IPC, then recall it with Ctrl+R and the history browser

The pre-input-loop dispatch path cannot be reached deterministically from a PTY test — by the time reedline has painted the prompt that a test waits for, the fast path has already been passed. It is covered through unit tests on the shared helper instead, and the integration test that previously claimed to exercise it has been renamed to stop implying otherwise.
