### PR TITLE
fix: tighten r_source_overrides file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Experimental:** arf can now automatically pick up the R version pinned by project tooling such as rv via `rproject.toml` or `.r-version` and switch to it. Override files are resolved from the current directory and must be bare filenames; this feature is opt-in.
+- **Experimental:** arf can now automatically pick up the R version pinned by project tooling such as rv via `rproject.toml` or `.r-version` and switch to it. Override files are resolved from the current directory, version files use their first non-empty line, and filenames must be bare; this feature is opt-in.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges in the style Cargo and npm use (e.g. `^4.4`, `>=4.3, <5.0`) in addition to exact and partial version numbers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain text file containing just the version — for example a file named `.r-version` containing:
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain text file containing just the version — for example, following the same convention as `.python-version` or `.ruby-version`, a file named `.r-version` containing:
 
   ```
   4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ### Added
 
-- **Experimental:** arf can now automatically pick up the R version pinned by project tooling such as rv via `rproject.toml` or `.r-version` and switch to it. Override files are resolved from the current directory, version files use their first non-empty line, and filenames must be bare; this feature is opt-in.
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain file such as `.r-version`, and a `toml-key` entry reads a value out of a TOML file — for example rv's `rproject.toml`:
+
+  ```toml
+  [project]
+  r_version = "4.4"
+  ```
+
+  is read by `{ type = "toml-key", file = "rproject.toml", key = "project.r_version" }`. Only the current directory is searched, and only R versions rig has already installed can be selected.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
-- `--with-r-version` and `:switch` now accept version ranges in the style Cargo and npm use (e.g. `^4.4`, `>=4.3, <5.0`) in addition to exact and partial version numbers.
+- `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain file such as `.r-version`, and a `toml-key` entry reads a value out of a TOML file — for example rv's `rproject.toml`:
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain text file containing just the version — for example a file named `.r-version` containing:
+
+  ```
+  4.4
+  ```
+
+  A `toml-key` entry reads a value out of a TOML file — for example rv's `rproject.toml`:
 
   ```toml
   [project]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Experimental:** arf can now automatically pick up the R version pinned by project tooling such as rv via `rproject.toml` and switch to it. This feature is opt-in.
+- **Experimental:** arf can now automatically pick up the R version pinned by project tooling such as rv via `rproject.toml` or `.r-version` and switch to it. Override files are resolved from the current directory and must be bare filenames; this feature is opt-in.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges in the style Cargo and npm use (e.g. `^4.4`, `>=4.3, <5.0`) in addition to exact and partial version numbers.
 

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -128,9 +128,11 @@ pub(crate) fn run_headless(
     };
 
     // Set up R
+    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
+        &base_dir,
         r_home,
         r_version,
         no_r_source_overrides,

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -128,11 +128,10 @@ pub(crate) fn run_headless(
     };
 
     // Set up R
-    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
-        &base_dir,
+        None,
         r_home,
         r_version,
         no_r_source_overrides,

--- a/crates/arf-console/src/app/setup.rs
+++ b/crates/arf-console/src/app/setup.rs
@@ -501,11 +501,17 @@ where
         let trimmed_version = version.trim().to_owned();
         let spec = match rversion::VersionSpec::parse(&trimmed_version) {
             Ok(spec) => spec,
-            Err(error) => {
+            Err(rversion::VersionSpecParseError::Empty) => {
                 diagnostics.push(format!(
-                    "Warning: {} contains invalid R version \"{}\" ({error}); trying the next R source override.",
-                    override_location(source),
-                    trimmed_version
+                    "Warning: {} contains an empty R version specification; trying the next R source override.",
+                    override_location(source)
+                ));
+                continue;
+            }
+            Err(rversion::VersionSpecParseError::Invalid) => {
+                diagnostics.push(format!(
+                    "Warning: {} contains an R version specification that could not be parsed; trying the next R source override.",
+                    override_location(source)
                 ));
                 continue;
             }
@@ -1273,6 +1279,51 @@ mod r_source_override_tests {
             }
             OverrideResolution::Applied { .. } => {
                 panic!("an invalid first line must not be applied")
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_version_markers_are_not_disclosed_for_file_providers() {
+        let marker = "SUPER-SECRET-TOKEN-abc123";
+
+        for provider in ["version-file", "toml-key"] {
+            let temp = tempfile::tempdir().unwrap();
+            let overrides = if provider == "version-file" {
+                std::fs::write(temp.path().join("project.r-version"), marker).unwrap();
+                vec![RSourceOverride::VersionFile {
+                    file: "project.r-version".into(),
+                }]
+            } else {
+                std::fs::write(
+                    temp.path().join("rproject.toml"),
+                    format!("[project]\nr_version = \"{marker}\"\n"),
+                )
+                .unwrap();
+                vec![RSourceOverride::TomlKey {
+                    file: "rproject.toml".into(),
+                    key: "project.r_version".to_string(),
+                }]
+            };
+
+            let result = setup_r_via_overrides_with(
+                &overrides,
+                Some(temp.path()),
+                || panic!("rig should not be queried for an invalid version"),
+                || panic!("installed versions should not be queried for an invalid version"),
+                |_, _| panic!("version resolution should not be attempted"),
+            )
+            .unwrap();
+
+            match result {
+                OverrideResolution::Fallback { diagnostics } => {
+                    let diagnostics = diagnostics.join("\n");
+                    assert!(!diagnostics.contains(marker));
+                    assert!(diagnostics.contains("could not be parsed"));
+                }
+                OverrideResolution::Applied { .. } => {
+                    panic!("an invalid version must not be applied")
+                }
             }
         }
     }

--- a/crates/arf-console/src/app/setup.rs
+++ b/crates/arf-console/src/app/setup.rs
@@ -11,9 +11,7 @@ use crate::rversion;
 use anyhow::{Context, Result};
 use reedline::Reedline;
 use std::fs;
-use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Run in script execution mode (non-interactive).
 pub(crate) fn run_script(cli: &Cli) -> Result<()> {
@@ -21,11 +19,10 @@ pub(crate) fn run_script(cli: &Cli) -> Result<()> {
     let config = load_config_or_warn(cli.config.as_ref());
 
     // Set up R based on r_source config (with optional CLI override)
-    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
-        &base_dir,
+        None,
         cli.r_home.as_deref(),
         cli.r_version.as_deref(),
         cli.no_r_source_overrides,
@@ -199,7 +196,7 @@ impl RSourceResolutionReport {
 pub(crate) fn setup_r(
     r_source: &RSource,
     r_source_overrides: &[RSourceOverride],
-    base_dir: &Path,
+    base_dir: Option<&Path>,
     cli_r_home: Option<&std::path::Path>,
     cli_version: Option<&str>,
     no_r_source_overrides: bool,
@@ -356,7 +353,7 @@ enum OverrideResolution {
 /// Try the configured directory-level R source overrides in priority order.
 fn setup_r_via_overrides(
     overrides: &[RSourceOverride],
-    base_dir: &Path,
+    base_dir: Option<&Path>,
 ) -> Option<OverrideResolution> {
     setup_r_via_overrides_with(
         overrides,
@@ -367,9 +364,20 @@ fn setup_r_via_overrides(
     )
 }
 
+fn resolve_override_path(file: &Path, base_dir: &mut Option<PathBuf>) -> std::io::Result<PathBuf> {
+    if let Some(base_dir) = base_dir.as_ref() {
+        return Ok(base_dir.join(file));
+    }
+
+    let current_dir = std::env::current_dir()?;
+    let path = current_dir.join(file);
+    *base_dir = Some(current_dir);
+    Ok(path)
+}
+
 fn setup_r_via_overrides_with<FAvailable, FList, FResolve>(
     overrides: &[RSourceOverride],
-    base_dir: &Path,
+    base_dir: Option<&Path>,
     rig_available: FAvailable,
     list_versions: FList,
     resolve_selected_rig_version: FResolve,
@@ -383,6 +391,7 @@ where
     let mut evaluated_provider = false;
     let mut rig_available_cache = None;
     let mut installed_versions_cache = None;
+    let mut base_dir = base_dir.map(Path::to_path_buf);
 
     for source in overrides {
         let provider = override_provider_name(source);
@@ -400,7 +409,17 @@ where
                     diagnostics.push(invalid_override_file_warning(provider, file));
                     continue;
                 }
-                let path = base_dir.join(file);
+                let path = match resolve_override_path(file, &mut base_dir) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
+                            "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
+                            file.display()
+                        ));
+                        continue;
+                    }
+                };
                 match rversion::read_version_file(&path) {
                     Ok(version) => {
                         evaluated_provider = true;
@@ -426,7 +445,17 @@ where
                     diagnostics.push(invalid_override_file_warning(provider, file));
                     continue;
                 }
-                let path = base_dir.join(file);
+                let path = match resolve_override_path(file, &mut base_dir) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
+                            "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
+                            file.display()
+                        ));
+                        continue;
+                    }
+                };
                 match rversion::read_toml_key(&path, key) {
                     Ok(version) => {
                         evaluated_provider = true;
@@ -903,7 +932,7 @@ mod r_source_override_tests {
             &[RSourceOverride::VersionFile {
                 file: ".r-version".into(),
             }],
-            temp.path(),
+            Some(temp.path()),
             None,
             None,
             false,
@@ -917,18 +946,27 @@ mod r_source_override_tests {
     #[test]
     fn empty_override_configuration_is_not_configured() {
         let temp = tempfile::tempdir().unwrap();
+        let report = setup_r(&path_source(temp.path()), &[], None, None, None, false).unwrap();
+
+        assert_eq!(report.override_state, RSourceOverrideState::NotConfigured);
+        assert!(report.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn pixi_only_override_resolution_does_not_need_a_base_dir() {
+        let temp = tempfile::tempdir().unwrap();
         let report = setup_r(
             &path_source(temp.path()),
-            &[],
-            temp.path(),
+            &[RSourceOverride::Pixi],
+            None,
             None,
             None,
             false,
         )
         .unwrap();
 
-        assert_eq!(report.override_state, RSourceOverrideState::NotConfigured);
-        assert!(report.diagnostics.is_empty());
+        assert_eq!(report.override_state, RSourceOverrideState::Failed);
+        assert!(report.diagnostics[0].contains("pixi"));
     }
 
     #[test]
@@ -937,7 +975,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
-            temp.path(),
+            Some(temp.path()),
             None,
             None,
             true,
@@ -962,7 +1000,7 @@ mod r_source_override_tests {
                 file: "rproject.toml".into(),
                 key: "project.r_version".to_string(),
             }],
-            temp.path(),
+            Some(temp.path()),
             Some(temp.path()),
             None,
             false,
@@ -980,7 +1018,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
-            temp.path(),
+            Some(temp.path()),
             Some(temp.path()),
             None,
             true,
@@ -997,7 +1035,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
-            temp.path(),
+            Some(temp.path()),
             None,
             None,
             false,
@@ -1104,7 +1142,7 @@ mod r_source_override_tests {
                     file: second_file.clone(),
                 },
             ],
-            temp.path(),
+            Some(temp.path()),
             || true,
             || Ok(vec![rig_version("4.4.2")]),
             |selected, versions| {
@@ -1134,6 +1172,107 @@ mod r_source_override_tests {
             }
             OverrideResolution::Fallback { .. } => {
                 panic!("the installed provider should be applied")
+            }
+        }
+    }
+
+    #[test]
+    fn version_file_resolution_uses_first_line_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = Path::new("project.r-version");
+        std::fs::write(
+            temp.path().join(file),
+            "4.4.2\nprivate trailing contents that must not be read\n",
+        )
+        .unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::VersionFile {
+                file: file.to_path_buf(),
+            }],
+            Some(temp.path()),
+            || true,
+            || Ok(vec![rig_version("4.4.2")]),
+            |selected, versions| {
+                assert_eq!(selected, &semver::Version::new(4, 4, 2));
+                Ok(RSourceStatus::Rig {
+                    version: versions[0].version.clone(),
+                    override_info: None,
+                })
+            },
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Applied {
+                info, diagnostics, ..
+            } => {
+                assert_eq!(info.requested_version, "4.4.2");
+                assert!(diagnostics.is_empty());
+            }
+            OverrideResolution::Fallback { .. } => {
+                panic!("the first version-file line should resolve")
+            }
+        }
+    }
+
+    #[test]
+    fn overlong_version_file_value_is_not_disclosed_in_diagnostic() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = "4".repeat(300);
+        std::fs::write(temp.path().join("project.r-version"), &marker).unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::VersionFile {
+                file: "project.r-version".into(),
+            }],
+            Some(temp.path()),
+            || panic!("rig should not be queried when reading the version file fails"),
+            || panic!("installed versions should not be queried when reading fails"),
+            |_, _| panic!("version resolution should not be attempted"),
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Fallback { diagnostics } => {
+                let diagnostics = diagnostics.join("\n");
+                assert!(diagnostics.contains("exceeds 256 bytes"));
+                assert!(!diagnostics.contains(&marker));
+            }
+            OverrideResolution::Applied { .. } => {
+                panic!("an overlong version-file value must not be applied")
+            }
+        }
+    }
+
+    #[test]
+    fn later_version_file_lines_are_not_disclosed_in_diagnostic() {
+        let temp = tempfile::tempdir().unwrap();
+        let private_contents = "private trailing contents that must not be disclosed";
+        std::fs::write(
+            temp.path().join("project.r-version"),
+            format!("not-a-version\n{private_contents}\n"),
+        )
+        .unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::VersionFile {
+                file: "project.r-version".into(),
+            }],
+            Some(temp.path()),
+            || true,
+            || Ok(vec![rig_version("4.4.2")]),
+            |_, _| panic!("version resolution should not be attempted"),
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Fallback { diagnostics } => {
+                let diagnostics = diagnostics.join("\n");
+                assert!(!diagnostics.contains(private_contents));
+            }
+            OverrideResolution::Applied { .. } => {
+                panic!("an invalid first line must not be applied")
             }
         }
     }
@@ -1180,7 +1319,7 @@ mod r_source_override_tests {
 
                 let result = setup_r_via_overrides_with(
                     &overrides,
-                    temp.path(),
+                    Some(temp.path()),
                     || true,
                     || Ok(vec![rig_version("4.4.2")]),
                     |selected, versions| {
@@ -1229,7 +1368,7 @@ mod r_source_override_tests {
                     file: second_file.clone(),
                 },
             ],
-            temp.path(),
+            Some(temp.path()),
             move || {
                 rig_available_calls_for_closure.fetch_add(1, Ordering::Relaxed);
                 true
@@ -1270,7 +1409,7 @@ mod r_source_override_tests {
                     file: "missing-second.r-version".into(),
                 },
             ],
-            temp.path(),
+            Some(temp.path()),
             move || {
                 rig_available_calls_for_closure.fetch_add(1, Ordering::Relaxed);
                 true

--- a/crates/arf-console/src/app/setup.rs
+++ b/crates/arf-console/src/app/setup.rs
@@ -477,10 +477,10 @@ where
                     ));
                         continue;
                     }
-                    Err(rversion::TomlKeyError::Parse(error)) => {
+                    Err(rversion::TomlKeyError::Parse(_)) => {
                         evaluated_provider = true;
                         diagnostics.push(format!(
-                        "Warning: Failed to parse R source override file {}: {error}; trying the next R source override.",
+                        "Warning: Failed to parse R source override file {}; trying the next R source override.",
                         file.display()
                     ));
                         continue;
@@ -1324,6 +1324,42 @@ mod r_source_override_tests {
                 OverrideResolution::Applied { .. } => {
                     panic!("an invalid version must not be applied")
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_toml_does_not_disclose_file_contents_in_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = "SUPER-SECRET-TOML-CONTENTS";
+        std::fs::write(
+            temp.path().join("rproject.toml"),
+            format!("[project]\nr_version = \"{marker}\n"),
+        )
+        .unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::TomlKey {
+                file: "rproject.toml".into(),
+                key: "project.r_version".to_string(),
+            }],
+            Some(temp.path()),
+            || panic!("rig should not be queried for malformed TOML"),
+            || panic!("installed versions should not be queried for malformed TOML"),
+            |_, _| panic!("version resolution should not be attempted"),
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Fallback { diagnostics } => {
+                let diagnostics = diagnostics.join("\n");
+                assert!(diagnostics.contains(
+                    "Warning: Failed to parse R source override file rproject.toml; trying the next R source override."
+                ));
+                assert!(!diagnostics.contains(marker));
+            }
+            OverrideResolution::Applied { .. } => {
+                panic!("malformed TOML must not be applied")
             }
         }
     }

--- a/crates/arf-console/src/app/setup.rs
+++ b/crates/arf-console/src/app/setup.rs
@@ -11,6 +11,7 @@ use crate::rversion;
 use anyhow::{Context, Result};
 use reedline::Reedline;
 use std::fs;
+use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
 
@@ -20,9 +21,11 @@ pub(crate) fn run_script(cli: &Cli) -> Result<()> {
     let config = load_config_or_warn(cli.config.as_ref());
 
     // Set up R based on r_source config (with optional CLI override)
+    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
+        &base_dir,
         cli.r_home.as_deref(),
         cli.r_version.as_deref(),
         cli.no_r_source_overrides,
@@ -196,6 +199,7 @@ impl RSourceResolutionReport {
 pub(crate) fn setup_r(
     r_source: &RSource,
     r_source_overrides: &[RSourceOverride],
+    base_dir: &Path,
     cli_r_home: Option<&std::path::Path>,
     cli_version: Option<&str>,
     no_r_source_overrides: bool,
@@ -244,7 +248,7 @@ pub(crate) fn setup_r(
         return setup_r_fallback(r_source, RSourceOverrideState::Disabled);
     }
 
-    if let Some(result) = setup_r_via_overrides(r_source_overrides) {
+    if let Some(result) = setup_r_via_overrides(r_source_overrides, base_dir) {
         match result {
             OverrideResolution::Applied {
                 status,
@@ -350,9 +354,13 @@ enum OverrideResolution {
 }
 
 /// Try the configured directory-level R source overrides in priority order.
-fn setup_r_via_overrides(overrides: &[RSourceOverride]) -> Option<OverrideResolution> {
+fn setup_r_via_overrides(
+    overrides: &[RSourceOverride],
+    base_dir: &Path,
+) -> Option<OverrideResolution> {
     setup_r_via_overrides_with(
         overrides,
+        base_dir,
         external::rig::rig_available,
         external::rig::list_versions,
         setup_r_via_selected_rig_version,
@@ -361,6 +369,7 @@ fn setup_r_via_overrides(overrides: &[RSourceOverride]) -> Option<OverrideResolu
 
 fn setup_r_via_overrides_with<FAvailable, FList, FResolve>(
     overrides: &[RSourceOverride],
+    base_dir: &Path,
     rig_available: FAvailable,
     list_versions: FList,
     resolve_selected_rig_version: FResolve,
@@ -385,62 +394,79 @@ where
                 ));
                 continue;
             }
-            RSourceOverride::VersionFile { file } => match rversion::read_version_file(file) {
-                Ok(version) => {
+            RSourceOverride::VersionFile { file } => {
+                if !is_bare_filename(file) {
                     evaluated_provider = true;
-                    version
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    log::debug!("R source override file {} is not present", file.display());
+                    diagnostics.push(invalid_override_file_warning(provider, file));
                     continue;
                 }
-                Err(error) => {
-                    evaluated_provider = true;
-                    diagnostics.push(format!(
+                let path = base_dir.join(file);
+                match rversion::read_version_file(&path) {
+                    Ok(version) => {
+                        evaluated_provider = true;
+                        version
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        log::debug!("R source override file {} is not present", file.display());
+                        continue;
+                    }
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
                         "Warning: Failed to read R version override file {}: {error}; trying the next R source override.",
                         file.display()
                     ));
+                        continue;
+                    }
+                }
+            }
+            RSourceOverride::TomlKey { file, key } => {
+                if !is_bare_filename(file) {
+                    evaluated_provider = true;
+                    diagnostics.push(invalid_override_file_warning(provider, file));
                     continue;
                 }
-            },
-            RSourceOverride::TomlKey { file, key } => match rversion::read_toml_key(file, key) {
-                Ok(version) => {
-                    evaluated_provider = true;
-                    version
-                }
-                Err(error) if error.is_not_found() => {
-                    log::debug!("R source override file {} is not present", file.display());
-                    continue;
-                }
-                Err(
-                    rversion::TomlKeyError::MissingKey(_) | rversion::TomlKeyError::NotString(_),
-                ) => {
-                    evaluated_provider = true;
-                    diagnostics.push(format!(
+                let path = base_dir.join(file);
+                match rversion::read_toml_key(&path, key) {
+                    Ok(version) => {
+                        evaluated_provider = true;
+                        version
+                    }
+                    Err(error) if error.is_not_found() => {
+                        log::debug!("R source override file {} is not present", file.display());
+                        continue;
+                    }
+                    Err(
+                        rversion::TomlKeyError::MissingKey(_)
+                        | rversion::TomlKeyError::NotString(_),
+                    ) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
                         "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
                         file.display(),
                         key
                     ));
-                    continue;
-                }
-                Err(rversion::TomlKeyError::Parse(error)) => {
-                    evaluated_provider = true;
-                    diagnostics.push(format!(
+                        continue;
+                    }
+                    Err(rversion::TomlKeyError::Parse(error)) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
                         "Warning: Failed to parse R source override file {}: {error}; trying the next R source override.",
                         file.display()
                     ));
-                    continue;
-                }
-                Err(error) => {
-                    evaluated_provider = true;
-                    diagnostics.push(format!(
+                        continue;
+                    }
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(format!(
                         "Warning: Failed to read R version from TOML key '{}' in {}: {error}; trying the next R source override.",
                         key,
                         file.display()
                     ));
-                    continue;
+                        continue;
+                    }
                 }
-            },
+            }
         };
 
         let trimmed_version = version.trim().to_owned();
@@ -542,6 +568,32 @@ where
     } else {
         None
     }
+}
+
+fn is_bare_filename(file: &Path) -> bool {
+    let Some(file) = file.to_str() else {
+        return false;
+    };
+
+    if file.is_empty()
+        || file == "."
+        || file == ".."
+        || file.contains('/')
+        || file.contains('\\')
+        || Path::new(file).is_absolute()
+    {
+        return false;
+    }
+
+    let bytes = file.as_bytes();
+    !(bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+fn invalid_override_file_warning(provider: &str, file: &Path) -> String {
+    format!(
+        "Warning: R source override provider '{provider}' has invalid file '{}'; file must be a bare filename; trying the next R source override.",
+        file.display()
+    )
 }
 
 fn script_override_notice(resolution: &RSourceResolutionReport) -> Option<String> {
@@ -811,6 +863,7 @@ mod session_id_tests {
 mod r_source_override_tests {
     use super::*;
     use std::path::Path;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -848,8 +901,9 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::VersionFile {
-                file: temp.path().join(".r-version"),
+                file: ".r-version".into(),
             }],
+            temp.path(),
             None,
             None,
             false,
@@ -863,7 +917,15 @@ mod r_source_override_tests {
     #[test]
     fn empty_override_configuration_is_not_configured() {
         let temp = tempfile::tempdir().unwrap();
-        let report = setup_r(&path_source(temp.path()), &[], None, None, false).unwrap();
+        let report = setup_r(
+            &path_source(temp.path()),
+            &[],
+            temp.path(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(report.override_state, RSourceOverrideState::NotConfigured);
         assert!(report.diagnostics.is_empty());
@@ -875,6 +937,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
+            temp.path(),
             None,
             None,
             true,
@@ -896,9 +959,10 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::TomlKey {
-                file: temp.path().join("rproject.toml"),
+                file: "rproject.toml".into(),
                 key: "project.r_version".to_string(),
             }],
+            temp.path(),
             Some(temp.path()),
             None,
             false,
@@ -916,6 +980,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
+            temp.path(),
             Some(temp.path()),
             None,
             true,
@@ -932,6 +997,7 @@ mod r_source_override_tests {
         let report = setup_r(
             &path_source(temp.path()),
             &[RSourceOverride::Pixi],
+            temp.path(),
             None,
             None,
             false,
@@ -1026,10 +1092,10 @@ mod r_source_override_tests {
     #[test]
     fn not_installed_override_falls_through_to_installed_provider() {
         let temp = tempfile::tempdir().unwrap();
-        let first_file = temp.path().join("first.r-version");
-        let second_file = temp.path().join("second.r-version");
-        std::fs::write(&first_file, "4.3.0\n").unwrap();
-        std::fs::write(&second_file, "4.4.2\n").unwrap();
+        let first_file = Path::new("first.r-version").to_path_buf();
+        let second_file = Path::new("second.r-version").to_path_buf();
+        std::fs::write(temp.path().join(&first_file), "4.3.0\n").unwrap();
+        std::fs::write(temp.path().join(&second_file), "4.4.2\n").unwrap();
 
         let result = setup_r_via_overrides_with(
             &[
@@ -1038,6 +1104,7 @@ mod r_source_override_tests {
                     file: second_file.clone(),
                 },
             ],
+            temp.path(),
             || true,
             || Ok(vec![rig_version("4.4.2")]),
             |selected, versions| {
@@ -1072,12 +1139,83 @@ mod r_source_override_tests {
     }
 
     #[test]
+    fn invalid_override_filenames_are_skipped_with_diagnostics() {
+        let invalid_files = ["../x", "sub/x", r"a\b", "/absolute", "C:foo", ".", "..", ""];
+
+        for provider in ["version-file", "toml-key"] {
+            for invalid_file in invalid_files {
+                let temp = tempfile::tempdir().unwrap();
+                let valid_file = if provider == "version-file" {
+                    PathBuf::from("valid.r-version")
+                } else {
+                    PathBuf::from("valid.toml")
+                };
+                let valid_path = temp.path().join(&valid_file);
+                if provider == "version-file" {
+                    std::fs::write(valid_path, "4.4.2\n").unwrap();
+                } else {
+                    std::fs::write(valid_path, "[project]\nr_version = \"4.4.2\"\n").unwrap();
+                }
+
+                let invalid = PathBuf::from(invalid_file);
+                let overrides = if provider == "version-file" {
+                    vec![
+                        RSourceOverride::VersionFile { file: invalid },
+                        RSourceOverride::VersionFile {
+                            file: valid_file.clone(),
+                        },
+                    ]
+                } else {
+                    vec![
+                        RSourceOverride::TomlKey {
+                            file: invalid,
+                            key: "project.r_version".to_string(),
+                        },
+                        RSourceOverride::TomlKey {
+                            file: valid_file.clone(),
+                            key: "project.r_version".to_string(),
+                        },
+                    ]
+                };
+
+                let result = setup_r_via_overrides_with(
+                    &overrides,
+                    temp.path(),
+                    || true,
+                    || Ok(vec![rig_version("4.4.2")]),
+                    |selected, versions| {
+                        assert_eq!(selected, &semver::Version::new(4, 4, 2));
+                        Ok(RSourceStatus::Rig {
+                            version: versions[0].version.clone(),
+                            override_info: None,
+                        })
+                    },
+                )
+                .unwrap();
+
+                match result {
+                    OverrideResolution::Applied {
+                        info, diagnostics, ..
+                    } => {
+                        assert_eq!(info.file, Some(valid_file));
+                        assert_eq!(diagnostics.len(), 1);
+                        assert!(diagnostics[0].contains("file must be a bare filename"));
+                    }
+                    OverrideResolution::Fallback { .. } => {
+                        panic!("the valid provider should be applied")
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn rig_data_is_fetched_once_across_override_providers() {
         let temp = tempfile::tempdir().unwrap();
-        let first_file = temp.path().join("first.r-version");
-        let second_file = temp.path().join("second.r-version");
-        std::fs::write(&first_file, "4.3.0\n").unwrap();
-        std::fs::write(&second_file, "4.4.2\n").unwrap();
+        let first_file = Path::new("first.r-version").to_path_buf();
+        let second_file = Path::new("second.r-version").to_path_buf();
+        std::fs::write(temp.path().join(&first_file), "4.3.0\n").unwrap();
+        std::fs::write(temp.path().join(&second_file), "4.4.2\n").unwrap();
 
         let rig_available_calls = Arc::new(AtomicUsize::new(0));
         let list_versions_calls = Arc::new(AtomicUsize::new(0));
@@ -1091,6 +1229,7 @@ mod r_source_override_tests {
                     file: second_file.clone(),
                 },
             ],
+            temp.path(),
             move || {
                 rig_available_calls_for_closure.fetch_add(1, Ordering::Relaxed);
                 true
@@ -1125,12 +1264,13 @@ mod r_source_override_tests {
         let result = setup_r_via_overrides_with(
             &[
                 RSourceOverride::VersionFile {
-                    file: temp.path().join("missing-first.r-version"),
+                    file: "missing-first.r-version".into(),
                 },
                 RSourceOverride::VersionFile {
-                    file: temp.path().join("missing-second.r-version"),
+                    file: "missing-second.r-version".into(),
                 },
             ],
+            temp.path(),
             move || {
                 rig_available_calls_for_closure.fetch_add(1, Ordering::Relaxed);
                 true

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -22,7 +22,7 @@ mod traps;
 #[cfg(test)]
 mod test_utils;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use app::commands::{handle_config_command, handle_history_command, handle_ipc_command};
 use app::config_load::load_config_with_fallback;
 use app::headless::run_headless;
@@ -241,9 +241,11 @@ fn run() -> Result<()> {
     }
 
     // Set up R based on r_source config (with optional CLI override)
+    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
+        &base_dir,
         cli.r_home.as_deref(),
         cli.r_version.as_deref(),
         cli.no_r_source_overrides,

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -22,7 +22,7 @@ mod traps;
 #[cfg(test)]
 mod test_utils;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use app::commands::{handle_config_command, handle_history_command, handle_ipc_command};
 use app::config_load::load_config_with_fallback;
 use app::headless::run_headless;
@@ -241,11 +241,10 @@ fn run() -> Result<()> {
     }
 
     // Set up R based on r_source config (with optional CLI override)
-    let base_dir = std::env::current_dir().context("Failed to determine current directory")?;
     let resolution = setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
-        &base_dir,
+        None,
         cli.r_home.as_deref(),
         cli.r_version.as_deref(),
         cli.no_r_source_overrides,

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -7,7 +7,7 @@ use semver::{Version, VersionReq};
 use std::fmt;
 use std::fs::{self, File};
 use std::io;
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::path::Path;
 
 /// A parsed R version specification.
@@ -27,7 +27,7 @@ pub enum VersionSpecParseError {
     /// The specification is empty.
     Empty,
     /// The specification is not a valid numeric prefix, name, or semver requirement.
-    Invalid(String),
+    Invalid,
 }
 
 /// An error returned when reading a version from a TOML key.
@@ -47,7 +47,7 @@ impl fmt::Display for TomlKeyError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Read(error) => write!(formatter, "failed to read TOML file: {error}"),
-            Self::Parse(error) => write!(formatter, "failed to parse TOML: {error}"),
+            Self::Parse(_) => formatter.write_str("failed to parse TOML"),
             Self::MissingKey(key) => write!(formatter, "TOML key not found: {key}"),
             Self::NotString(key) => write!(formatter, "TOML key is not a string: {key}"),
         }
@@ -82,8 +82,20 @@ pub fn read_version_file(path: &Path) -> io::Result<String> {
 
     loop {
         line.clear();
-        if reader.read_line(&mut line)? == 0 {
+        let bytes_read = reader
+            .by_ref()
+            .take((MAX_VERSION_FILE_VALUE_LENGTH + 1) as u64)
+            .read_line(&mut line)?;
+        if bytes_read == 0 {
             return Ok(String::new());
+        }
+
+        // Reject rather than truncate: truncation could turn an invalid value into a valid one.
+        if bytes_read > MAX_VERSION_FILE_VALUE_LENGTH && !line.ends_with('\n') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("version file value exceeds {MAX_VERSION_FILE_VALUE_LENGTH} bytes"),
+            ));
         }
 
         let value = line.trim();
@@ -127,7 +139,7 @@ impl fmt::Display for VersionSpecParseError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Empty => formatter.write_str("version specification must not be empty"),
-            Self::Invalid(spec) => write!(formatter, "invalid version specification: {spec}"),
+            Self::Invalid => formatter.write_str("invalid version specification"),
         }
     }
 }
@@ -164,19 +176,19 @@ impl VersionSpec {
             // A version has at most major, minor and patch, so a longer
             // specification could never match anything.
             if components.len() > VERSION_COMPONENT_COUNT {
-                return Err(VersionSpecParseError::Invalid(input.to_owned()));
+                return Err(VersionSpecParseError::Invalid);
             }
             let digits = components
                 .iter()
                 .map(|component| component.parse::<u64>())
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| VersionSpecParseError::Invalid(input.to_owned()))?;
+                .map_err(|_| VersionSpecParseError::Invalid)?;
             return Ok(Self::Digits(digits));
         }
 
         VersionReq::parse(input)
             .map(Self::Range)
-            .map_err(|_| VersionSpecParseError::Invalid(input.to_owned()))
+            .map_err(|_| VersionSpecParseError::Invalid)
     }
 
     fn matches(&self, version: &Version) -> bool {
@@ -320,7 +332,7 @@ mod tests {
     fn numeric_specs_longer_than_a_version_are_rejected() {
         assert!(matches!(
             VersionSpec::parse("4.4.1.0"),
-            Err(VersionSpecParseError::Invalid(spec)) if spec == "4.4.1.0"
+            Err(VersionSpecParseError::Invalid)
         ));
     }
 
@@ -344,6 +356,24 @@ mod tests {
         let error = read_version_file(file.path()).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "version file value exceeds 256 bytes");
+    }
+
+    #[test]
+    fn version_file_rejects_an_enormous_single_line() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), format!("{}\n", "4".repeat(1024 * 1024))).unwrap();
+
+        let error = read_version_file(file.path()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn version_file_rejects_an_enormous_whitespace_only_line() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), format!("{}\n", " ".repeat(1024 * 1024))).unwrap();
+
+        let error = read_version_file(file.path()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -84,7 +84,8 @@ pub fn read_version_file(path: &Path) -> io::Result<String> {
         line.clear();
         let bytes_read = reader
             .by_ref()
-            .take((MAX_VERSION_FILE_VALUE_LENGTH + 1) as u64)
+            // Limit + 1 for the line's own `\n`, plus 1 to recognize `\r\n` before judging length.
+            .take((MAX_VERSION_FILE_VALUE_LENGTH + 2) as u64)
             .read_line(&mut line)?;
         if bytes_read == 0 {
             return Ok(String::new());
@@ -393,6 +394,77 @@ mod tests {
         let error = read_version_file(file.path()).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "version file value exceeds 256 bytes");
+    }
+
+    #[test]
+    fn version_file_accepts_value_one_byte_under_limit_with_unix_and_windows_line_endings() {
+        for line_ending in ["\n", "\r\n"] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(
+                file.path(),
+                format!(
+                    "{}{}",
+                    "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH - 1),
+                    line_ending
+                ),
+            )
+            .unwrap();
+
+            assert_eq!(
+                read_version_file(file.path()).unwrap(),
+                "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH - 1)
+            );
+        }
+    }
+
+    #[test]
+    fn version_file_accepts_value_at_limit_with_unix_and_windows_line_endings() {
+        for line_ending in ["\n", "\r\n"] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(
+                file.path(),
+                format!(
+                    "{}{}",
+                    "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH),
+                    line_ending
+                ),
+            )
+            .unwrap();
+
+            assert_eq!(
+                read_version_file(file.path()).unwrap(),
+                "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH)
+            );
+        }
+    }
+
+    #[test]
+    fn version_file_rejects_value_one_byte_over_limit_with_unix_and_windows_line_endings() {
+        for line_ending in ["\n", "\r\n"] {
+            let file = tempfile::NamedTempFile::new().unwrap();
+            std::fs::write(
+                file.path(),
+                format!(
+                    "{}{}",
+                    "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH + 1),
+                    line_ending
+                ),
+            )
+            .unwrap();
+
+            let error = read_version_file(file.path()).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            assert_eq!(error.to_string(), "version file value exceeds 256 bytes");
+        }
+    }
+
+    #[test]
+    fn version_file_accepts_value_at_limit_at_end_of_file_without_trailing_newline() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let value = "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH);
+        std::fs::write(file.path(), &value).unwrap();
+
+        assert_eq!(read_version_file(file.path()).unwrap(), value);
     }
 
     #[test]

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -186,9 +186,20 @@ impl VersionSpec {
             return Ok(Self::Digits(digits));
         }
 
-        VersionReq::parse(input)
-            .map(Self::Range)
-            .map_err(|_| VersionSpecParseError::Invalid)
+        let requirement = VersionReq::parse(input).map_err(|_| VersionSpecParseError::Invalid)?;
+
+        // R versions have no prerelease identifiers or build metadata, so a
+        // requirement containing either could never match an installed R version.
+        if input.contains('+')
+            || requirement
+                .comparators
+                .iter()
+                .any(|comparator| !comparator.pre.is_empty())
+        {
+            return Err(VersionSpecParseError::Invalid);
+        }
+
+        Ok(Self::Range(requirement))
     }
 
     fn matches(&self, version: &Version) -> bool {
@@ -308,6 +319,16 @@ mod tests {
     }
 
     #[test]
+    fn supported_r_version_specifications_are_accepted() {
+        for specification in ["4.4.2", "4.4", "4", "^4.4", ">=4.3, <5.0", "~4.4", "*"] {
+            assert!(
+                VersionSpec::parse(specification).is_ok(),
+                "expected {specification:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
     fn named_specs_use_a_dedicated_variant() {
         assert_eq!(
             VersionSpec::parse("devel").unwrap(),
@@ -334,6 +355,22 @@ mod tests {
             VersionSpec::parse("4.4.1.0"),
             Err(VersionSpecParseError::Invalid)
         ));
+    }
+
+    #[test]
+    fn prerelease_and_build_metadata_specs_are_rejected() {
+        for specification in [
+            "4.3.0-SUPER-SECRET-TOKEN",
+            ">=4.3.0-alpha",
+            "=4.4.2-x",
+            ">=4.3.0+SUPERSECRET",
+            "^4.4.0+build",
+        ] {
+            assert!(matches!(
+                VersionSpec::parse(specification),
+                Err(VersionSpecParseError::Invalid)
+            ));
+        }
     }
 
     #[test]

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -5,8 +5,9 @@
 
 use semver::{Version, VersionReq};
 use std::fmt;
-use std::fs;
+use std::fs::{self, File};
 use std::io;
+use std::io::BufRead;
 use std::path::Path;
 
 /// A parsed R version specification.
@@ -70,9 +71,35 @@ impl TomlKeyError {
     }
 }
 
-/// Read a complete version specification from a plain text file.
+/// The maximum length of the trimmed value read from a version file.
+const MAX_VERSION_FILE_VALUE_LENGTH: usize = 256;
+
+/// Read the first non-empty version specification from a plain text file.
 pub fn read_version_file(path: &Path) -> io::Result<String> {
-    fs::read_to_string(path).map(|contents| contents.trim().to_owned())
+    let file = File::open(path)?;
+    let mut reader = io::BufReader::new(file);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(String::new());
+        }
+
+        let value = line.trim();
+        if value.is_empty() {
+            continue;
+        }
+
+        // Reject rather than truncate: truncation could turn an invalid value into a valid one.
+        if value.len() > MAX_VERSION_FILE_VALUE_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("version file value exceeds {MAX_VERSION_FILE_VALUE_LENGTH} bytes"),
+            ));
+        }
+        return Ok(value.to_owned());
+    }
 }
 
 /// Read a string value from a dot-separated key path in a TOML file.
@@ -298,11 +325,25 @@ mod tests {
     }
 
     #[test]
-    fn version_file_contents_are_trimmed() {
+    fn version_file_uses_first_non_empty_line() {
         let file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(file.path(), "\n  4.4.2\r\n").unwrap();
+        std::fs::write(file.path(), "\n  4.4.2\r\nprivate trailing contents\n").unwrap();
 
         assert_eq!(read_version_file(file.path()).unwrap(), "4.4.2");
+    }
+
+    #[test]
+    fn version_file_rejects_overlong_first_non_empty_line() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            format!("{}\n", "4".repeat(MAX_VERSION_FILE_VALUE_LENGTH + 1)),
+        )
+        .unwrap();
+
+        let error = read_version_file(file.path()).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "version file value exceeds 256 bytes");
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -594,7 +594,7 @@ r_source = { path = "/opt/R/4.5.2" }
 
 ### Version Specifications
 
-arf uses the same installed-version matching for `--with-r-version`, `:switch`, and R source overrides. An R version is a plain `major.minor.patch` number: R does not publish prereleases or build metadata, and rig reports installed R versions in that form. For installed-version matching, arf accepts two forms:
+arf uses the same installed-version matching for `--with-r-version`, `:switch`, and R source overrides. `--with-r-version` and `:switch` additionally accept rig's own selectors, which are tried first — see [rig Integration](#rig-integration). An R version is a plain `major.minor.patch` number: R does not publish prereleases or build metadata, and rig reports installed R versions in that form. For installed-version matching, arf accepts two forms:
 
 - Exact or partial version numbers: `4`, `4.4`, or `4.4.2`. The number of components written determines the precision: `4.4` matches the `4.4.x` series, while `4.4.2` matches only `4.4.2`.
 - Ranges using comparison operators such as `^4.4`, `~4.4`, `>=4.3`, `<5.0`, and `*`. Operators can be combined, for example `>=4.3, <5.0`.
@@ -632,6 +632,8 @@ Rig selectors are separate from version specifications:
 | `default` | Use rig's default R version |
 | Rig alias (e.g. `release` or `devel`) | Use the version associated with that rig alias |
 | Rig-assigned name (e.g. `custom-name`) | Use the installed version with that rig name |
+
+`--with-r-version` and `:switch` try these selectors before interpreting the value as a version specification, in the order listed above. R source overrides never consult them and always interpret the value as a version specification. This matters when a rig alias or name looks like a version number: if an installation is named `4.4`, then `--with-r-version 4.4` selects that installation by name, while `4.4` in an override file selects the newest installed `4.4.x` release, which may be a different installation.
 
 ## History Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -815,7 +815,7 @@ Entries are evaluated in array order, which is the priority order. The first ent
 | Option | Default | Description |
 |--------|---------|-------------|
 | `r_source_overrides` | `[]` (disabled) | Ordered list of R source providers. |
-| `type = "version-file"` | — | Reads the complete version specification from the `file` field. |
+| `type = "version-file"` | — | Reads the first non-empty line as the version specification from the `file` field. |
 | `type = "toml-key"` | — | Reads a string version specification from the dot-separated TOML key in the `file` and `key` fields. |
 | `type = "pixi"` | — | Uses the active pixi environment. This provider is not implemented yet and has no additional fields. |
 
@@ -837,13 +837,13 @@ The other provider forms are:
 
 **File formats read by each provider:**
 
-`version-file` reads the entire file as text and trims leading/trailing whitespace and newlines; the trimmed result is used as the version specification. This is the same shape as `.python-version`, `.node-version` and similar files in other ecosystems — a single version on its own line, e.g. a `.r-version` containing:
+`version-file` reads the first non-empty line and trims its leading/trailing whitespace; the trimmed result is used as the version specification. Values longer than 256 bytes are rejected. This is the same shape as `.python-version`, `.node-version` and similar files in other ecosystems — a single version on its own line, e.g. a `.r-version` containing:
 
 ```
 4.4.1
 ```
 
-Comments are not supported, and the whole trimmed file has to be one specification — it may be any supported form, including a range such as `>=4.3, <5.0`, but not several specifications. Only spaces are accepted inside a specification, so a range must stay on one line: leading and trailing newlines are trimmed away, but one in the middle makes the file invalid.
+Comments are not supported. The first non-empty line may be any supported form, including a range such as `>=4.3, <5.0`; later lines are ignored. Only spaces are accepted inside a specification, so a range must stay on one line.
 
 `toml-key` parses `file` as TOML and follows `key` as a dot-separated path through its tables. For example, rv's `rproject.toml` might contain:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -816,6 +816,8 @@ Automatically select an installed R version from project tooling. This feature i
 
 Override files are resolved as `<current directory>/<file>`. `file` must be a bare filename: it cannot be empty, `.`, `..`, contain subdirectories, or be an absolute path. arf does **not** walk up parent directories, even though the tools that write these files often do.
 
+arf uses the `file` value as written and performs no case folding, so whether `.r-version` also matches a file named `.R-version` depends on the filesystem: case-insensitive on typical macOS and Windows setups, case-sensitive on typical Linux ones. Write the exact spelling your project uses to keep the config portable across platforms.
+
 Entries are evaluated in array order, which is the priority order. The first entry that successfully resolves a version is used; later entries are not evaluated once one succeeds.
 
 **Configuration options:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -592,6 +592,15 @@ r_source = "rig"
 r_source = { path = "/opt/R/4.5.2" }
 ```
 
