### PR TITLE
refactor: remove dead R event polling helpers

### DIFF
--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -161,10 +161,6 @@ pub struct RLibrary {
     // Event processing functions
     pub r_processevents: unsafe extern "C" fn(),
 
-    // Windows-specific event processing (from Rgraphapp.dll)
-    #[cfg(windows)]
-    pub ga_peekevent: Option<unsafe extern "C" fn() -> c_int>,
-
     // Unix-specific event processing
     #[cfg(unix)]
     pub r_checkactivity: unsafe extern "C" fn(c_int, c_int) -> *mut std::ffi::c_void,
@@ -402,9 +398,9 @@ impl RLibrary {
             #[cfg(windows)]
             load_symbol!(get_r_user, b"getRUser\0");
 
-            // Load Rgraphapp.dll functions (GA_initapp, GA_peekevent)
+            // Load Rgraphapp.dll functions (GA_initapp)
             #[cfg(windows)]
-            let (ga_initapp, ga_peekevent) = {
+            let ga_initapp = {
                 // Find Rgraphapp.dll in the same directory as R.dll
                 let rgraphapp_path = library_path.parent().map(|p| p.join("Rgraphapp.dll"));
 
@@ -443,37 +439,23 @@ impl RLibrary {
                                     }
                                 );
 
-                                let ga_peekevent: Option<unsafe extern "C" fn() -> c_int> =
-                                    graphapp_lib
-                                        .get::<unsafe extern "C" fn() -> c_int>(b"GA_peekevent\0")
-                                        .ok()
-                                        .map(|s| *s);
-                                log::info!(
-                                    "[WINDOWS] GA_peekevent: {}",
-                                    if ga_peekevent.is_some() {
-                                        "found"
-                                    } else {
-                                        "not found"
-                                    }
-                                );
-
                                 // Leak the library so it stays loaded
                                 std::mem::forget(graphapp_lib);
 
-                                (ga_initapp, ga_peekevent)
+                                ga_initapp
                             }
                             Err(e) => {
                                 log::warn!("[WINDOWS] Failed to load Rgraphapp.dll: {:?}", e);
-                                (None, None)
+                                None
                             }
                         }
                     } else {
                         log::warn!("[WINDOWS] Rgraphapp.dll not found at {:?}", path);
-                        (None, None)
+                        None
                     }
                 } else {
                     log::warn!("[WINDOWS] Could not determine Rgraphapp.dll path");
-                    (None, None)
+                    None
                 }
             };
 
