### PR TITLE
docs(ipc): note that `--timeout` does not cancel the R evaluation

### DIFF
--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -175,10 +175,12 @@ arf ipc eval --pid 12345 'getwd()'
 |-----------|-------------|
 | `<CODE>` | R code to evaluate (required) |
 | `--visible` | Also show output in the session |
-| `--timeout <MS>` | Timeout in milliseconds (default: 300000 = 5 minutes) |
+| `--timeout <MS>` | Timeout in milliseconds (default: 300000 = 5 minutes). This does NOT cancel the R evaluation — long-running code keeps R busy after timeout. |
 | `--pid <PID>` | Target session PID |
 
 **Output format:** JSON object with `stdout` (string), `stderr` (string), `value` (string or null), and `error` (string or null). All four fields are always present. In silent mode (the default), the printed result appears in the `value` field rather than `stdout`. R evaluation errors are included in the `error` field with exit code 0 — they are a normal response, not an IPC failure.
+
+When the timeout fires, the IPC call returns an error, but the R evaluation continues and the session stays busy until it finishes.
 
 Example (silent eval, result captured in `value`):
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -180,7 +180,7 @@ arf ipc eval --pid 12345 'getwd()'
 
 **Output format:** JSON object with `stdout` (string), `stderr` (string), `value` (string or null), and `error` (string or null). All four fields are always present. In silent mode (the default), the printed result appears in the `value` field rather than `stdout`. R evaluation errors are included in the `error` field with exit code 0 — they are a normal response, not an IPC failure.
 
-When the timeout fires, the IPC call returns an error, but the R evaluation continues and the session stays busy until it finishes.
+When the timeout fires, the server reports a JSON-RPC error as structured JSON on stderr and the client exits with code 4; this is not placed in the result object's `error` field, and the R evaluation continues so the session stays busy until it finishes.
 
 Example (silent eval, result captured in `value`):
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -175,12 +175,12 @@ arf ipc eval --pid 12345 'getwd()'
 |-----------|-------------|
 | `<CODE>` | R code to evaluate (required) |
 | `--visible` | Also show output in the session |
-| `--timeout <MS>` | Timeout in milliseconds (default: 300000 = 5 minutes). This does NOT cancel the R evaluation — long-running code keeps R busy after timeout. |
+| `--timeout <MS>` | Timeout in milliseconds for waiting for the response (default: 300000 = 5 minutes). This does NOT cancel the R evaluation — long-running code keeps R busy after timeout. |
 | `--pid <PID>` | Target session PID |
 
 **Output format:** JSON object with `stdout` (string), `stderr` (string), `value` (string or null), and `error` (string or null). All four fields are always present. In silent mode (the default), the printed result appears in the `value` field rather than `stdout`. R evaluation errors are included in the `error` field with exit code 0 — they are a normal response, not an IPC failure.
 
-When the timeout fires, the server reports a JSON-RPC error as structured JSON on stderr and the client exits with code 4; this is not placed in the result object's `error` field, and the R evaluation continues so the session stays busy until it finishes.
+When the timeout fires, the server returns a JSON-RPC error response instead of a result, and the client prints that error as structured JSON on stderr and exits with code 4 — the timeout is therefore not reported in the result object's `error` field. The R evaluation continues, so the session stays busy until it finishes.
 
 Example (silent eval, result captured in `value`):
 


### PR DESCRIPTION
## Summary

Documentation only. Adds the `--timeout` caveat to the `arf ipc eval` parameter table in `docs/ipc.md`: it bounds only how long the IPC call waits for a reply, and does not cancel the running R evaluation. This caveat already existed in the CLI help and the troubleshooting section, but was missing from the parameter table. Also adds a sentence near the output-format description noting the session stays busy after a timeout.

## Test plan

- [x] Docs-only change, reviewed for accuracy against existing CLI help and troubleshooting text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
