### PR TITLE
docs: highlight per-directory R version selection for the next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order (a plain-text `.r-version` file is one option among these). [rv](https://a2-ai.github.io/rv-docs/) pins the version in `rproject.toml`:
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order.
+
+  [rv](https://a2-ai.github.io/rv-docs/) pins the version in `rproject.toml`:
 
   ```toml
   [project]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order:
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look.
+
+  For example, the following configuration looks for two TOML files named `rproject.toml` and `rproj.toml` in the current directory, in order:
 
   ```toml
   [experimental]
@@ -14,21 +16,25 @@
   ]
   ```
 
-  That configuration covers two conventions. [rv](https://a2-ai.github.io/rv-docs/) pins a plain version in `rproject.toml`:
+  The `rproject.toml` file is used by [rv](https://a2-ai.github.io/rv-docs/).
+  Looks like this:
 
   ```toml
   [project]
   r_version = "4.4"
   ```
 
-  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes `rproj.toml`, with a different key and a Cargo-style version range. Both forms are supported:
+  The `rproj.toml` file is a draft proposal from [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31).
+  Differs from `rproject.toml` used by rv, this one supports Cargo-style version ranges as well:
 
   ```toml
   [r]
   version = ">= 4.1.0, < 4.5.0"
   ```
 
-  Neither looks widely adopted enough to hardcode, so a `toml-key` entry takes the filename and key path from you rather than committing arf to either. Only the current directory is searched, and only R versions rig has already installed can be selected.
+  For now, it seems neither of these formats is widely adopted, so arf introduces a generic `toml-key` type that allows us to specify the filename and key path and supports Cargo-style version ranges.
+  Of course, we can also support other TOML files with different names and keys for specifying the R version.
+
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 - `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look.
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default.
+  It is opt-in through `experimental.r_source_overrides` in the `arf.toml` config.
 
   For example, the following configuration looks for two TOML files named `rproject.toml` and `rproj.toml` in the current directory, in order:
 
@@ -16,16 +17,19 @@
   ]
   ```
 
-  The `rproject.toml` file is used by [rv](https://a2-ai.github.io/rv-docs/).
-  Looks like this:
+  If arf finds an R version defined in one of these files, it will select a matching version from the list of versions installed by rig and start that R.
+  If none of them yields a matching version, arf falls back to the R selected by `startup.r_source`.
+
+  The first of the two, `rproject.toml`, is used by [rv](https://a2-ai.github.io/rv-docs/).
+  It looks like this:
 
   ```toml
   [project]
   r_version = "4.4"
   ```
 
-  The `rproj.toml` file is a draft proposal from [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31).
-  Differs from `rproject.toml` used by rv, this one supports Cargo-style version ranges as well:
+  The second, `rproj.toml`, is a draft proposal from [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31).
+  Unlike rv's `rproject.toml`, it also supports Cargo-style version ranges:
 
   ```toml
   [r]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   version = ">= 4.1.0, < 4.5.0"
   ```
 
-  Neither convention has settled yet, so arf does not bet on either — a `toml-key` entry takes the filename and key path from you, and multiple entries can be checked at once, Cargo-style version ranges included:
+  Neither looks widely adopted enough to hardcode, so arf reads both through configuration instead — a `toml-key` entry takes the filename and key path from you, and multiple entries can be checked at once, Cargo-style version ranges included:
 
   ```toml
   [experimental]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@
   r_version = "4.4"
   ```
 
-  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes a different shape in `rproj.toml`:
+  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes `rproj.toml`, with a different key and a Cargo-style version range in place of a plain version. Both forms are supported:
 
   ```toml
   [r]
   version = ">= 4.1.0, < 4.5.0"
   ```
 
-  Neither looks widely adopted enough to hardcode, so arf reads both through configuration instead — a `toml-key` entry takes the filename and key path from you, and multiple entries can be checked at once, Cargo-style version ranges included:
+  Neither looks widely adopted enough to hardcode, so arf reads both through configuration instead: a `toml-key` entry takes the filename and key path from you, and several can be listed at once.
 
   ```toml
   [experimental]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,7 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order.
