### PR TITLE
fix: collapse duplicated CLI argument definitions into shared Args structs

### DIFF
--- a/crates/arf-console/src/app/config_load.rs
+++ b/crates/arf-console/src/app/config_load.rs
@@ -13,7 +13,7 @@ use crate::config::{
 pub(crate) fn load_config_with_fallback(
     cli: &Cli,
 ) -> (Config, Option<std::path::PathBuf>, ConfigStatus) {
-    let (result, config_path) = if let Some(path) = &cli.config {
+    let (result, config_path) = if let Some(path) = &cli.r_source.config {
         (load_config_from_path(path), Some(path.clone()))
     } else {
         let default_path = config_file_path();

--- a/crates/arf-console/src/app/setup/script.rs
+++ b/crates/arf-console/src/app/setup/script.rs
@@ -8,16 +8,16 @@ use std::fs;
 /// Run in script execution mode (non-interactive).
 pub(crate) fn run_script(cli: &Cli) -> Result<()> {
     // Load configuration (from file or default)
-    let config = load_config_or_warn(cli.config.as_ref());
+    let config = load_config_or_warn(cli.r_source.config.as_ref());
 
     // Set up R based on r_source config (with optional CLI override)
     let resolution = super::setup_r(
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
         None,
-        cli.r_home.as_deref(),
-        cli.r_version.as_deref(),
-        cli.no_r_source_overrides,
+        cli.r_source.r_home.as_deref(),
+        cli.r_source.r_version.as_deref(),
+        cli.r_source.no_r_source_overrides,
     )?;
     resolution.emit_diagnostics();
     if let Some(notice) = super::overrides::script_override_notice(&resolution) {

--- a/crates/arf-console/src/cli/headless.rs
+++ b/crates/arf-console/src/cli/headless.rs
@@ -1,59 +1,10 @@
-use clap::builder::TypedValueParser;
 use clap::{Args, ValueHint};
 use std::path::PathBuf;
 
 #[derive(Args, Debug)]
 pub(crate) struct HeadlessArgs {
-    /// Path to configuration file
-    #[arg(short, long, value_hint = ValueHint::FilePath)]
-    pub(crate) config: Option<PathBuf>,
-
-    /// Highest-priority R source: use this R version via rig
-    ///
-    /// Accepts a rig alias (e.g. "release"), "default", a rig-assigned
-    /// name, a full version ("4.4.1"), a partial version ("4.4" or "4",
-    /// matching the latest release in that series), or a version range in
-    /// the style Cargo and npm use ("^4.4", ">=4.3, <5.0").
-    ///
-    /// Requires rig. Candidates are limited to R versions rig has
-    /// installed (from `rig list --json`); the version string is never
-    /// passed to rig.
-    ///
-    /// Takes precedence over ARF_R_VERSION, r_source_overrides and
-    /// startup.r_source, which are not consulted at all when this is set.
-    ///
-    /// Config: startup.r_source
-    #[arg(
-        long = "with-r-version",
-        env = "ARF_R_VERSION",
-        conflicts_with = "r_home"
-    )]
-    pub(crate) r_version: Option<String>,
-
-    /// Highest-priority R source: use this explicit R_HOME path
-    ///
-    /// Mutually exclusive with --with-r-version and ARF_R_VERSION.
-    ///
-    /// Takes precedence over ARF_R_HOME, r_source_overrides and
-    /// startup.r_source, which are not consulted at all when this is set.
-    ///
-    /// Config: startup.r_source
-    #[arg(
-        long = "r-home",
-        value_hint = ValueHint::DirPath,
-        env = "ARF_R_HOME",
-        conflicts_with = "r_version"
-    )]
-    pub(crate) r_home: Option<PathBuf>,
-
-    /// Disable experimental directory-level R source overrides
-    ///
-    /// This only disables r_source_overrides. An R source given by
-    /// --r-home, --with-r-version, ARF_R_HOME or ARF_R_VERSION still applies.
-    ///
-    /// Config: [experimental].r_source_overrides
-    #[arg(long = "no-r-source-overrides")]
-    pub(crate) no_r_source_overrides: bool,
+    #[command(flatten)]
+    pub(crate) r_source: super::shared::RSourceArgs,
 
     /// Bind IPC socket to a specific path instead of the default.
     /// On Unix, ensure the parent directory is user-private (mode 0700)
@@ -87,55 +38,9 @@ pub(crate) struct HeadlessArgs {
     #[arg(long = "log-file", value_hint = ValueHint::FilePath)]
     pub(crate) log_file: Option<PathBuf>,
 
-    /// Start R in vanilla mode (no init files, no save/restore)
-    #[arg(long = "vanilla")]
-    pub(crate) vanilla: bool,
+    #[command(flatten)]
+    pub(crate) r_compat: super::shared::RCompatArgs,
 
-    /// [R] Don't read the site and user environment files
-    #[arg(long = "no-environ", hide_short_help = true)]
-    pub(crate) no_environ: bool,
-
-    /// [R] Don't read the site-wide Rprofile
-    #[arg(long = "no-site-file", hide_short_help = true)]
-    pub(crate) no_site_file: bool,
-
-    /// [R] Don't read the user's .Rprofile
-    #[arg(long = "no-init-file", hide_short_help = true)]
-    pub(crate) no_init_file: bool,
-
-    /// [R] Set max number of connections to N
-    #[arg(long = "max-connections", hide = true)]
-    pub(crate) max_connections: Option<u32>,
-
-    /// [R] Set max size of protect stack to N
-    #[arg(long = "max-ppsize", hide = true)]
-    pub(crate) max_ppsize: Option<u32>,
-
-    /// Custom history directory (overrides default XDG location)
-    ///
-    /// History will be stored at `{dir}/r.db`.
-    ///
-    /// Config: history.dir
-    #[arg(
-        long = "history-dir",
-        value_hint = ValueHint::DirPath,
-        env = "ARF_HISTORY_DIR",
-        hide_short_help = true,
-        value_parser = clap::builder::NonEmptyStringValueParser::new().map(PathBuf::from),
-    )]
-    pub(crate) history_dir: Option<PathBuf>,
-
-    /// Disable history (no history saved)
-    ///
-    /// Config: history.disabled
-    #[arg(long = "no-history", hide_short_help = true)]
-    pub(crate) no_history: bool,
-
-    /// [R] Set min number of fixed size obj's ("cons cells") to N
-    #[arg(long = "min-nsize", hide = true)]
-    pub(crate) min_nsize: Option<String>,
-
-    /// [R] Set vector heap minimum to N bytes; '4M' = 4 MegaB
-    #[arg(long = "min-vsize", hide = true)]
-    pub(crate) min_vsize: Option<String>,
+    #[command(flatten)]
+    pub(crate) history: super::shared::HistoryOptions,
 }

--- a/crates/arf-console/src/cli/mod.rs
+++ b/crates/arf-console/src/cli/mod.rs
@@ -7,13 +7,13 @@ mod history;
 mod ipc;
 mod r_args;
 mod r_home;
+mod shared;
 
 pub(crate) use config::ConfigAction;
 pub(crate) use history::{HistoryAction, ImportSource};
 pub(crate) use ipc::IpcAction;
 pub(crate) use r_args::RArgsBuilder;
 
-use clap::builder::TypedValueParser;
 use clap::{Parser, Subcommand, ValueHint};
 #[cfg(test)]
 use clap_complete::Shell;
@@ -44,9 +44,9 @@ pub struct Cli {
     #[arg(long)]
     pub auto_format: bool,
 
-    /// Path to configuration file
-    #[arg(short, long, value_hint = ValueHint::FilePath)]
-    pub config: Option<PathBuf>,
+    /// Shared R source options
+    #[command(flatten)]
+    pub r_source: shared::RSourceArgs,
 
     /// Suppress the startup banner
     ///
@@ -54,52 +54,10 @@ pub struct Cli {
     #[arg(long)]
     pub no_banner: bool,
 
-    /// Highest-priority R source: use this R version via rig
-    ///
-    /// Accepts a rig alias (e.g. "release"), "default", a rig-assigned name,
-    /// a full version ("4.4.1"), a partial version ("4.4" or "4", matching
-    /// the latest release in that series), or a version range in the style
-    /// Cargo and npm use ("^4.4", ">=4.3, <5.0").
-    ///
-    /// Requires rig. Candidates are limited to R versions rig has installed
-    /// (from `rig list --json`); the version string is never passed to rig.
-    ///
-    /// Takes precedence over ARF_R_VERSION, r_source_overrides and
-    /// startup.r_source, which are not consulted at all when this is set.
-    ///
-    /// Config: startup.r_source
-    #[arg(
-        long = "with-r-version",
-        env = "ARF_R_VERSION",
-        conflicts_with = "r_home"
-    )]
-    pub r_version: Option<String>,
-
-    /// Highest-priority R source: use this explicit R_HOME path
-    ///
-    /// Mutually exclusive with --with-r-version and ARF_R_VERSION.
-    ///
-    /// Takes precedence over ARF_R_HOME, r_source_overrides and
-    /// startup.r_source, which are not consulted at all when this is set.
-    ///
-    /// Config: startup.r_source
-    #[arg(long = "r-home", value_hint = ValueHint::DirPath, env = "ARF_R_HOME", conflicts_with = "r_version")]
-    pub r_home: Option<PathBuf>,
-
-    /// Disable experimental directory-level R source overrides
-    ///
-    /// This only disables r_source_overrides. An R source given by
-    /// --r-home, --with-r-version, ARF_R_HOME or ARF_R_VERSION still applies.
-    ///
-    /// Config: [experimental].r_source_overrides
-    #[arg(long = "no-r-source-overrides")]
-    pub no_r_source_overrides: bool,
-
     // R-compatible flags (passed to R, for vscode-R and radian compatibility)
     // Hidden from short help (-h) but shown in long help (--help).
-    /// Start R in vanilla mode (no init files, no save/restore)
-    #[arg(long = "vanilla")]
-    pub vanilla: bool,
+    #[command(flatten)]
+    pub r_compat: shared::RCompatArgs,
 
     /// [R] Don't print R startup message
     #[arg(short = 'q', long = "quiet", alias = "silent", hide_short_help = true)]
@@ -125,18 +83,6 @@ pub struct Cli {
     #[arg(long = "restore-data", conflicts_with_all = ["no_restore", "no_restore_data"], hide_short_help = true)]
     pub restore_data: bool,
 
-    /// [R] Don't read the site and user environment files
-    #[arg(long = "no-environ", hide_short_help = true)]
-    pub no_environ: bool,
-
-    /// [R] Don't read the site-wide Rprofile
-    #[arg(long = "no-site-file", hide_short_help = true)]
-    pub no_site_file: bool,
-
-    /// [R] Don't read the user's .Rprofile
-    #[arg(long = "no-init-file", hide_short_help = true)]
-    pub no_init_file: bool,
-
     /// [R] Force R to run interactively (no-op, always interactive)
     #[arg(long = "interactive", hide = true)]
     pub interactive: bool,
@@ -160,22 +106,6 @@ pub struct Cli {
     /// [R] Specify encoding to be used for stdin (no-op)
     #[arg(long = "encoding", hide = true)]
     pub encoding: Option<String>,
-
-    /// [R] Set max number of connections to N
-    #[arg(long = "max-connections", hide = true)]
-    pub max_connections: Option<u32>,
-
-    /// [R] Set max size of protect stack to N
-    #[arg(long = "max-ppsize", hide = true)]
-    pub max_ppsize: Option<u32>,
-
-    /// [R] Set min number of fixed size obj's ("cons cells") to N
-    #[arg(long = "min-nsize", hide = true)]
-    pub min_nsize: Option<String>,
-
-    /// [R] Set vector heap minimum to N bytes; '4M' = 4 MegaB
-    #[arg(long = "min-vsize", hide = true)]
-    pub min_vsize: Option<String>,
 
     /// [R] Run R through debugger NAME (no-op)
     #[arg(short = 'd', long = "debugger", hide = true)]
@@ -238,25 +168,8 @@ pub struct Cli {
     #[arg(long = "no-completion", hide = true)]
     pub no_completion: bool,
 
-    /// Custom history directory (overrides default XDG location)
-    ///
-    /// R history will be stored at `{dir}/r.db`, Shell at `{dir}/shell.db`.
-    ///
-    /// Config: history.dir
-    #[arg(
-        long = "history-dir",
-        value_hint = ValueHint::DirPath,
-        env = "ARF_HISTORY_DIR",
-        hide_short_help = true,
-        value_parser = clap::builder::NonEmptyStringValueParser::new().map(PathBuf::from),
-    )]
-    pub history_dir: Option<PathBuf>,
-
-    /// Disable history (no history saved or loaded)
-    ///
-    /// Config: history.disabled
-    #[arg(long = "no-history", hide_short_help = true)]
-    pub no_history: bool,
+    #[command(flatten)]
+    pub history: shared::HistoryOptions,
 
     /// Subcommands
     #[command(subcommand)]
@@ -464,7 +377,7 @@ mod tests {
         let _r_home = EnvVarGuard::unset("ARF_R_HOME");
         let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
         let cli = Cli::try_parse_from(["arf", "--no-r-source-overrides"]).unwrap();
-        assert!(cli.no_r_source_overrides);
+        assert!(cli.r_source.no_r_source_overrides);
     }
 
     #[test]
@@ -476,7 +389,7 @@ mod tests {
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");
         };
-        assert!(args.no_r_source_overrides);
+        assert!(args.r_source.no_r_source_overrides);
     }
 
     #[test]
@@ -500,11 +413,11 @@ mod tests {
             panic!("expected r-home command");
         };
 
-        assert_eq!(args.config, Some(PathBuf::from("/tmp/arf.toml")));
-        assert_eq!(args.r_home, Some(PathBuf::from("/tmp/r-home")));
-        assert!(args.no_r_source_overrides);
+        assert_eq!(args.r_source.config, Some(PathBuf::from("/tmp/arf.toml")));
+        assert_eq!(args.r_source.r_home, Some(PathBuf::from("/tmp/r-home")));
+        assert!(args.r_source.no_r_source_overrides);
         assert!(args.json);
-        assert!(args.r_version.is_none());
+        assert!(args.r_source.r_version.is_none());
     }
 
     #[test]
