### PR TITLE
refactor: extract JSON output helpers into a shared module

### DIFF
--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -9,6 +9,7 @@ use crate::cli::RArgsBuilder;
 use crate::config;
 use crate::ipc;
 use crate::ipc::session::{SessionInfo, SessionType};
+use crate::output::write_json;
 use crate::pid_file::{
     absolute_pid_file_path, cleanup_ipc_pid_file, register_ipc_pid_file_atexit, write_pid_file,
 };
@@ -258,19 +259,15 @@ pub(crate) fn run_headless(
     if json {
         // Output session info as JSON to stdout
         let output = HeadlessInfo::from_session(&session, warnings, &resolution);
-        let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
-        let json_str = if is_tty {
-            serde_json::to_string_pretty(&output)
-        } else {
-            serde_json::to_string(&output)
-        }
-        .context("Failed to serialize session info")?;
         // Use writeln + flush instead of println to ensure the JSON is
         // delivered immediately when stdout is piped (non-TTY). This is the
         // readiness signal for CI scripts waiting on the output.
         use std::io::Write;
+        let pretty = std::io::IsTerminal::is_terminal(&std::io::stdout());
         let mut stdout = std::io::stdout().lock();
-        writeln!(stdout, "{json_str}").context("Failed to write session info to stdout")?;
+        write_json(&mut stdout, &output, pretty)
+            .context("Failed to write session info to stdout")?;
+        writeln!(stdout).context("Failed to write session info to stdout")?;
         stdout
             .flush()
             .context("Failed to flush session info to stdout")?;

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -267,7 +267,7 @@ pub(crate) fn run_headless(
         let mut stdout = std::io::stdout().lock();
         write_json(&mut stdout, &output, pretty)
             .context("Failed to write session info to stdout")?;
-        writeln!(stdout).context("Failed to write session info to stdout")?;
+        writeln!(stdout).context("Failed to write session info newline to stdout")?;
         stdout
             .flush()
             .context("Failed to flush session info to stdout")?;

--- a/crates/arf-console/src/ipc/client.rs
+++ b/crates/arf-console/src/ipc/client.rs
@@ -8,6 +8,7 @@
 
 use crate::ipc::protocol::JsonRpcResponse;
 use crate::ipc::session::{find_session, list_sessions};
+use crate::output::{self, write_json};
 use anyhow::{Context, Result};
 
 /// Default transport timeout for client-side socket reads (5 minutes).
@@ -31,21 +32,16 @@ const EXIT_PROTOCOL: i32 = 4;
 
 // ── Output helpers ───────────────────────────────────────────────────
 
-/// Serialize a JSON value to a string, using pretty-printing when the
-/// given stream is a terminal.
-fn format_json(value: &serde_json::Value, is_tty: bool) -> String {
-    if is_tty {
-        serde_json::to_string_pretty(value).expect("format_json: serialization failed")
-    } else {
-        serde_json::to_string(value).expect("format_json: serialization failed")
+fn print_json_or_exit(value: &serde_json::Value) {
+    if let Err(error) = output::print_json(value) {
+        exit_error(
+            EXIT_CLIENT,
+            "OUTPUT_ERROR",
+            &format!("Failed to write JSON output: {error:#}"),
+            None,
+            None,
+        );
     }
-}
-
-/// Print a JSON value to stdout. Pretty-prints when stdout is a
-/// terminal, compact when piped.
-fn print_json(value: &serde_json::Value) {
-    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
-    println!("{}", format_json(value, is_tty));
 }
 
 /// Print a structured error to stderr as JSON and exit with the given code.
@@ -77,8 +73,17 @@ fn exit_error(
             "data": data,
         }
     });
-    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
-    eprintln!("{}", format_json(&error, is_tty));
+    let pretty = std::io::IsTerminal::is_terminal(&std::io::stderr());
+    let write_result = {
+        let mut stderr = std::io::stderr().lock();
+        write_json(&mut stderr, &error, pretty).and_then(|_| {
+            use std::io::Write;
+            writeln!(stderr).context("Failed to write JSON newline")
+        })
+    };
+    if let Err(write_error) = write_result {
+        eprintln!("Error writing JSON error: {write_error:#}");
+    }
     std::process::exit(exit_code);
 }
 
@@ -146,7 +151,7 @@ fn handle_response(response: JsonRpcResponse) {
     }
 
     match response.result {
-        Some(result) => print_json(&result),
+        Some(result) => print_json_or_exit(&result),
         None => {
             // JSON-RPC 2.0 requires exactly one of `result` or `error` to be
             // present. Reaching here indicates a server-side bug.
@@ -183,7 +188,7 @@ pub fn cmd_list() {
         })
         .collect();
 
-    print_json(&serde_json::json!({ "sessions": sessions_json }));
+    print_json_or_exit(&serde_json::json!({ "sessions": sessions_json }));
 }
 
 /// Resolve a session or exit with a structured JSON error.

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -12,6 +12,7 @@ mod highlighter;
 mod history;
 mod ipc;
 mod logging;
+mod output;
 mod pager;
 mod pid_file;
 pub(crate) mod r_parser;

--- a/crates/arf-console/src/output.rs
+++ b/crates/arf-console/src/output.rs
@@ -1,0 +1,68 @@
+//! JSON output helpers: pretty-print to terminals and compact output to pipes.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::io::Write;
+
+/// Write JSON to `writer`, using pretty-printing when `pretty` is true.
+///
+/// This function does not flush the writer; flushing remains the caller's
+/// responsibility.
+pub(crate) fn write_json<T, W>(writer: &mut W, value: &T, pretty: bool) -> Result<()>
+where
+    T: Serialize + ?Sized,
+    W: Write + ?Sized,
+{
+    let json = if pretty {
+        serde_json::to_string_pretty(value).context("Failed to serialize JSON")?
+    } else {
+        serde_json::to_string(value).context("Failed to serialize JSON")?
+    };
+
+    writer
+        .write_all(json.as_bytes())
+        .context("Failed to write JSON")?;
+    Ok(())
+}
+
+/// Print JSON to stdout, selecting pretty or compact output based on whether
+/// stdout is a terminal. Writes a trailing newline but does not flush stdout;
+/// flushing remains the caller's responsibility.
+pub(crate) fn print_json<T>(value: &T) -> Result<()>
+where
+    T: Serialize + ?Sized,
+{
+    let pretty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    let mut stdout = std::io::stdout().lock();
+    write_json(&mut stdout, value, pretty)?;
+    writeln!(stdout).context("Failed to write JSON newline")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_json;
+    use serde_json::Value;
+
+    #[test]
+    fn compact_json_is_single_line_and_valid() {
+        let value = serde_json::json!({"name": "arf", "items": [1, 2, 3]});
+        let mut output = Vec::new();
+
+        write_json(&mut output, &value, false).unwrap();
+
+        assert!(!output.contains(&b'\n'));
+        assert!(serde_json::from_slice::<Value>(&output).is_ok());
+    }
+
+    #[test]
+    fn pretty_json_is_multiple_lines_and_valid() {
+        let value = serde_json::json!({"name": "arf", "items": [1, 2, 3]});
+        let mut output = Vec::new();
+
+        write_json(&mut output, &value, true).unwrap();
+
+        assert!(output.contains(&b'\n'));
+        assert!(serde_json::from_slice::<Value>(&output).is_ok());
+    }
+}

--- a/crates/arf-console/src/output.rs
+++ b/crates/arf-console/src/output.rs
@@ -32,8 +32,9 @@ pub(crate) fn print_json<T>(value: &T) -> Result<()>
 where
     T: Serialize + ?Sized,
 {
-    let pretty = std::io::IsTerminal::is_terminal(&std::io::stdout());
-    let mut stdout = std::io::stdout().lock();
+    let stdout = std::io::stdout();
+    let pretty = std::io::IsTerminal::is_terminal(&stdout);
+    let mut stdout = stdout.lock();
     write_json(&mut stdout, value, pretty)?;
     writeln!(stdout).context("Failed to write JSON newline")?;
     Ok(())


### PR DESCRIPTION
The logic that picks pretty-printed JSON for terminals and compact JSON for pipes was duplicated between the IPC client and the headless entry point. This moves it into a new `output` module exposing `write_json` and `print_json`.

`write_json` is generic over the writer so both stdout and stderr can use it, and so the formatting can be unit tested without a terminal. Flushing stays with the caller: `arf headless --json` flushes immediately because its output is the readiness signal CI scripts wait on, and folding that into the helper would mix process lifecycle concerns into formatting.

Serialization errors now propagate as `anyhow::Result` instead of panicking. The IPC client turns them into a structured `OUTPUT_ERROR` response, which also means a broken pipe no longer panics the way `println!` did.

No user-visible change to the JSON that either command already emitted.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1057 passed, 0 failed)
- [x] New unit tests in `output.rs` cover compact and pretty output

🤖 Generated with [Claude Code](https://claude.com/claude-code)