-
-  [rv](https://a2-ai.github.io/rv-docs/) pins the version in `rproject.toml`:
-
-  ```toml
-  [project]
-  r_version = "4.4"
-  ```
-
-  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes `rproj.toml`, with a different key and a Cargo-style version range in place of a plain version. Both forms are supported:
-
-  ```toml
-  [r]
-  version = ">= 4.1.0, < 4.5.0"
-  ```
-
-  Neither looks widely adopted enough to hardcode, so arf reads both through configuration instead: a `toml-key` entry takes the filename and key path from you, and several can be listed at once.
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order:
 
   ```toml
   [experimental]
@@ -30,7 +14,21 @@
   ]
   ```
 
-  Only the current directory is searched, and only R versions rig has already installed can be selected.
+  That configuration covers two conventions. [rv](https://a2-ai.github.io/rv-docs/) pins a plain version in `rproject.toml`:
+
+  ```toml
+  [project]
+  r_version = "4.4"
+  ```
+
+  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes `rproj.toml`, with a different key and a Cargo-style version range. Both forms are supported:
+
+  ```toml
+  [r]
+  version = ">= 4.1.0, < 4.5.0"
+  ```
+
+  Neither looks widely adopted enough to hardcode, so a `toml-key` entry takes the filename and key path from you rather than committing arf to either. Only the current directory is searched, and only R versions rig has already installed can be selected.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 - `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,31 @@
 
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order. A `version-file` entry reads a plain text file containing just the version — for example, following the same convention as `.python-version` or `.ruby-version`, a file named `.r-version` containing:
-
-  ```
-  4.4
-  ```
-
-  A `toml-key` entry reads a value out of a TOML file — for example rv's `rproject.toml`:
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default. It is opt-in through `experimental.r_source_overrides`, which lists where to look, in priority order (a plain-text `.r-version` file is one option among these). [rv](https://a2-ai.github.io/rv-docs/) pins the version in `rproject.toml`:
 
   ```toml
   [project]
   r_version = "4.4"
   ```
 
-  is read by `{ type = "toml-key", file = "rproject.toml", key = "project.r_version" }`. Only the current directory is searched, and only R versions rig has already installed can be selected.
+  The open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft proposes a different shape in `rproj.toml`:
+
+  ```toml
+  [r]
+  version = ">= 4.1.0, < 4.5.0"
+  ```
+
+  Neither convention has settled yet, so arf does not bet on either — a `toml-key` entry takes the filename and key path from you, and multiple entries can be checked at once, Cargo-style version ranges included:
+
+  ```toml
+  [experimental]
+  r_source_overrides = [
+    { type = "toml-key", file = "rproject.toml", key = "project.r_version" },
+    { type = "toml-key", file = "rproj.toml", key = "r.version" },
+  ]
+  ```
+
+  Only the current directory is searched, and only R versions rig has already installed can be selected.
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 - `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 - Single binary with no runtime dependencies
 - Cross-platform: Linux, macOS, and Windows
-- [rig](https://github.com/r-lib/rig) integration — switch R versions with `--with-r-version` or `:switch` within a session; experimental per-directory selection via `experimental.r_source_overrides`
+- R version selection via [rig](https://github.com/r-lib/rig) (switch within a session, or experimental per-directory auto-switching)
 - Vi and Emacs editing modes
 - Multiline editing with proper indentation
 - Auto-matching brackets and quotes (with smart skip-over)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 - Single binary with no runtime dependencies
 - Cross-platform: Linux, macOS, and Windows
-- [rig](https://github.com/r-lib/rig) integration — switch R versions with `--with-r-version` or `:switch` within a session
+- [rig](https://github.com/r-lib/rig) integration — switch R versions with `--with-r-version` or `:switch` within a session; experimental per-directory selection via `experimental.r_source_overrides`
 - Vi and Emacs editing modes
 - Multiline editing with proper indentation
 - Auto-matching brackets and quotes (with smart skip-over)
@@ -258,6 +258,20 @@ See the full [IPC & Headless Mode Guide](docs/ipc.md) for details.
 ## Experimental Features
 
 Features in this section are under development and may change or be removed in future versions. Configure them under the `[experimental]` table and its subtables (e.g. `[experimental.prompt_spinner]`).
+
+### R Source Overrides
+
+Select an R version per directory or project with `experimental.r_source_overrides`. **Disabled by default.** It can read a `.r-version` file or [rv](https://a2-ai.github.io/rv-docs/)'s `rproject.toml`; only the current directory is searched, and only R versions rig has already installed can be selected.
+
+```toml
+[experimental]
+r_source_overrides = [
+  { type = "version-file", file = ".r-version" },
+  { type = "toml-key", file = "rproject.toml", key = "project.r_version" },
+]
+```
+
+See [R Source Overrides configuration](docs/configuration.md#r-source-overrides) for provider options and resolution details.
 
 ### Spinner
 

--- a/crates/arf-console/src/external/rig.rs
+++ b/crates/arf-console/src/external/rig.rs
@@ -497,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn semver_ranges_select_the_newest_matching_version() {
+    fn version_ranges_select_the_newest_matching_version() {
         let versions = vec![
             rig_version("4.3.9", false, "4.3.9", &[]),
             rig_version("4.4.0", false, "4.4.0", &[]),

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -971,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_meta_command_switch_force_accepts_spaced_semver_range() {
+    fn test_process_meta_command_switch_force_accepts_spaced_version_range() {
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 pub enum VersionSpec {
     /// Numeric components pin the precision supplied by the caller.
     Digits(Vec<u64>),
-    /// A semantic-version requirement.
+    /// A version range requirement.
     Range(VersionReq),
     /// A named version selector that requires caller-specific handling.
     Named(String),
@@ -26,7 +26,7 @@ pub enum VersionSpec {
 pub enum VersionSpecParseError {
     /// The specification is empty.
     Empty,
-    /// The specification is not a valid numeric prefix, name, or semver requirement.
+    /// The specification is not a valid numeric prefix, name, or version range requirement.
     Invalid,
 }
 
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn semver_ranges_are_parsed_and_applied() {
+    fn version_ranges_are_parsed_and_applied() {
         let installed = versions(&["4.3.9", "4.4.0", "4.4.5", "4.5.0", "5.0.0"]);
 
         let caret = VersionSpec::parse("^4.4").unwrap();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -837,7 +837,7 @@ Entries are evaluated in array order, which is the priority order. The first ent
 | `type = "toml-key"` | — | Reads a string version specification from the dot-separated TOML key in the `file` and `key` fields. |
 | `type = "pixi"` | — | Uses the active pixi environment. This provider is not implemented yet and has no additional fields. |
 
-For example, rv stores its R version in `rproject.toml`. This configuration reads the `project.r_version` string and tries to select the matching installed R version:
+For example, [rv](https://a2-ai.github.io/rv-docs/) stores its R version in `rproject.toml`. This configuration reads the `project.r_version` string and tries to select the matching installed R version:
 
 ```toml
 [experimental]

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -55,10 +55,11 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 {
   "pid": 12345,
   "socket_path": "/run/user/1000/arf/12345.sock",
-  "r_version": "4.4.1",
+  "r_version": "4.4.2",
   "cwd": "/workspace",
   "started_at": "2026-03-22T10:00:00+09:00",
   "log_file": null,
+  "history_session_id": null,
   "r_source_override": {
     "state": "applied",
     "provider": "toml-key",
@@ -71,7 +72,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version` and `log_file` may be `null`. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `log_file`, and `history_session_id` may be `null`. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
 
 Output is pretty-printed when stdout is a terminal, compact when piped. This is useful in CI scripts:
 


### PR DESCRIPTION
Per-directory R version selection (`experimental.r_source_overrides`) is a headline feature of the next release, but it was documented only in `docs/configuration.md`, so it was hard to discover.

## README

Advertise the feature in the feature list next to the existing rig integration, and add an "R Source Overrides" subsection under Experimental Features, following the pattern of the other experimental subsections (short description, config snippet, link to the configuration guide).

The rig entry in the feature list is also shortened. It had grown to name both `--with-r-version` and `:switch`, making it far longer than every other line; the meta command table and the configuration guide already cover the specifics.

## CHANGELOG

Restructure the `r_source_overrides` entry to lead with the configuration itself — a snippet reading two TOML files — followed by what arf does with what it finds: select a matching version from those rig has installed, or fall back to the R selected by `startup.r_source` when no override yields a match.

The two files in that snippet are the two conventions the feature has to serve: rv's `rproject.toml` and the `rproj.toml` from the open [Tidyup 9](https://github.com/tidyverse/tidyups/pull/31) draft. Showing both files, and a configuration that reads either, explains why `toml-key` takes the filename and key path from the user: neither format is widely adopted yet, so hardcoding either one would serve only part of the audience.

Two claims here were verified rather than assumed. That the draft `rproj.toml` is readable today: `VersionSpec::parse(">= 4.1.0, < 4.5.0")` succeeds and, against installed 4.0.5 / 4.1.0 / 4.4.2 / 4.5.0, resolves to 4.4.2. And the fallback target: when no override matches, resolution falls through to `startup.r_source`, which is not necessarily the default installation — it is whatever that setting names.

## `docs/ipc.md`

The headless `--json` example paired `"state": "applied"` with `r_version` 4.4.1 and `resolved_version` 4.4.2. When an override is applied arf starts the resolved version, so the two normally agree; showing them differing suggested a contradiction. (They do come from different sources — `r_version` from the loaded R process, `resolved_version` from rig metadata — so they can diverge if rig's recorded version is stale, but that edge case is not what the example should illustrate.)

The example was also missing `history_session_id`, and the prose below it did not list that key among the nullable ones even though the `HeadlessInfo` doc comment does.

## Version range naming

The SemVer specification does not define range or comparator syntax; operators such as `^`, `~`, `>=` and comma-separated compound constraints are a convention popularised by Cargo and npm, and R version numbers are not SemVer versions to begin with. `docs/configuration.md` already said this correctly, but three test names and two `VersionSpec` doc comments called them "semver ranges". Renamed. References to the `semver` crate's own types are untouched. No behavior change.

Also link rv's documentation site on first mention in each file, so readers know what rv is.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test -p arf-console` — passes with the renamed tests
- [x] Field names, order, and nullability in the `docs/ipc.md` example checked against `HeadlessInfo` / `HeadlessRSourceOverride`
- [x] `docs/configuration.md#r-source-overrides` anchor confirmed to resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