@@ -526,7 +439,7 @@ mod tests {
         let cli = Cli::try_parse_from(["arf"]).unwrap();
 
         assert_eq!(
-            cli.r_home.as_deref(),
+            cli.r_source.r_home.as_deref(),
             Some(std::path::Path::new("/env/r-home"))
         );
     }
@@ -539,7 +452,7 @@ mod tests {
         let _env = EnvVarGuard::set("ARF_R_VERSION", "4.5");
         let cli = Cli::try_parse_from(["arf"]).unwrap();
 
-        assert_eq!(cli.r_version.as_deref(), Some("4.5"));
+        assert_eq!(cli.r_source.r_version.as_deref(), Some("4.5"));
     }
 
     #[test]
@@ -551,7 +464,7 @@ mod tests {
             let _home_env = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
             let home_cli = Cli::try_parse_from(["arf", "--r-home", "/cli/r-home"]).unwrap();
             assert_eq!(
-                home_cli.r_home.as_deref(),
+                home_cli.r_source.r_home.as_deref(),
                 Some(std::path::Path::new("/cli/r-home"))
             );
         }
@@ -559,7 +472,7 @@ mod tests {
         {
             let _version_env = EnvVarGuard::set("ARF_R_VERSION", "4.4");
             let version_cli = Cli::try_parse_from(["arf", "--with-r-version", "4.5"]).unwrap();
-            assert_eq!(version_cli.r_version.as_deref(), Some("4.5"));
+            assert_eq!(version_cli.r_source.r_version.as_deref(), Some("4.5"));
         }
     }
 
