### PR TITLE
chore: update reedline to 0.49 and rusqlite to 0.40

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      reedline-rusqlite:
+        patterns:
+          - "reedline"
+          - "rusqlite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,11 +882,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1125,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201e8e0160cbe7bb5eb2caccf281e178e77fac95115ab31a2c29edc5593603c8"
+checksum = "826c1fc22a2b1f14c3f6a80fc3d56adfbfb913d07f170bce4246700de7adfd50"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1808,6 +1808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rtoolbox"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
@@ -1829,6 +1839,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2101,6 +2112,18 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ crossterm = "0.29"
 crokey = "1.4"
 nu-ansi-term = { version = "0.50", features = ["derive_serde_style"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
-reedline = { version = "0.48", features = ["sqlite", "idle_callback"] }
+# NOTE: reedline and rusqlite share the `links = "sqlite3"` native library (via
+# libsqlite3-sys) and must be upgraded together in lockstep, or Cargo's
+# dependency resolution fails.
+reedline = { version = "0.49", features = ["sqlite", "idle_callback"] }
 
 # Configuration
 dirs = "6.0"
@@ -53,7 +56,8 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 
 # Database
-rusqlite = { version = "0.37.0", features = ["bundled"] }
+# NOTE: must be upgraded together with reedline; see the comment there.
+rusqlite = { version = "0.40.1", features = ["bundled"] }
 
 # Utilities
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

Dependabot never proposed reedline 0.49. It requires rusqlite 0.40, and rusqlite depends on libsqlite3-sys, which declares `links = "sqlite3"`. Cargo allows only one package in the graph to claim a given `links` value, so raising reedline while rusqlite stayed at 0.37 could not resolve:

```
package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts
with a previous package which links to `sqlite3` as well
  reedline 0.49.0 → rusqlite ^0.40.1 → libsqlite3-sys ^0.38.1
  arf-console    → rusqlite  0.37.0  → libsqlite3-sys  0.35.0
```

Nothing surfaced as an error — the update was simply absent, which is how it went unnoticed.

Move both together, and note beside each declaration why they are coupled so the next person to bump one knows the other has to follow. The Dependabot config now groups them as well, though grouping combines updates into one pull request and is not documented to make the resolver try candidates jointly, so it may not be sufficient on its own.

No source changes were required: SQL parameters are already bound as `i64` and `prepare_cached` is unused, so rusqlite 0.38 making the `u64`/`usize` conversions opt-in does not apply here; `Completer` already satisfied the `Send` bound that reedline 0.49 stopped requiring.

`libsqlite3-sys` now resolves to a single 0.38.1 shared by both dependents. The lockfile also gains `rsqlite-vfs` and `sqlite-wasm-rs`, which are wasm-only and are not built for any target this project ships.

## Tests

- [x] Full suite green; no snapshot changes
- [x] Interactive check in tmux: history recall and reverse search over the SQLite-backed history, completion menu, continuation prompt, multi-line definitions, interrupt during evaluation, external SIGINT, and clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