+### Version Specifications
+
+arf uses the same installed-version matching for `--with-r-version`, `:switch`, and R source overrides. An R version is a plain `major.minor.patch` number: R does not publish prereleases or build metadata, and rig reports installed R versions in that form. For installed-version matching, arf accepts two forms:
+
+- Exact or partial version numbers: `4`, `4.4`, or `4.4.2`. The number of components written determines the precision: `4.4` matches the `4.4.x` series, while `4.4.2` matches only `4.4.2`.
+- Ranges using comparison operators such as `^4.4`, `~4.4`, `>=4.3`, `<5.0`, and `*`. Operators can be combined, for example `>=4.3, <5.0`.
+
+The range operators use the syntax popularised by Cargo and npm. This is only range notation for selecting R versions; R version numbers are not SemVer. Because an R version has only three components, numeric specifications with four or more components, such as `4.4.1.0`, cannot match and are rejected. Likewise, prerelease identifiers and build metadata are rejected because installed R versions never carry them. If multiple installed versions match, arf selects the newest one.
+
 ### CLI Options
 
 The `--r-home` flag specifies an explicit R_HOME path:
@@ -600,7 +609,7 @@ The `--r-home` flag specifies an explicit R_HOME path:
 arf --r-home /opt/R/4.5.2
 ```
 
-The `--with-r-version` flag temporarily overrides `r_source` and uses rig:
+The `--with-r-version` flag temporarily overrides `r_source` and uses rig. It accepts one of the version specifications above or a selector from rig's own metadata:
 
 ```bash
 arf --with-r-version 4.5