@@ -583,7 +496,7 @@ mod tests {
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");
         };
-        assert_eq!(args.r_home, Some(PathBuf::from("/env/r-home")));
+        assert_eq!(args.r_source.r_home, Some(PathBuf::from("/env/r-home")));
 
         drop(_r_home);
         drop(_r_version);
@@ -593,7 +506,7 @@ mod tests {
         let Some(Commands::RHome(args)) = cli.command else {
             panic!("expected r-home command");
         };
-        assert_eq!(args.r_version.as_deref(), Some("4.5"));
+        assert_eq!(args.r_source.r_version.as_deref(), Some("4.5"));
     }
 
     #[test]
@@ -618,6 +531,9 @@ mod tests {
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");
         };
-        assert_eq!(args.history_dir, Some(PathBuf::from("/env/history")));
+        assert_eq!(
+            args.history.history_dir,
+            Some(PathBuf::from("/env/history"))
+        );
     }
 }

--- a/crates/arf-console/src/cli/mod.rs
+++ b/crates/arf-console/src/cli/mod.rs
@@ -54,8 +54,7 @@ pub struct Cli {
     #[arg(long)]
     pub no_banner: bool,
 
-    // R-compatible flags (passed to R, for vscode-R and radian compatibility)
-    // Hidden from short help (-h) but shown in long help (--help).
+    // R-compatible flags; see shared::RCompatArgs.
     #[command(flatten)]
     pub r_compat: shared::RCompatArgs,
 

--- a/crates/arf-console/src/cli/r_args.rs
+++ b/crates/arf-console/src/cli/r_args.rs
@@ -92,16 +92,16 @@ impl super::Cli {
     /// Returns a vector of R arguments like ["--quiet", "--no-save", "--no-restore"].
     pub fn r_args(&self) -> Vec<String> {
         RArgsBuilder {
-            vanilla: self.vanilla,
-            no_environ: self.no_environ,
-            no_site_file: self.no_site_file,
-            no_init_file: self.no_init_file,
+            vanilla: self.r_compat.vanilla,
+            no_environ: self.r_compat.no_environ,
+            no_site_file: self.r_compat.no_site_file,
+            no_init_file: self.r_compat.no_init_file,
             save: self.save,
             restore: self.restore_data || self.restore,
-            max_connections: self.max_connections,
-            max_ppsize: self.max_ppsize,
-            min_nsize: self.min_nsize.as_deref(),
-            min_vsize: self.min_vsize.as_deref(),
+            max_connections: self.r_compat.max_connections,
+            max_ppsize: self.r_compat.max_ppsize,
+            min_nsize: self.r_compat.min_nsize.as_deref(),
+            min_vsize: self.r_compat.min_vsize.as_deref(),
         }
         .build()
     }

--- a/crates/arf-console/src/cli/r_home.rs
+++ b/crates/arf-console/src/cli/r_home.rs
@@ -1,32 +1,9 @@
-use clap::{Args, ValueHint};
-use std::path::PathBuf;
+use clap::Args;
 
 #[derive(Args, Debug)]
 pub(crate) struct RHomeArgs {
-    /// Path to configuration file
-    #[arg(short, long, value_hint = ValueHint::FilePath)]
-    pub(crate) config: Option<PathBuf>,
-
-    /// Highest-priority R source: use this R version via rig
-    #[arg(
-        long = "with-r-version",
-        env = "ARF_R_VERSION",
-        conflicts_with = "r_home"
-    )]
-    pub(crate) r_version: Option<String>,
-
-    /// Highest-priority R source: use this explicit R_HOME path
-    #[arg(
-        long = "r-home",
-        value_hint = ValueHint::DirPath,
-        env = "ARF_R_HOME",
-        conflicts_with = "r_version"
-    )]
-    pub(crate) r_home: Option<PathBuf>,
-
-    /// Disable experimental directory-level R source overrides
-    #[arg(long = "no-r-source-overrides")]
-    pub(crate) no_r_source_overrides: bool,
+    #[command(flatten)]
+    pub(crate) r_source: super::shared::RSourceArgs,
 
     /// Print resolution details as JSON
     #[arg(long)]

--- a/crates/arf-console/src/cli/shared.rs
+++ b/crates/arf-console/src/cli/shared.rs
@@ -1,0 +1,115 @@
+use clap::builder::TypedValueParser;
+use clap::{Args, ValueHint};
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct RSourceArgs {
+    /// Path to configuration file
+    #[arg(short, long, value_hint = ValueHint::FilePath)]
+    pub config: Option<PathBuf>,
+
+    /// Highest-priority R source: use this explicit R_HOME path
+    ///
+    /// Mutually exclusive with --with-r-version and ARF_R_VERSION.
+    ///
+    /// Takes precedence over ARF_R_HOME, r_source_overrides and
+    /// startup.r_source, which are not consulted at all when this is set.
+    ///
+    /// Config: startup.r_source
+    #[arg(
+        long = "r-home",
+        value_hint = ValueHint::DirPath,
+        env = "ARF_R_HOME",
+        conflicts_with = "r_version"
+    )]
+    pub r_home: Option<PathBuf>,
+
+    /// Highest-priority R source: use this R version via rig
+    ///
+    /// Accepts a rig alias (e.g. "release"), "default", a rig-assigned name,
+    /// a full version ("4.4.1"), a partial version ("4.4" or "4", matching
+    /// the latest release in that series), or a version range in the style
+    /// Cargo and npm use ("^4.4", ">=4.3, <5.0").
+    ///
+    /// Requires rig. Candidates are limited to R versions rig has installed
+    /// (from `rig list --json`); the version string is never passed to rig.
+    ///
+    /// Takes precedence over ARF_R_VERSION, r_source_overrides and
+    /// startup.r_source, which are not consulted at all when this is set.
+    ///
+    /// Config: startup.r_source
+    #[arg(
+        long = "with-r-version",
+        env = "ARF_R_VERSION",
+        conflicts_with = "r_home"
+    )]
+    pub r_version: Option<String>,
+
+    /// Disable experimental directory-level R source overrides
+    ///
+    /// This only disables r_source_overrides. An R source given by
+    /// --r-home, --with-r-version, ARF_R_HOME or ARF_R_VERSION still applies.
+    ///
+    /// Config: [experimental].r_source_overrides
+    #[arg(long = "no-r-source-overrides")]
+    pub no_r_source_overrides: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct RCompatArgs {
+    /// Start R in vanilla mode (no init files, no save/restore)
+    #[arg(long = "vanilla")]
+    pub vanilla: bool,
+
+    /// [R] Don't read the site and user environment files
+    #[arg(long = "no-environ", hide_short_help = true)]
+    pub no_environ: bool,
+
+    /// [R] Don't read the site-wide Rprofile
+    #[arg(long = "no-site-file", hide_short_help = true)]
+    pub no_site_file: bool,
+
+    /// [R] Don't read the user's .Rprofile
+    #[arg(long = "no-init-file", hide_short_help = true)]
+    pub no_init_file: bool,
+
+    /// [R] Set max number of connections to N
+    #[arg(long = "max-connections", hide = true)]
+    pub max_connections: Option<u32>,
+
+    /// [R] Set max size of protect stack to N
+    #[arg(long = "max-ppsize", hide = true)]
+    pub max_ppsize: Option<u32>,
+
+    /// [R] Set min number of fixed size obj's ("cons cells") to N
+    #[arg(long = "min-nsize", hide = true)]
+    pub min_nsize: Option<String>,
+
+    /// [R] Set vector heap minimum to N bytes; '4M' = 4 MegaB
+    #[arg(long = "min-vsize", hide = true)]
+    pub min_vsize: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct HistoryOptions {
+    /// Custom history directory (overrides default XDG location)
+    ///
+    /// R history is stored at `{dir}/r.db`. The interactive console also
+    /// stores shell history at `{dir}/shell.db`.
+    ///
+    /// Config: history.dir
+    #[arg(
+        long = "history-dir",
+        value_hint = ValueHint::DirPath,
+        env = "ARF_HISTORY_DIR",
+        hide_short_help = true,
+        value_parser = clap::builder::NonEmptyStringValueParser::new().map(PathBuf::from),
+    )]
+    pub history_dir: Option<PathBuf>,
+
+    /// Disable history (no history saved or loaded)
+    ///
+    /// Config: history.disabled
+    #[arg(long = "no-history", hide_short_help = true)]
+    pub no_history: bool,
+}