@@ -667,8 +649,6 @@ impl RLibrary {
                 #[cfg(windows)]
                 character_mode,
                 r_processevents,
-                #[cfg(windows)]
-                ga_peekevent,
                 #[cfg(unix)]
                 r_checkactivity,
                 #[cfg(unix)]

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -33,8 +33,8 @@ pub use sys::{
     ensure_ld_library_path, find_r_library, finish_ipc_capture, flush_reprex_buffer, get_r_home,
     global_error_handler_code, initialize_r, initialize_r_with_args, is_r_awaiting_console_input,
     is_r_interrupt_flag_available, is_spinner_active, mark_error_condition,
-    mark_global_error_handler_initialized, peek_r_event, polled_events_for_repl, process_r_events,
-    reset_command_error_state, restore_stderr, run_r_mainloop, set_r_interrupt_pending,
-    set_read_console_callback, set_reprex_mode, set_spinner_color, set_spinner_frames,
-    set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
+    mark_global_error_handler_initialized, process_r_events, reset_command_error_state,
+    restore_stderr, run_r_mainloop, set_r_interrupt_pending, set_read_console_callback,
+    set_reprex_mode, set_spinner_color, set_spinner_frames, set_write_console_callback,
+    start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
 };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -21,7 +21,7 @@ pub use error_state::{
 pub use init::{initialize_r, initialize_r_with_args, run_r_mainloop};
 pub use interrupt::{
     clear_r_interrupt_pending, is_r_awaiting_console_input, is_r_interrupt_flag_available,
-    peek_r_event, polled_events_for_repl, process_r_events, set_r_interrupt_pending,
+    process_r_events, set_r_interrupt_pending,
 };
 pub use output::{
     clear_write_console_callback, finish_ipc_capture, flush_reprex_buffer, set_reprex_mode,

--- a/crates/arf-libr/src/sys/interrupt.rs
+++ b/crates/arf-libr/src/sys/interrupt.rs
@@ -147,13 +147,14 @@ pub fn process_r_events() {
     };
 
     // Drop any pending interrupt before calling into R's event machinery.
-    // This function is only called from Rust input-waiting loops (reedline
-    // idle callback, headless loop), where there is no R computation to
+    // This function is only called while no R computation is running: from
+    // Rust input-waiting code (the reedline idle callback, the headless
+    // loop, and once just before read_line()), so there is nothing to
     // interrupt. If the flag were left set, an interrupt observed here (by
     // R_ProcessEvents on Windows or R_checkActivity/R_runHandlers on Unix)
     // would call onintr(), which longjmps to R's top level straight through
-    // the Rust frames of the waiting loop (undefined behavior; in practice
-    // it leaks a RefCell borrow and the session exits on the next
+    // the Rust frames of the caller (undefined behavior; in practice it
+    // leaks a RefCell borrow and the session exits on the next
     // ReadConsole).
     clear_r_interrupt_pending();
 

--- a/crates/arf-libr/src/sys/interrupt.rs
+++ b/crates/arf-libr/src/sys/interrupt.rs
@@ -158,10 +158,14 @@ pub fn process_r_events() {
     };
 
     // Drop any pending interrupt before calling into R's event machinery.
-    // See peek_r_event() for the rationale: an interrupt observed here
-    // (by R_ProcessEvents on Windows or R_checkActivity/R_runHandlers on
-    // Unix) would longjmp through the Rust frames of the input-waiting
-    // loop that called us.
+    // This function is only called from Rust input-waiting loops (reedline
+    // idle callback, headless loop), where there is no R computation to
+    // interrupt. If the flag were left set, an interrupt observed here (by
+    // R_ProcessEvents on Windows or R_checkActivity/R_runHandlers on Unix)
+    // would call onintr(), which longjmps to R's top level straight through
+    // the Rust frames of the waiting loop (undefined behavior; in practice
+    // it leaks a RefCell borrow and the session exits on the next
+    // ReadConsole).
     clear_r_interrupt_pending();
 
     // Suspend interrupts for the duration of the call so that a flag set
@@ -185,86 +189,6 @@ pub fn process_r_events() {
                 }
             }
         }
-    }
-}
-
-/// Check if there are pending R events that need processing.
-///
-/// This is useful for polling before calling `process_r_events()` to avoid
-/// unnecessary processing when idle.
-///
-/// Returns `true` if there are events to process, `false` otherwise.
-///
-/// # Safety
-/// R must be initialized before calling this function.
-pub fn peek_r_event() -> bool {
-    let lib = match r_library() {
-        Ok(lib) => lib,
-        Err(_) => return false,
-    };
-
-    // Drop any pending interrupt before calling into R's event machinery.
-    // This function is only called from Rust input-waiting loops (reedline
-    // idle callback, headless loop), where there is no R computation to
-    // interrupt. If the flag were left set, R_checkActivity would call
-    // onintr(), which longjmps to R's top level straight through the Rust
-    // frames of the waiting loop (undefined behavior; in practice it leaks
-    // a RefCell borrow and the session exits on the next ReadConsole).
-    clear_r_interrupt_pending();
-
-    // Suspend interrupts for the duration of the call so that a flag set
-    // concurrently (by a SIGINT handler running on another thread) cannot
-    // trigger that longjmp either. See SuspendRInterruptsGuard.
-    let _suspend_guard = SuspendRInterruptsGuard::new(lib.r_interrupts_suspended);
-
-    unsafe {
-        #[cfg(windows)]
-        {
-            // On Windows, use GA_peekevent from Rgraphapp.dll
-            if let Some(ga_peekevent) = lib.ga_peekevent {
-                return ga_peekevent() != 0;
-            }
-            false
-        }
-
-        #[cfg(unix)]
-        {
-            // On Unix, use R_checkActivity
-            if lib.r_inputhandlers.is_null() {
-                return false;
-            }
-            let what = (lib.r_checkactivity)(0, 1);
-            !what.is_null()
-        }
-    }
-}
-
-/// Process R events in a loop suitable for use during input waiting.
-///
-/// This function processes any pending events and returns. It's designed
-/// to be called from an input hook or polling loop.
-///
-/// The pattern for use is:
-/// ```ignore
-/// loop {
-///     if input_ready() {
-///         break;
-///     }
-///     polled_events_for_repl();
-///     std::thread::sleep(Duration::from_millis(33)); // ~30fps
-/// }
-/// ```
-///
-/// # Safety
-/// R must be initialized before calling this function.
-pub fn polled_events_for_repl() {
-    // Check if there are pending events first
-    if peek_r_event() {
-        process_r_events();
-    } else {
-        // Even if no events are pending, call R_ProcessEvents occasionally
-        // to handle R's internal housekeeping
-        process_r_events();
     }
 }
 

