### PR TITLE
feat(ipc): report `session_type` in session metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   is read by `{ type = "toml-key", file = "rproject.toml", key = "project.r_version" }`. Only the current directory is searched, and only R versions rig has already installed can be selected.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
+- `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.
 - `arf r-home` reports the `R_HOME` selected by arf without starting R, including installations found through platform-specific default library paths, so external tools can use the same R version and source overrides. If no R installation can be discovered, normal startup continues without R evaluation while `arf r-home` exits with an error because there is no path to report.
 
 ### Changed

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -8,7 +8,7 @@ use crate::app::setup::{RSourceOverrideState, RSourceResolutionReport, setup_r};
 use crate::cli::RArgsBuilder;
 use crate::config;
 use crate::ipc;
-use crate::ipc::session::SessionInfo;
+use crate::ipc::session::{SessionInfo, SessionType};
 use crate::pid_file::{
     absolute_pid_file_path, cleanup_ipc_pid_file, register_ipc_pid_file_atexit, write_pid_file,
 };
@@ -220,7 +220,7 @@ pub(crate) fn run_headless(
             .display()
             .to_string()
     });
-    let session = ipc::start_server(bind, log_file_str, session_id_raw)
+    let session = ipc::start_server(bind, log_file_str, session_id_raw, SessionType::Headless)
         .context("Failed to start IPC server")?;
     if !quiet {
         eprintln!("IPC server listening on: {}", session.socket_path);

--- a/crates/arf-console/src/cli/ipc.rs
+++ b/crates/arf-console/src/cli/ipc.rs
@@ -11,7 +11,8 @@ pub(crate) enum IpcAction {
     /// List active arf sessions as JSON
     ///
     /// Returns a JSON object with a `sessions` array. Each entry contains
-    /// pid, r_version, socket_path, cwd, started_at, log_file, and history_session_id.
+    /// pid, r_version, socket_path, cwd, started_at, session_type, log_file,
+    /// and history_session_id.
     /// Returns `{"sessions": []}` when no sessions are running (exit 0).
     #[command(after_long_help = "\
 Examples:

--- a/crates/arf-console/src/ipc/mod.rs
+++ b/crates/arf-console/src/ipc/mod.rs
@@ -144,6 +144,7 @@ pub fn start_server(
     bind: Option<&str>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
+    session_type: session::SessionType,
 ) -> std::io::Result<session::SessionInfo> {
     let (tx, rx) = std::sync::mpsc::channel();
 
@@ -157,7 +158,14 @@ pub fn start_server(
     // Start the server thread first; only update the receiver after
     // confirming that the server bound successfully, so a failed start
     // doesn't break an already-running server's channel.
-    let session = server::start_server(tx, bind, &started_at, log_file, history_session_id)?;
+    let session = server::start_server(
+        tx,
+        bind,
+        &started_at,
+        log_file,
+        history_session_id,
+        session_type,
+    )?;
 
     // Note: session metadata is now cached inside server::start_server()
     // right after bind confirmation, before the server can serve any request.

--- a/crates/arf-console/src/ipc/server.rs
+++ b/crates/arf-console/src/ipc/server.rs
@@ -10,7 +10,7 @@ use crate::ipc::protocol::{
     INVALID_REQUEST, IpcMethod, IpcRequest, IpcResponse, JsonRpcRequest, JsonRpcResponse,
     METHOD_NOT_FOUND, PARSE_ERROR, ShutdownResult, UserInputParams,
 };
-use crate::ipc::session::{SessionInfo, remove_session, write_session};
+use crate::ipc::session::{SessionInfo, SessionType, remove_session, write_session};
 use std::sync::mpsc;
 use std::sync::{Mutex, OnceLock};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -42,6 +42,7 @@ pub fn start_server(
     started_at: &str,
     log_file: Option<String>,
     history_session_id: Option<i64>,
+    session_type: SessionType,
 ) -> std::io::Result<SessionInfo> {
     // Acquire the lock once and hold it through check-and-set to avoid TOCTOU.
     let handle_store = SERVER_HANDLE.get_or_init(|| Mutex::new(None));
@@ -216,6 +217,7 @@ pub fn start_server(
         r_version,
         cwd,
         started_at: started_at.to_string(),
+        session_type: Some(session_type),
         log_file,
         history_session_id,
     };

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -33,6 +33,10 @@ pub struct SessionInfo {
     pub r_version: Option<String>,
     pub cwd: String,
     pub started_at: String,
+    /// Whether this session is headless or interactive, or `None` for session
+    /// files written by an older arf that did not record this.
+    #[serde(default)]
+    pub session_type: Option<SessionType>,
     /// Log file path, or `None` if no log file is configured.
     #[serde(default)]
     pub log_file: Option<String>,
@@ -41,6 +45,13 @@ pub struct SessionInfo {
     /// database failed to open.
     #[serde(default)]
     pub history_session_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionType {
+    Headless,
+    Interactive,
 }
 
 /// Return the directory where session files are stored.
@@ -218,5 +229,80 @@ fn is_process_alive(pid: u32) -> bool {
                         .is_some_and(|f| f.trim_matches('"') == pid.to_string())
                 })
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn session_info(session_type: Option<SessionType>) -> SessionInfo {
+        SessionInfo {
+            pid: 12345,
+            socket_path: "/tmp/arf.sock".to_string(),
+            r_version: Some("4.4.1".to_string()),
+            cwd: "/tmp".to_string(),
+            started_at: "2026-01-01T00:00:00+00:00".to_string(),
+            session_type,
+            log_file: None,
+            history_session_id: Some(42),
+        }
+    }
+
+    #[test]
+    fn session_type_serializes_and_round_trips() {
+        let info = session_info(Some(SessionType::Headless));
+        let json = serde_json::to_value(&info).unwrap();
+
+        assert_eq!(json["session_type"], "headless");
+
+        let restored: SessionInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.session_type, Some(SessionType::Headless));
+    }
+
+    #[test]
+    fn legacy_session_without_session_type_deserializes_as_unknown() {
+        let json = r#"
+        {
+            "pid": 12345,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": "4.4.1",
+            "cwd": "/tmp",
+            "started_at": "2026-01-01T00:00:00+00:00"
+        }
+        "#;
+
+        let info: SessionInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.session_type, None);
+    }
+
+    #[test]
+    #[serial]
+    fn clear_session_history_id_preserves_session_type() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let previous_dir = std::env::var_os(ARF_IPC_SESSIONS_DIR);
+        unsafe { std::env::set_var(ARF_IPC_SESSIONS_DIR, temp_dir.path()) };
+
+        let pid = std::process::id();
+        let info = SessionInfo {
+            pid,
+            session_type: Some(SessionType::Interactive),
+            ..session_info(Some(SessionType::Interactive))
+        };
+        write_session(&info).unwrap();
+
+        clear_session_history_id(pid);
+
+        let contents =
+            std::fs::read_to_string(temp_dir.path().join(format!("{pid}.json"))).unwrap();
+        let cleared: SessionInfo = serde_json::from_str(&contents).unwrap();
+        assert_eq!(cleared.history_session_id, None);
+        assert_eq!(cleared.session_type, Some(SessionType::Interactive));
+
+        match previous_dir {
+            Some(value) => unsafe { std::env::set_var(ARF_IPC_SESSIONS_DIR, value) },
+            None => unsafe { std::env::remove_var(ARF_IPC_SESSIONS_DIR) },
+        }
     }
 }

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -281,13 +281,11 @@ mod tests {
     #[serial]
     fn clear_session_history_id_preserves_session_type() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let previous_dir = std::env::var_os(ARF_IPC_SESSIONS_DIR);
-        unsafe { std::env::set_var(ARF_IPC_SESSIONS_DIR, temp_dir.path()) };
+        let _guard = crate::test_utils::lock_env_var(ARF_IPC_SESSIONS_DIR, temp_dir.path());
 
         let pid = std::process::id();
         let info = SessionInfo {
             pid,
-            session_type: Some(SessionType::Interactive),
             ..session_info(Some(SessionType::Interactive))
         };
         write_session(&info).unwrap();
@@ -299,10 +297,5 @@ mod tests {
         let cleared: SessionInfo = serde_json::from_str(&contents).unwrap();
         assert_eq!(cleared.history_session_id, None);
         assert_eq!(cleared.session_type, Some(SessionType::Interactive));
-
-        match previous_dir {
-            Some(value) => unsafe { std::env::set_var(ARF_IPC_SESSIONS_DIR, value) },
-            None => unsafe { std::env::remove_var(ARF_IPC_SESSIONS_DIR) },
-        }
     }
 }

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -376,7 +376,12 @@ fn run() -> Result<()> {
     // fails, `clear_history_session_id()` is called to set it back to `null`.
     // In practice the window is negligibly short (milliseconds).
     if cli.with_ipc {
-        match ipc::start_server(cli.ipc_bind.as_deref(), None, session_id_raw) {
+        match ipc::start_server(
+            cli.ipc_bind.as_deref(),
+            None,
+            session_id_raw,
+            ipc::session::SessionType::Interactive,
+        ) {
             Ok(session) => {
                 log::info!("IPC server started on {}", session.socket_path);
                 if let Some(pid_path) = &cli.ipc_pid_file {

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -244,7 +244,12 @@ pub fn process_meta_command(
         "ipc" => {
             let subcmd = parts.get(1).copied().unwrap_or("status");
             match subcmd {
-                "start" => match crate::ipc::start_server(None, None, history_session_id) {
+                "start" => match crate::ipc::start_server(
+                    None,
+                    None,
+                    history_session_id,
+                    crate::ipc::session::SessionType::Interactive,
+                ) {
                     Ok(session) => {
                         arf_println!("IPC server started: {}", session.socket_path)
                     }

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -3,6 +3,7 @@
 //! This module provides helpers for tests that need to coordinate
 //! access to process-global state like `current_dir`.
 
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
@@ -12,6 +13,9 @@ use std::sync::{Mutex, MutexGuard};
 /// change cwd must hold this lock to avoid interfering with each other
 /// during parallel test execution.
 static CWD_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Process-global mutex for tests that modify environment variables.
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Acquire the cwd lock and save the current directory.
 ///
@@ -53,6 +57,41 @@ impl Drop for CwdGuard {
                     "CwdGuard: failed to restore original working directory {:?}: {}",
                     self.original, err
                 );
+            }
+        }
+    }
+}
+
+/// Set an environment variable while holding a lock and restore its original
+/// value when the returned guard is dropped.
+pub fn lock_env_var(name: &'static str, value: impl AsRef<OsStr>) -> EnvVarGuard {
+    let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let original = std::env::var_os(name);
+    // SAFETY: Tests serialize access to these process-global variables.
+    unsafe { std::env::set_var(name, value) };
+    EnvVarGuard {
+        _lock: lock,
+        name,
+        original,
+    }
+}
+
+/// RAII guard that holds the environment-variable mutex and restores the
+/// original value on drop.
+pub struct EnvVarGuard {
+    _lock: MutexGuard<'static, ()>,
+    name: &'static str,
+    original: Option<OsString>,
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: Tests serialize access to these process-global variables.
+        unsafe {
+            if let Some(value) = &self.original {
+                std::env::set_var(self.name, value);
+            } else {
+                std::env::remove_var(self.name);
             }
         }
     }

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -291,6 +291,7 @@ arf ipc list
 #       "socket_path": "/run/user/1000/arf/12345.sock",
 #       "cwd": "/workspace",
 #       "started_at": "2026-03-22T10:00:00+09:00",
+#       "session_type": "headless",
 #       "log_file": null,
 #       "history_session_id": 1742601600000000000
 #     }
@@ -299,6 +300,12 @@ arf ipc list
 ```
 
 When no sessions are running, returns `{"sessions": []}` (exit 0).