--- a/crates/arf-console/src/cli/shared.rs
+++ b/crates/arf-console/src/cli/shared.rs
@@ -55,6 +55,13 @@ pub struct RSourceArgs {
     pub no_r_source_overrides: bool,
 }
 
+/// R-compatible flags that let `arf` act as a drop-in replacement for the `R` binary for vscode-R
+/// and radian.
+///
+/// `--vanilla` is visible in short help because it is the composite flag a migrating user
+/// reaches for first. The individual initialization flags (`--no-environ`, `--no-site-file`, and
+/// `--no-init-file`) appear only in long help. The memory-tuning flags (`--max-connections`,
+/// `--max-ppsize`, `--min-nsize`, and `--min-vsize`) are hidden from both short and long help.
 #[derive(Args, Debug)]
 pub struct RCompatArgs {
     /// Start R in vanilla mode (no init files, no save/restore)

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -131,8 +131,8 @@ fn run() -> Result<()> {
         Some(Commands::History(args)) => {
             return handle_history_command(
                 &args.action,
-                cli.config.as_ref(),
-                cli.history_dir.as_ref(),
+                cli.r_source.config.as_ref(),
+                cli.history.history_dir.as_ref(),
             );
         }
         Some(Commands::Ipc(args)) => {
@@ -141,38 +141,38 @@ fn run() -> Result<()> {
         }
         Some(Commands::Headless(args)) => {
             let r_args_builder = RArgsBuilder {
-                vanilla: args.vanilla,
-                no_environ: args.no_environ,
-                no_site_file: args.no_site_file,
-                no_init_file: args.no_init_file,
+                vanilla: args.r_compat.vanilla,
+                no_environ: args.r_compat.no_environ,
+                no_site_file: args.r_compat.no_site_file,
+                no_init_file: args.r_compat.no_init_file,
                 save: false,
                 restore: false,
-                max_connections: args.max_connections,
-                max_ppsize: args.max_ppsize,
-                min_nsize: args.min_nsize.as_deref(),
-                min_vsize: args.min_vsize.as_deref(),
+                max_connections: args.r_compat.max_connections,
+                max_ppsize: args.r_compat.max_ppsize,
+                min_nsize: args.r_compat.min_nsize.as_deref(),
+                min_vsize: args.r_compat.min_vsize.as_deref(),
             };
             return run_headless(
-                args.config.as_ref(),
-                args.r_home.as_deref(),
-                args.r_version.as_deref(),
+                args.r_source.config.as_ref(),
+                args.r_source.r_home.as_deref(),
+                args.r_source.r_version.as_deref(),
                 r_args_builder,
                 args.bind.as_deref(),
                 args.pid_file.as_deref(),
                 args.quiet,
                 args.json,
                 args.log_file.as_deref(),
-                args.history_dir.as_deref(),
-                args.no_history,
-                args.no_r_source_overrides,
+                args.history.history_dir.as_deref(),
+                args.history.no_history,
+                args.r_source.no_r_source_overrides,
             );
         }
         Some(Commands::RHome(args)) => {
             return run_r_home(
-                args.config.as_deref(),
-                args.r_home.as_deref(),
-                args.r_version.as_deref(),
-                args.no_r_source_overrides,
+                args.r_source.config.as_deref(),
+                args.r_source.r_home.as_deref(),
+                args.r_source.r_version.as_deref(),
+                args.r_source.no_r_source_overrides,
                 args.json,
             );
         }
@@ -229,9 +229,9 @@ fn run() -> Result<()> {
     }
 
     // History configuration: CLI flag overrides default XDG location
-    if cli.no_history {
+    if cli.history.no_history {
         config.history.disabled = true;
-    } else if let Some(history_dir) = &cli.history_dir {
+    } else if let Some(history_dir) = &cli.history.history_dir {
         config.history.dir = Some(history_dir.clone());
     }
 
@@ -254,9 +254,9 @@ fn run() -> Result<()> {
         &config.startup.r_source,
         &config.experimental.r_source_overrides,
         None,
-        cli.r_home.as_deref(),
-        cli.r_version.as_deref(),
-        cli.no_r_source_overrides,
+        cli.r_source.r_home.as_deref(),
+        cli.r_source.r_version.as_deref(),
+        cli.r_source.no_r_source_overrides,
     )?;
     resolution.emit_diagnostics();
     let r_source_status = resolution.status;

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: completions
 ---
 _arf() {
@@ -186,7 +186,7 @@ _arf() {
 
     case "${cmd}" in
         arf)
-            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --no-banner --with-r-version --r-home --no-r-source-overrides --vanilla --quiet --no-save --save --no-restore --no-restore-data --restore-data --no-environ --no-site-file --no-init-file --interactive --no-echo --slave --restore --verbose --encoding --max-connections --max-ppsize --min-nsize --min-vsize --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --ipc-bind --ipc-pid-file --no-auto-match --no-completion --history-dir --no-history --help --version completions config history ipc headless r-home help"
+            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --r-home --with-r-version --no-r-source-overrides --no-banner --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --quiet --no-save --save --no-restore --no-restore-data --restore-data --interactive --no-echo --slave --restore --verbose --encoding --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --ipc-bind --ipc-pid-file --no-auto-match --no-completion --history-dir --no-history --help --version completions config history ipc headless r-home help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -260,10 +260,6 @@ _arf() {
                     fi
                     return 0
                     ;;
-                --with-r-version)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --r-home)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -271,7 +267,7 @@ _arf() {
                     fi
                     return 0
                     ;;
-                --encoding)
+                --with-r-version)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -288,6 +284,10 @@ _arf() {
                     return 0
                     ;;
                 --min-vsize)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --encoding)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -502,7 +502,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__headless)
-            opts="-c -h --config --with-r-version --r-home --no-r-source-overrides --ipc-bind --ipc-pid-file --quiet --json --log-file --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --history-dir --no-history --min-nsize --min-vsize --help"
+            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --ipc-bind --ipc-pid-file --quiet --json --log-file --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --history-dir --no-history --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -538,15 +538,15 @@ _arf() {
                     fi
                     return 0
                     ;;
-                --with-r-version)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --r-home)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o plusdirs
                     fi