@@ -616,16 +625,13 @@ When using rig via `r_source = "auto"` with rig installed or `r_source = "rig"`,
 rig default 4.5
 ```
 
-The `--with-r-version` flag supports version resolution:
+Rig selectors are separate from version specifications:
 
-| Specification | Description |
+| Selector | Description |
 |--------------|-------------|
 | `default` | Use rig's default R version |
-| Rig alias (e.g. `release`) | Use the version associated with that rig alias |
+| Rig alias (e.g. `release` or `devel`) | Use the version associated with that rig alias |
 | Rig-assigned name (e.g. `custom-name`) | Use the installed version with that rig name |
-| Full version (e.g. `4.5.2`) | Match that exact version |
-| Partial version (e.g. `4.5` or `4`) | Use the latest installed version in the `4.5.x` or `4.x` series |
-| Version range (e.g. `^4.4` or `>=4.3, <5.0`) | Use the latest installed version that satisfies the range |
 
 ## History Configuration
 
@@ -855,18 +861,11 @@ r_version = "4.4"
 
 With `key = "project.r_version"`, arf looks up the `project` table and reads its `r_version` field. The value must be a TOML string; any other type is treated as an error.
 
-**Version strings are interpreted as follows:**
-
-- Numeric precision is determined by the number of components written: `4.4` matches any `4.4.x` release, while `4.4.1` matches only `4.4.1`.
-- If multiple installed R versions match, the newest matching version is selected.
-- Version ranges such as `^4.4` and `>=4.3, <5.0` are also supported. These use the syntax Cargo and npm popularised; the SemVer specification itself does not define range operators.
-- Prerelease identifiers and build metadata are not supported because R versions are release versions in `major.minor.patch` form.
-- The `devel` and `release` aliases are not currently supported by the R source override path.
-- Numeric version strings with four or more components, such as `4.4.1.0`, are invalid.
+**Version strings read by `version-file` and `toml-key` use the version specifications above.** These providers accept exact or partial numbers and ranges, and select the newest installed version that matches. `devel` and `release` are recognised names, but named selectors are not supported by the R source override path.
 
 **Who performs the matching:** arf runs rig only to check that it is there (`rig --version`) and to list what is installed (`rig list --json`). It then matches the specification against that list itself and asks the selected installation's R binary for its `R_HOME`. rig never sees the specification, so it is arf that decides what `4.4` means.
 
-`--with-r-version`, `:switch` and `r_source_overrides` share that matching, so numeric specifications and version ranges mean the same thing everywhere. Only the selectors that come from rig's own metadata differ: `default`, aliases such as `release`, and exact rig names work with `--with-r-version` and `:switch`, and have no equivalent in an override file.
+`--with-r-version`, `:switch` and `r_source_overrides` share the numeric and range matching described above. Only selectors from rig's own metadata differ: `default`, aliases such as `release`, and exact rig names work with `--with-r-version` and `:switch`, while named selectors are unsupported in an override file.
 
 When resolving providers, a missing file is silently skipped and arf moves to the next entry. If a file exists but its value cannot be parsed, arf logs a warning and moves to the next entry. `pixi` logs the following warning and also moves to the next entry:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -806,7 +806,7 @@ Automatically select an installed R version from project tooling. This feature i
 > [!IMPORTANT]
 > A version read from a file is only ever matched against the R installations that rig knows about — arf takes the candidate list from `rig list --json`. **The `version-file` and `toml-key` providers therefore require rig**, and can only select an R version that rig has already installed. Without rig, or when no installed version matches, arf warns and falls back to `startup.r_source` rather than failing to start.
 
-Override files are searched in the current working directory only. arf does **not** walk up parent directories, even though the tools that write these files often do. Relative `file` paths are therefore relative to the current working directory.
+Override files are resolved as `<current directory>/<file>`. `file` must be a bare filename: it cannot be empty, `.`, `..`, contain subdirectories, or be an absolute path. arf does **not** walk up parent directories, even though the tools that write these files often do.
 
 Entries are evaluated in array order, which is the priority order. The first entry that successfully resolves a version is used; later entries are not evaluated once one succeeds.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -860,6 +860,7 @@ With `key = "project.r_version"`, arf looks up the `project` table and reads its
 - Numeric precision is determined by the number of components written: `4.4` matches any `4.4.x` release, while `4.4.1` matches only `4.4.1`.
 - If multiple installed R versions match, the newest matching version is selected.
 - Version ranges such as `^4.4` and `>=4.3, <5.0` are also supported. These use the syntax Cargo and npm popularised; the SemVer specification itself does not define range operators.
+- Prerelease identifiers and build metadata are not supported because R versions are release versions in `major.minor.patch` form.
 - The `devel` and `release` aliases are not currently supported by the R source override path.
 - Numeric version strings with four or more components, such as `4.4.1.0`, are invalid.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -847,7 +847,7 @@ The other provider forms are:
 
 **File formats read by each provider:**
 
-`version-file` reads the first non-empty line and trims its leading/trailing whitespace; the trimmed result is used as the version specification. Values longer than 256 bytes are rejected. This is the same shape as `.python-version`, `.node-version` and similar files in other ecosystems — a single version on its own line, e.g. a `.r-version` containing:
+`version-file` reads the first non-empty line and trims its leading/trailing whitespace; the trimmed result is used as the version specification. Values longer than 256 bytes are rejected. The format follows the version-file convention popularised by other ecosystems' version managers — `.python-version`, `.ruby-version` and similar files — a single version on its own line, e.g. a `.r-version` containing:
 
 ```
 4.4.1