+
+The `session_type` field is `"headless"` for sessions started with
+`arf headless --json` and `"interactive"` for sessions running an interactive
+REPL. A `null` value means the session was created by an older arf that did not
+record its type. Clients must treat `null` as unknown and must not send
+`shutdown` to that session.
 
 ### `arf ipc history` — Query Command History
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -302,7 +302,7 @@ arf ipc list
 When no sessions are running, returns `{"sessions": []}` (exit 0).
 
 The `session_type` field is `"headless"` for sessions started with
-`arf headless --json` and `"interactive"` for sessions running an interactive
+`arf headless` and `"interactive"` for sessions running an interactive
 REPL. A `null` value means the session was created by an older arf that did not
 record its type. Clients must treat `null` as unknown and must not send
 `shutdown` to that session.


### PR DESCRIPTION
## Summary

`arf ipc list` had no way to tell whether a session is headless or an interactive REPL, so clients couldn't distinguish them before acting on a session (e.g. sending `shutdown`). This adds a `session_type` field to session metadata.

- Adds `enum SessionType { Headless, Interactive }` (serde `rename_all = "lowercase"`) and `session_type: Option<SessionType>` on `SessionInfo` in `crates/arf-console/src/ipc/session.rs`.
- `start_server` (`ipc/server.rs`, `ipc/mod.rs`) now takes the session type as a parameter; call sites pass it explicitly: `app/headless.rs` → `Headless`, `main.rs` → `Interactive`, the `:ipc start` meta-command in `repl/meta_command.rs` → `Interactive`.
- Field is named `session_type` rather than `mode` because `mode` is already overloaded elsewhere in this codebase (e.g. the public `editor.mode` config).
- Field is `Option` and defaults to `None` via `#[serde(default)]` so session files written by an older arf (which lack the field) deserialize as "unknown" rather than being misclassified or dropped from the listing.
- Documents the new field in `docs/ipc.md` and the `arf ipc list` CLI long help.
- Adds a CHANGELOG entry.
- Adds tests in `session.rs`: serialization round-trip, legacy JSON without the field deserializing to `None`, and `clear_session_history_id` preserving the field.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p arf-console` (all pass)
- [x] No insta snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