+                    return 0
+                    ;;
+                --with-r-version)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --ipc-bind)
@@ -602,19 +602,19 @@ _arf() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                --history-dir)
-                    COMPREPLY=()
-                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
-                        compopt -o plusdirs
-                    fi
-                    return 0
-                    ;;
                 --min-nsize)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --min-vsize)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --history-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
                     return 0
                     ;;
                 *)
@@ -1321,7 +1321,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__r__subcmd__home)
-            opts="-c -h --config --with-r-version --r-home --no-r-source-overrides --json --help"
+            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --json --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1357,15 +1357,15 @@ _arf() {
                     fi
                     return 0
                     ;;
-                --with-r-version)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --r-home)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o plusdirs
                     fi
+                    return 0
+                    ;;
+                --with-r-version)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 *)

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
@@ -1,10 +1,10 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: completions
 ---
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_arf_global_optspecs
-    string join \n e/eval= f/file= reprex auto-format c/config= no-banner with-r-version= r-home= no-r-source-overrides vanilla q/quiet no-save save no-restore no-restore-data restore-data no-environ no-site-file no-init-file interactive no-echo slave restore verbose encoding= max-connections= max-ppsize= min-nsize= min-vsize= d/debugger= debugger-args= g/gui= arch= args no-readline no-restore-history with-ipc ipc-bind= ipc-pid-file= no-auto-match no-completion history-dir= no-history h/help V/version
+    string join \n e/eval= f/file= reprex auto-format c/config= r-home= with-r-version= no-r-source-overrides no-banner vanilla no-environ no-site-file no-init-file max-connections= max-ppsize= min-nsize= min-vsize= q/quiet no-save save no-restore no-restore-data restore-data interactive no-echo slave restore verbose encoding= d/debugger= debugger-args= g/gui= arch= args no-readline no-restore-history with-ipc ipc-bind= ipc-pid-file= no-auto-match no-completion history-dir= no-history h/help V/version
 end
 
 function __fish_arf_needs_command
@@ -31,13 +31,13 @@ end
 complete -c arf -n "__fish_arf_needs_command" -s e -l eval -d 'Evaluate R expression and exit' -r
 complete -c arf -n "__fish_arf_needs_command" -s f -l file -d '[R] Take input from FILE' -r -F
 complete -c arf -n "__fish_arf_needs_command" -s c -l config -d 'Path to configuration file' -r -F
-complete -c arf -n "__fish_arf_needs_command" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_needs_command" -l r-home -d 'Highest-priority R source: use this explicit R_HOME path' -r -f -a "(__fish_complete_directories)"
-complete -c arf -n "__fish_arf_needs_command" -l encoding -d '[R] Specify encoding to be used for stdin (no-op)' -r
+complete -c arf -n "__fish_arf_needs_command" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_needs_command" -l max-connections -d '[R] Set max number of connections to N' -r
 complete -c arf -n "__fish_arf_needs_command" -l max-ppsize -d '[R] Set max size of protect stack to N' -r
 complete -c arf -n "__fish_arf_needs_command" -l min-nsize -d '[R] Set min number of fixed size obj\'s ("cons cells") to N' -r
 complete -c arf -n "__fish_arf_needs_command" -l min-vsize -d '[R] Set vector heap minimum to N bytes; \'4M\' = 4 MegaB' -r
+complete -c arf -n "__fish_arf_needs_command" -l encoding -d '[R] Specify encoding to be used for stdin (no-op)' -r
 complete -c arf -n "__fish_arf_needs_command" -s d -l debugger -d '[R] Run R through debugger NAME (no-op)' -r
 complete -c arf -n "__fish_arf_needs_command" -l debugger-args -d '[R] Pass ARGS as arguments to the debugger (no-op)' -r
 complete -c arf -n "__fish_arf_needs_command" -s g -l gui -d '[R] Use TYPE as GUI (no-op)' -r
@@ -47,18 +47,18 @@ complete -c arf -n "__fish_arf_needs_command" -l ipc-pid-file -d 'Write server P
 complete -c arf -n "__fish_arf_needs_command" -l history-dir -d 'Custom history directory (overrides default XDG location)' -r -f -a "(__fish_complete_directories)"
 complete -c arf -n "__fish_arf_needs_command" -l reprex -d 'Enable reprex mode (no prompt, output prefixed with #>)'
 complete -c arf -n "__fish_arf_needs_command" -l auto-format -d 'Enable auto-formatting of R code in reprex mode (requires Air CLI)'
-complete -c arf -n "__fish_arf_needs_command" -l no-banner -d 'Suppress the startup banner'
 complete -c arf -n "__fish_arf_needs_command" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
+complete -c arf -n "__fish_arf_needs_command" -l no-banner -d 'Suppress the startup banner'
 complete -c arf -n "__fish_arf_needs_command" -l vanilla -d 'Start R in vanilla mode (no init files, no save/restore)'
+complete -c arf -n "__fish_arf_needs_command" -l no-environ -d '[R] Don\'t read the site and user environment files'
+complete -c arf -n "__fish_arf_needs_command" -l no-site-file -d '[R] Don\'t read the site-wide Rprofile'
+complete -c arf -n "__fish_arf_needs_command" -l no-init-file -d '[R] Don\'t read the user\'s .Rprofile'
 complete -c arf -n "__fish_arf_needs_command" -s q -l quiet -d '[R] Don\'t print R startup message'
 complete -c arf -n "__fish_arf_needs_command" -l no-save -d '[R] Don\'t save workspace at end of session (default)'
 complete -c arf -n "__fish_arf_needs_command" -l save -d '[R] Save workspace at end of session'
 complete -c arf -n "__fish_arf_needs_command" -l no-restore -d '[R] Don\'t restore previously saved objects (default)'
 complete -c arf -n "__fish_arf_needs_command" -l no-restore-data -d '[R] Don\'t restore previously saved objects'
 complete -c arf -n "__fish_arf_needs_command" -l restore-data -d '[R] Restore previously saved objects'
-complete -c arf -n "__fish_arf_needs_command" -l no-environ -d '[R] Don\'t read the site and user environment files'
-complete -c arf -n "__fish_arf_needs_command" -l no-site-file -d '[R] Don\'t read the site-wide Rprofile'
-complete -c arf -n "__fish_arf_needs_command" -l no-init-file -d '[R] Don\'t read the user\'s .Rprofile'
 complete -c arf -n "__fish_arf_needs_command" -l interactive -d '[R] Force R to run interactively (no-op, always interactive)'
 complete -c arf -n "__fish_arf_needs_command" -l no-echo -d '[R] Don\'t echo input (no-op, arf controls its own echo)'
 complete -c arf -n "__fish_arf_needs_command" -l slave -d '[R] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)'
@@ -151,16 +151,16 @@ complete -c arf -n "__fish_arf_using_subcommand ipc; and __fish_seen_subcommand_
 complete -c arf -n "__fish_arf_using_subcommand ipc; and __fish_seen_subcommand_from help" -f -a "history" -d 'Query command history from a running session'
 complete -c arf -n "__fish_arf_using_subcommand ipc; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c arf -n "__fish_arf_using_subcommand headless" -s c -l config -d 'Path to configuration file' -r -F