### PR DESCRIPTION
Follow-ups to the experimental `r_source_overrides` feature, all of it unreleased, so these are behaviour changes rather than fixes to shipped behaviour.

## `file` must be a bare filename

The `version-file` and `toml-key` providers passed the configured `file` straight to the filesystem, so `../rproject.toml` read the parent directory and an absolute path read anywhere on the system. That contradicted the design intent that overrides are scoped to the current directory, and an absolute path silently turned a directory-scoped feature into a global one.

Empty, `.`, `..`, values containing `/` or `\`, absolute paths, and Windows drive-relative forms such as `C:foo` are now refused. `\` is treated as a separator on Unix too, so the same config file means the same thing on every platform. An invalid entry is not a config load error: it warns and resolution moves on to the next override, matching how unimplemented providers and read failures already behave.

Resolution is now explicitly `base_dir.join(file)`. The base directory is looked up lazily, only when a `version-file` or `toml-key` entry is actually reached, so arf no longer fails to start from a deleted working directory when no file-based override is configured. A failure there warns and falls through rather than aborting startup.

## Override files no longer disclose their contents

Values read from override files reach stderr, the log file under `--log-file`, and the machine-readable `warnings` array of `headless --json`. Since a `.r-version` in an untrusted repository can be a symlink to a private file, an unparseable value dumped that file into those outputs.

Three things changed. `read_version_file` reads only the first non-empty line instead of the whole file, which is also simply more correct — a version file is a single short token by convention. Unparsed input is no longer echoed at all: the invalid-version diagnostic does not quote it, `VersionSpecParseError::Invalid` no longer carries it, and `TomlKeyError::Parse` no longer forwards the toml error, which can quote source lines from the file. Diagnostics that report an *already parsed* value are unchanged, including the `rig add <version>` hint, since that hint is the reason the not-installed warning exists.

Symlinks are deliberately still followed. A `symlink_metadata` check is separate from the open that follows it, so it would be a speed bump rather than a boundary, and refusing links would break dotfile managers and monorepos that symlink a shared version file into place.

Each line is read through a bounded reader so one enormous line cannot exhaust memory, and values over 256 bytes are rejected rather than truncated — truncating could turn an invalid value into a valid one. The bound accounts for a `\r\n` terminator, so a value exactly at the limit is accepted with both Unix and Windows line endings.

## Prerelease identifiers and build metadata are rejected

`VersionSpec::parse` fell through to `VersionReq::parse`, which accepted and preserved semver prerelease identifiers, so a specification could carry free-form text such as `4.3.0-SUPER-SECRET-TOKEN`. R version numbers are not semver: they are plain `major.minor.patch` releases with neither prerelease identifiers nor build metadata, and rig reports them that way, so a comparator carrying a prerelease could never match an installed version.

Both are now rejected, on the same reasoning that already rejects numeric specifications with more than three components. Build metadata is discarded by `VersionReq::parse`, so it is caught in the input rather than in the parsed value.

This also narrows what the not-installed warning can echo to digits, dots, comparison operators, commas, whitespace and `*`.

## Documentation

The version specification documentation had grown by accretion — each behaviour change appended another bullet, so a reader met the prerelease restriction having never been told semver notation was involved. A new Version Specifications section establishes the model first (an R version is a plain three-component number; arf accepts an exact or partial number whose written precision selects the release series, or a range built from comparison operators) and states the restrictions as consequences of it. Cargo and npm are kept as attribution for where the range syntax comes from, with the point made explicitly that R version numbers are not semver.

The rig selector table no longer mixes version specifications in with selectors that come from rig's own metadata, and the precedence between them is now documented: `--with-r-version` and `:switch` try `default`, rig aliases and rig names *before* interpreting the value as a version specification, while an override file never consults them. With an installation named `4.4`, `--with-r-version 4.4` selects it by name while `4.4` in an override file selects the newest installed `4.4.x`.

The changelog entries were rewritten in the same spirit, and now show the TOML that a `toml-key` entry actually reads rather than naming a file, with a parallel example for the `version-file` provider.

Two further notes came out of review. The `file` value is used as written and arf performs no case folding, so whether `.r-version` also matches a file named `.R-version` is decided by the filesystem — case-insensitive on typical macOS and Windows setups, case-sensitive on typical Linux ones — which is now stated so a config that works on one machine does not silently fail to find the file on another.

And `.r-version` is no longer introduced as though it were a standard. No R tool defines it canonically: rig does not read version files at all, rv pins its version in `rproject.toml`, and an older rbenv-derived tool uses a different spelling again. Both places where the name is first met now say it follows the version-file convention from other ecosystems, naming `.python-version` and `.ruby-version` as siblings — each is read by several independent tools, so they describe the convention without resting on any one of them. `.node-version` is not named, since it belongs to nodenv while nvm reads `.nvmrc`, a distinction readers routinely conflate.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Filename rejection covered for `../x`, `sub/x`, `a\b`, `/absolute`, `C:foo`, `.`, `..` and the empty string, across both providers
- [x] A short sensitive-looking marker in a version file, in a TOML value, and in malformed TOML never appears in any diagnostic
- [x] Version file length boundary covered at the limit minus one, the limit, and the limit plus one, with both LF and CRLF terminators, plus a value at the limit at end of file
- [x] Enormous single-line and whitespace-only-line files are rejected without buffering
- [x] Prerelease and build metadata specifications rejected; `4.4.2`, `4.4`, `4`, `^4.4`, `>=4.3, <5.0`, `~4.4` and `*` still accepted
- [x] An empty or pixi-only override list resolves without needing the current directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