--- a/crates/arf-libr/src/sys/interrupt.rs
+++ b/crates/arf-libr/src/sys/interrupt.rs
@@ -134,20 +134,9 @@ impl Drop for AwaitConsoleInputGuard {
 /// On Unix, this also runs input handlers for background tasks.
 ///
 /// This function should be called periodically while waiting for user input
-/// to keep R's interactive windows responsive.
-///
-/// # Current Limitations
-///
-/// Currently, this function is only called once before `read_line()` due to
-/// reedline's blocking design. This means graphics windows are only updated
-/// when the user presses a key. For fully responsive graphics windows,
-/// reedline would need an idle callback feature to call this function
-/// periodically during input waiting.
-///
-/// TODO: Consider forking reedline to add an idle callback feature, or
-/// contribute such a feature upstream. See:
-/// - Similar discussion: <https://github.com/nushell/reedline/issues/311>
-/// - External event queue PR (closed): <https://github.com/nushell/reedline/pull/822>
+/// to keep R's interactive windows responsive. arf does so from reedline's
+/// idle callback in the interactive REPL and from the polling loop in
+/// headless mode.
 ///
 /// # Safety
 /// R must be initialized before calling this function.


### PR DESCRIPTION
## Summary

Removes `polled_events_for_repl()` and `peek_r_event()` from `arf-libr`.

A reviewer on #269 flagged that `polled_events_for_repl()` calls `process_r_events()` from both arms of an `if`, and suggested making the branch meaningful. The premise is wrong: the function has **no callers anywhere**, and `peek_r_event()` is called only from it. Both are dead. `process_r_events()` is alive and stays.

## Is the probe load-bearing?

This was worth checking before deleting, because `peek_r_event()` clears the pending interrupt and installs a `SuspendRInterruptsGuard` — machinery from #245, which fixed `onintr()` longjmping through the Rust frames of the input-waiting loop and killing the session.

It is not load-bearing. `process_r_events()` performs that same sequence itself on every call, and `peek_r_event()`'s guard is dropped before `process_r_events()` even starts, so it could not protect that call in principle.

The comment explaining why the clearing is needed lived on `peek_r_event()`, so it moves onto `process_r_events()` instead of being deleted with it.

## Why not keep `peek_r_event()` as a public probe

It looks like a useful "is there work pending?" helper but misleads:

- Its boolean does not cover everything `process_r_events()` does — on Unix it returns `false` outright when `R_InputHandlers` is null, though `R_ProcessEvents()` still has housekeeping to do.
- Gating on it therefore skips that housekeeping, which is exactly why the dead wrapper processed in both arms.
- It silently mutates interrupt state, undocumented.

There is no cost problem to optimise for — arf calls the full function every 33 ms deliberately.

## Also in here

Two separate commits, droppable independently:

- `process_r_events()` documented that it could only be called once before `read_line()` because reedline lacks an idle callback, with a TODO to fork or upstream one. That feature has been enabled and in use since 0086517.
- `RLibrary::ga_peekevent` and its `GA_peekevent` lookup had no consumer left. `Rgraphapp.dll` is still loaded for `GA_initapp`.

## Compatibility

This removes public API from a published crate, but `arf-libr`'s README states it is internal with no stability guarantees, and no consumer exists. No CHANGELOG entry: no behavior changes, and the CHANGELOG covers the `arf` binary rather than internal crates.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 1061 passed, unchanged
- [x] Nothing to verify by hand: the removed code had no reachable call path
- [x] The `GA_peekevent` removal is Windows-only and unverifiable locally — confirmed by CI

One CI run hit a `test_pty_reprex_paste_strips_output_lines` failure that passed on re-run. It looks unrelated (the commits involved delete unreachable code and edit comments), but the investigation turned up a possible mismatch between that test's expectations and the actual reprex stripping behavior, which is now tracked separately.