-complete -c arf -n "__fish_arf_using_subcommand headless" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_using_subcommand headless" -l r-home -d 'Highest-priority R source: use this explicit R_HOME path' -r -f -a "(__fish_complete_directories)"
+complete -c arf -n "__fish_arf_using_subcommand headless" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_using_subcommand headless" -l ipc-bind -d 'Bind IPC socket to a specific path instead of the default. On Unix, ensure the parent directory is user-private (mode 0700) to avoid a brief permission window before the socket is restricted' -r -F
 complete -c arf -n "__fish_arf_using_subcommand headless" -l ipc-pid-file -d 'Write server PID to a file (removed on shutdown)' -r -F
 complete -c arf -n "__fish_arf_using_subcommand headless" -l log-file -d 'Redirect log output to a file instead of stderr' -r -F
 complete -c arf -n "__fish_arf_using_subcommand headless" -l max-connections -d '[R] Set max number of connections to N' -r
 complete -c arf -n "__fish_arf_using_subcommand headless" -l max-ppsize -d '[R] Set max size of protect stack to N' -r
-complete -c arf -n "__fish_arf_using_subcommand headless" -l history-dir -d 'Custom history directory (overrides default XDG location)' -r -f -a "(__fish_complete_directories)"
 complete -c arf -n "__fish_arf_using_subcommand headless" -l min-nsize -d '[R] Set min number of fixed size obj\'s ("cons cells") to N' -r
 complete -c arf -n "__fish_arf_using_subcommand headless" -l min-vsize -d '[R] Set vector heap minimum to N bytes; \'4M\' = 4 MegaB' -r
+complete -c arf -n "__fish_arf_using_subcommand headless" -l history-dir -d 'Custom history directory (overrides default XDG location)' -r -f -a "(__fish_complete_directories)"
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l quiet -d 'Suppress status messages on stderr (IPC path, ready, shutdown)'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l json -d 'Print session info as JSON to stdout when ready'
@@ -168,14 +168,14 @@ complete -c arf -n "__fish_arf_using_subcommand headless" -l vanilla -d 'Start R
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-environ -d '[R] Don\'t read the site and user environment files'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-site-file -d '[R] Don\'t read the site-wide Rprofile'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-init-file -d '[R] Don\'t read the user\'s .Rprofile'
-complete -c arf -n "__fish_arf_using_subcommand headless" -l no-history -d 'Disable history (no history saved)'
+complete -c arf -n "__fish_arf_using_subcommand headless" -l no-history -d 'Disable history (no history saved or loaded)'
 complete -c arf -n "__fish_arf_using_subcommand headless" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_using_subcommand r-home" -s c -l config -d 'Path to configuration file' -r -F
-complete -c arf -n "__fish_arf_using_subcommand r-home" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_using_subcommand r-home" -l r-home -d 'Highest-priority R source: use this explicit R_HOME path' -r -f -a "(__fish_complete_directories)"
+complete -c arf -n "__fish_arf_using_subcommand r-home" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_using_subcommand r-home" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
 complete -c arf -n "__fish_arf_using_subcommand r-home" -l json -d 'Print resolution details as JSON'
-complete -c arf -n "__fish_arf_using_subcommand r-home" -s h -l help -d 'Print help'
+complete -c arf -n "__fish_arf_using_subcommand r-home" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_using_subcommand help; and not __fish_seen_subcommand_from completions config history ipc headless r-home help" -f -a "completions" -d 'Generate shell completion scripts'
 complete -c arf -n "__fish_arf_using_subcommand help; and not __fish_seen_subcommand_from completions config history ipc headless r-home help" -f -a "config" -d 'Configuration management'
 complete -c arf -n "__fish_arf_using_subcommand help; and not __fish_seen_subcommand_from completions config history ipc headless r-home help" -f -a "history" -d 'History management'

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: completions
 ---
 
@@ -31,13 +31,13 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, '[R] Take input from FILE')
             [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Path to configuration file')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to configuration file')
-            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--r-home', '--r-home', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this explicit R_HOME path')
-            [CompletionResult]::new('--encoding', '--encoding', [CompletionResultType]::ParameterName, '[R] Specify encoding to be used for stdin (no-op)')
+            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--max-connections', '--max-connections', [CompletionResultType]::ParameterName, '[R] Set max number of connections to N')
             [CompletionResult]::new('--max-ppsize', '--max-ppsize', [CompletionResultType]::ParameterName, '[R] Set max size of protect stack to N')
             [CompletionResult]::new('--min-nsize', '--min-nsize', [CompletionResultType]::ParameterName, '[R] Set min number of fixed size obj''s ("cons cells") to N')
             [CompletionResult]::new('--min-vsize', '--min-vsize', [CompletionResultType]::ParameterName, '[R] Set vector heap minimum to N bytes; ''4M'' = 4 MegaB')
+            [CompletionResult]::new('--encoding', '--encoding', [CompletionResultType]::ParameterName, '[R] Specify encoding to be used for stdin (no-op)')
             [CompletionResult]::new('-d', '-d', [CompletionResultType]::ParameterName, '[R] Run R through debugger NAME (no-op)')
             [CompletionResult]::new('--debugger', '--debugger', [CompletionResultType]::ParameterName, '[R] Run R through debugger NAME (no-op)')
             [CompletionResult]::new('--debugger-args', '--debugger-args', [CompletionResultType]::ParameterName, '[R] Pass ARGS as arguments to the debugger (no-op)')
@@ -49,9 +49,12 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--history-dir', '--history-dir', [CompletionResultType]::ParameterName, 'Custom history directory (overrides default XDG location)')
             [CompletionResult]::new('--reprex', '--reprex', [CompletionResultType]::ParameterName, 'Enable reprex mode (no prompt, output prefixed with #>)')
             [CompletionResult]::new('--auto-format', '--auto-format', [CompletionResultType]::ParameterName, 'Enable auto-formatting of R code in reprex mode (requires Air CLI)')
-            [CompletionResult]::new('--no-banner', '--no-banner', [CompletionResultType]::ParameterName, 'Suppress the startup banner')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
+            [CompletionResult]::new('--no-banner', '--no-banner', [CompletionResultType]::ParameterName, 'Suppress the startup banner')
             [CompletionResult]::new('--vanilla', '--vanilla', [CompletionResultType]::ParameterName, 'Start R in vanilla mode (no init files, no save/restore)')
+            [CompletionResult]::new('--no-environ', '--no-environ', [CompletionResultType]::ParameterName, '[R] Don''t read the site and user environment files')
+            [CompletionResult]::new('--no-site-file', '--no-site-file', [CompletionResultType]::ParameterName, '[R] Don''t read the site-wide Rprofile')
+            [CompletionResult]::new('--no-init-file', '--no-init-file', [CompletionResultType]::ParameterName, '[R] Don''t read the user''s .Rprofile')
             [CompletionResult]::new('-q', '-q', [CompletionResultType]::ParameterName, '[R] Don''t print R startup message')
             [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, '[R] Don''t print R startup message')
             [CompletionResult]::new('--no-save', '--no-save', [CompletionResultType]::ParameterName, '[R] Don''t save workspace at end of session (default)')
@@ -59,9 +62,6 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--no-restore', '--no-restore', [CompletionResultType]::ParameterName, '[R] Don''t restore previously saved objects (default)')
             [CompletionResult]::new('--no-restore-data', '--no-restore-data', [CompletionResultType]::ParameterName, '[R] Don''t restore previously saved objects')
             [CompletionResult]::new('--restore-data', '--restore-data', [CompletionResultType]::ParameterName, '[R] Restore previously saved objects')
-            [CompletionResult]::new('--no-environ', '--no-environ', [CompletionResultType]::ParameterName, '[R] Don''t read the site and user environment files')
-            [CompletionResult]::new('--no-site-file', '--no-site-file', [CompletionResultType]::ParameterName, '[R] Don''t read the site-wide Rprofile')
-            [CompletionResult]::new('--no-init-file', '--no-init-file', [CompletionResultType]::ParameterName, '[R] Don''t read the user''s .Rprofile')
             [CompletionResult]::new('--interactive', '--interactive', [CompletionResultType]::ParameterName, '[R] Force R to run interactively (no-op, always interactive)')
             [CompletionResult]::new('--no-echo', '--no-echo', [CompletionResultType]::ParameterName, '[R] Don''t echo input (no-op, arf controls its own echo)')
             [CompletionResult]::new('--slave', '--slave', [CompletionResultType]::ParameterName, '[R] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)')
@@ -271,16 +271,16 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
         'arf;headless' {
             [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Path to configuration file')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to configuration file')
-            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--r-home', '--r-home', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this explicit R_HOME path')
+            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--ipc-bind', '--ipc-bind', [CompletionResultType]::ParameterName, 'Bind IPC socket to a specific path instead of the default. On Unix, ensure the parent directory is user-private (mode 0700) to avoid a brief permission window before the socket is restricted')
             [CompletionResult]::new('--ipc-pid-file', '--ipc-pid-file', [CompletionResultType]::ParameterName, 'Write server PID to a file (removed on shutdown)')
             [CompletionResult]::new('--log-file', '--log-file', [CompletionResultType]::ParameterName, 'Redirect log output to a file instead of stderr')
             [CompletionResult]::new('--max-connections', '--max-connections', [CompletionResultType]::ParameterName, '[R] Set max number of connections to N')
             [CompletionResult]::new('--max-ppsize', '--max-ppsize', [CompletionResultType]::ParameterName, '[R] Set max size of protect stack to N')
-            [CompletionResult]::new('--history-dir', '--history-dir', [CompletionResultType]::ParameterName, 'Custom history directory (overrides default XDG location)')
             [CompletionResult]::new('--min-nsize', '--min-nsize', [CompletionResultType]::ParameterName, '[R] Set min number of fixed size obj''s ("cons cells") to N')
             [CompletionResult]::new('--min-vsize', '--min-vsize', [CompletionResultType]::ParameterName, '[R] Set vector heap minimum to N bytes; ''4M'' = 4 MegaB')
+            [CompletionResult]::new('--history-dir', '--history-dir', [CompletionResultType]::ParameterName, 'Custom history directory (overrides default XDG location)')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
             [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Suppress status messages on stderr (IPC path, ready, shutdown)')
             [CompletionResult]::new('--json', '--json', [CompletionResultType]::ParameterName, 'Print session info as JSON to stdout when ready')
@@ -288,7 +288,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--no-environ', '--no-environ', [CompletionResultType]::ParameterName, '[R] Don''t read the site and user environment files')
             [CompletionResult]::new('--no-site-file', '--no-site-file', [CompletionResultType]::ParameterName, '[R] Don''t read the site-wide Rprofile')
             [CompletionResult]::new('--no-init-file', '--no-init-file', [CompletionResultType]::ParameterName, '[R] Don''t read the user''s .Rprofile')
-            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Disable history (no history saved)')
+            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Disable history (no history saved or loaded)')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break
@@ -296,12 +296,12 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
         'arf;r-home' {
             [CompletionResult]::new('-c', '-c', [CompletionResultType]::ParameterName, 'Path to configuration file')
             [CompletionResult]::new('--config', '--config', [CompletionResultType]::ParameterName, 'Path to configuration file')
-            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--r-home', '--r-home', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this explicit R_HOME path')
+            [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
             [CompletionResult]::new('--json', '--json', [CompletionResultType]::ParameterName, 'Print resolution details as JSON')
-            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
-            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break
         }
         'arf;help' {

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: completions
 ---
 #compdef arf
@@ -25,13 +25,13 @@ _arf() {
 '(-e --eval)--file=[\[R\] Take input from FILE]:FILE:_files' \
 '-c+[Path to configuration file]:CONFIG:_files' \
 '--config=[Path to configuration file]:CONFIG:_files' \
-'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '(--with-r-version)--r-home=[Highest-priority R source\: use this explicit R_HOME path]:R_HOME:_files -/' \
-'--encoding=[\[R\] Specify encoding to be used for stdin (no-op)]:ENCODING:_default' \
+'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '--max-connections=[\[R\] Set max number of connections to N]:MAX_CONNECTIONS:_default' \
 '--max-ppsize=[\[R\] Set max size of protect stack to N]:MAX_PPSIZE:_default' \
 '--min-nsize=[\[R\] Set min number of fixed size obj'\''s ("cons cells") to N]:MIN_NSIZE:_default' \
 '--min-vsize=[\[R\] Set vector heap minimum to N bytes; '\''4M'\'' = 4 MegaB]:MIN_VSIZE:_default' \
+'--encoding=[\[R\] Specify encoding to be used for stdin (no-op)]:ENCODING:_default' \
 '-d+[\[R\] Run R through debugger NAME (no-op)]:DEBUGGER:_default' \
 '--debugger=[\[R\] Run R through debugger NAME (no-op)]:DEBUGGER:_default' \
 '--debugger-args=[\[R\] Pass ARGS as arguments to the debugger (no-op)]:DEBUGGER_ARGS:_default' \
@@ -43,9 +43,12 @@ _arf() {
 '--history-dir=[Custom history directory (overrides default XDG location)]:HISTORY_DIR:_files -/' \
 '--reprex[Enable reprex mode (no prompt, output prefixed with #>)]' \
 '--auto-format[Enable auto-formatting of R code in reprex mode (requires Air CLI)]' \
-'--no-banner[Suppress the startup banner]' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
+'--no-banner[Suppress the startup banner]' \
 '--vanilla[Start R in vanilla mode (no init files, no save/restore)]' \
+'--no-environ[\[R\] Don'\''t read the site and user environment files]' \
+'--no-site-file[\[R\] Don'\''t read the site-wide Rprofile]' \
+'--no-init-file[\[R\] Don'\''t read the user'\''s .Rprofile]' \
 '-q[\[R\] Don'\''t print R startup message]' \
 '--quiet[\[R\] Don'\''t print R startup message]' \
 '--no-save[\[R\] Don'\''t save workspace at end of session (default)]' \
@@ -53,9 +56,6 @@ _arf() {
 '--no-restore[\[R\] Don'\''t restore previously saved objects (default)]' \
 '--no-restore-data[\[R\] Don'\''t restore previously saved objects]' \
 '(--no-restore --no-restore-data)--restore-data[\[R\] Restore previously saved objects]' \
-'--no-environ[\[R\] Don'\''t read the site and user environment files]' \
-'--no-site-file[\[R\] Don'\''t read the site-wide Rprofile]' \
-'--no-init-file[\[R\] Don'\''t read the user'\''s .Rprofile]' \
 '--interactive[\[R\] Force R to run interactively (no-op, always interactive)]' \
 '--no-echo[\[R\] Don'\''t echo input (no-op, arf controls its own echo)]' \
 '--slave[\[R\] Combine --quiet --no-save --no-restore (deprecated in R 4.0, use --no-echo)]' \
@@ -347,16 +347,16 @@ esac
 _arguments "${_arguments_options[@]}" : \
 '-c+[Path to configuration file]:CONFIG:_files' \
 '--config=[Path to configuration file]:CONFIG:_files' \
-'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '(--with-r-version)--r-home=[Highest-priority R source\: use this explicit R_HOME path]:R_HOME:_files -/' \
+'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '--ipc-bind=[Bind IPC socket to a specific path instead of the default. On Unix, ensure the parent directory is user-private (mode 0700) to avoid a brief permission window before the socket is restricted]:BIND:_files' \
 '--ipc-pid-file=[Write server PID to a file (removed on shutdown)]:PID_FILE:_files' \
 '--log-file=[Redirect log output to a file instead of stderr]:LOG_FILE:_files' \
 '--max-connections=[\[R\] Set max number of connections to N]:MAX_CONNECTIONS:_default' \
 '--max-ppsize=[\[R\] Set max size of protect stack to N]:MAX_PPSIZE:_default' \
-'--history-dir=[Custom history directory (overrides default XDG location)]:HISTORY_DIR:_files -/' \
 '--min-nsize=[\[R\] Set min number of fixed size obj'\''s ("cons cells") to N]:MIN_NSIZE:_default' \
 '--min-vsize=[\[R\] Set vector heap minimum to N bytes; '\''4M'\'' = 4 MegaB]:MIN_VSIZE:_default' \
+'--history-dir=[Custom history directory (overrides default XDG location)]:HISTORY_DIR:_files -/' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
 '--quiet[Suppress status messages on stderr (IPC path, ready, shutdown)]' \
 '--json[Print session info as JSON to stdout when ready]' \
@@ -364,7 +364,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-environ[\[R\] Don'\''t read the site and user environment files]' \
 '--no-site-file[\[R\] Don'\''t read the site-wide Rprofile]' \
 '--no-init-file[\[R\] Don'\''t read the user'\''s .Rprofile]' \
-'--no-history[Disable history (no history saved)]' \
+'--no-history[Disable history (no history saved or loaded)]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
@@ -373,12 +373,12 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-c+[Path to configuration file]:CONFIG:_files' \
 '--config=[Path to configuration file]:CONFIG:_files' \
-'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '(--with-r-version)--r-home=[Highest-priority R source\: use this explicit R_HOME path]:R_HOME:_files -/' \
+'(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
 '--json[Print resolution details as JSON]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
 (help)

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
@@ -12,6 +12,17 @@ Options:
   -c, --config <CONFIG>
           Path to configuration file
 
+      --r-home <R_HOME>
+          Highest-priority R source: use this explicit R_HOME path
+          
+          Mutually exclusive with --with-r-version and ARF_R_VERSION.
+          
+          Takes precedence over ARF_R_HOME, r_source_overrides and startup.r_source, which are not consulted at all when this is set.
+          
+          Config: startup.r_source
+          
+          [env: ARF_R_HOME=]
+
       --with-r-version <R_VERSION>
           Highest-priority R source: use this R version via rig
           
@@ -24,17 +35,6 @@ Options:
           Config: startup.r_source
           
           [env: ARF_R_VERSION=]
-
-      --r-home <R_HOME>
-          Highest-priority R source: use this explicit R_HOME path
-          
-          Mutually exclusive with --with-r-version and ARF_R_VERSION.
-          
-          Takes precedence over ARF_R_HOME, r_source_overrides and startup.r_source, which are not consulted at all when this is set.
-          
-          Config: startup.r_source
-          
-          [env: ARF_R_HOME=]
 
       --no-r-source-overrides
           Disable experimental directory-level R source overrides
@@ -77,14 +77,14 @@ Options:
       --history-dir <HISTORY_DIR>
           Custom history directory (overrides default XDG location)
           
-          History will be stored at `{dir}/r.db`.
+          R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
           Config: history.dir
           
           [env: ARF_HISTORY_DIR=]
 
       --no-history
-          Disable history (no history saved)
+          Disable history (no history saved or loaded)
           
           Config: history.disabled
 

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: help
 ---
 A cross-platform R console written in Rust
@@ -35,10 +35,16 @@ Options:
   -c, --config <CONFIG>
           Path to configuration file
 
-      --no-banner
-          Suppress the startup banner
+      --r-home <R_HOME>
+          Highest-priority R source: use this explicit R_HOME path
           
-          Config: show_banner
+          Mutually exclusive with --with-r-version and ARF_R_VERSION.
+          
+          Takes precedence over ARF_R_HOME, r_source_overrides and startup.r_source, which are not consulted at all when this is set.
+          
+          Config: startup.r_source
+          
+          [env: ARF_R_HOME=]
 
       --with-r-version <R_VERSION>
           Highest-priority R source: use this R version via rig
@@ -53,17 +59,6 @@ Options:
           
           [env: ARF_R_VERSION=]
 
-      --r-home <R_HOME>
-          Highest-priority R source: use this explicit R_HOME path
-          
-          Mutually exclusive with --with-r-version and ARF_R_VERSION.
-          
-          Takes precedence over ARF_R_HOME, r_source_overrides and startup.r_source, which are not consulted at all when this is set.
-          
-          Config: startup.r_source
-          
-          [env: ARF_R_HOME=]
-
       --no-r-source-overrides
           Disable experimental directory-level R source overrides
           
@@ -71,8 +66,22 @@ Options:
           
           Config: [experimental].r_source_overrides
 
+      --no-banner
+          Suppress the startup banner
+          
+          Config: show_banner
+
       --vanilla
           Start R in vanilla mode (no init files, no save/restore)
+
+      --no-environ
+          [R] Don't read the site and user environment files
+
+      --no-site-file
+          [R] Don't read the site-wide Rprofile
+
+      --no-init-file
+          [R] Don't read the user's .Rprofile
 
   -q, --quiet
           [R] Don't print R startup message
@@ -91,15 +100,6 @@ Options:
 
       --restore-data
           [R] Restore previously saved objects
-
-      --no-environ
-          [R] Don't read the site and user environment files
-
-      --no-site-file
-          [R] Don't read the site-wide Rprofile
-
-      --no-init-file
-          [R] Don't read the user's .Rprofile
 
       --no-echo
           [R] Don't echo input (no-op, arf controls its own echo)
@@ -122,7 +122,7 @@ Options:
       --history-dir <HISTORY_DIR>
           Custom history directory (overrides default XDG location)
           
-          R history will be stored at `{dir}/r.db`, Shell at `{dir}/shell.db`.
+          R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
           Config: history.dir
           


### PR DESCRIPTION
## Summary

The top-level `Cli` struct and the `headless` / `r-home` subcommands each declared their own copy of the same options. The copies had drifted — `r-home` carried abbreviated one-line descriptions, `headless` described the history directory as if the shell database did not exist, and the argument order differed between all three.

Collapse them into shared `#[derive(Args)]` structs embedded with `#[command(flatten)]`, so each option is described once:

- `RSourceArgs` — `--config`, `--r-home`, `--with-r-version`, `--no-r-source-overrides`, including the `ARF_R_HOME` and `ARF_R_VERSION` bindings
- `RCompatArgs` — the R-compatibility flags shared with `headless`
- `HistoryOptions` — `--history-dir` and `--no-history`

`--quiet` stays separate: at the top level it suppresses R's startup message, under `headless` it suppresses IPC status messages.

The comment describing the R-compatibility group was wrong in both halves — `--vanilla` does appear in short help, and the memory-tuning flags appear in neither short nor long help. It now sits on the struct it describes and records why `--vanilla` is the exception, so a future reader does not "correct" it by hiding the flag. Whether `-h` shows the right set of flags at all is a separate question, left to a follow-up.

No behavior change. The same options are accepted, with the same conflicts and environment bindings. Help and completion output changes in two ways: arguments are grouped in struct order, and the subcommands now show the fuller shared descriptions instead of their abbreviated copies.

## Tests

- [x] Existing suite passes unchanged
- [x] Snapshots regenerated; the diffs are argument ordering and the consolidated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
