### PR TITLE
test: make the R-not-found resolve test deterministic

### DIFF
--- a/crates/arf-console/src/app/setup/r_source.rs
+++ b/crates/arf-console/src/app/setup/r_source.rs
@@ -419,11 +419,19 @@ pub(super) fn resolve_path_r_home_for_report_with<F>(
 
     match resolve_path_r_home_with(find_r_library) {
         Ok(r_home) => report.r_home = Some(r_home),
-        Err(error) => report.diagnostics.push(warning(
-            "r_discovery.failed",
-            format!("Warning: Failed to determine R_HOME from PATH: {error}"),
-            None,
-        )),
+        Err(error) => {
+            // When discovery is disabled the root cause already says so. The
+            // surrounding context mentions a PATH search that never ran, so
+            // report only the cause to avoid misdirecting the user.
+            let message = if arf_libr::is_r_auto_discovery_disabled() {
+                format!("Warning: {}", error.root_cause())
+            } else {
+                format!("Warning: Failed to determine R_HOME from PATH: {error}")
+            };
+            report
+                .diagnostics
+                .push(warning("r_discovery.failed", message, None));
+        }
     }
 }
 

--- a/crates/arf-console/src/app/setup/r_source.rs
+++ b/crates/arf-console/src/app/setup/r_source.rs
@@ -420,13 +420,21 @@ pub(super) fn resolve_path_r_home_for_report_with<F>(
     match resolve_path_r_home_with(find_r_library) {
         Ok(r_home) => report.r_home = Some(r_home),
         Err(error) => {
-            // When discovery is disabled the root cause already says so. The
-            // surrounding context mentions a PATH search that never ran, so
-            // report only the cause to avoid misdirecting the user.
-            let message = if arf_libr::is_r_auto_discovery_disabled() {
-                format!("Warning: {}", error.root_cause())
-            } else {
-                format!("Warning: Failed to determine R_HOME from PATH: {error}")
+            // When discovery is disabled the cause already explains itself, so
+            // report it alone: the surrounding context describes a PATH search
+            // that never ran. Take the payload rather than the `RError`
+            // display, whose "not found at:" wording would read as a path.
+            let disabled_message = arf_libr::is_r_auto_discovery_disabled()
+                .then(
+                    || match error.root_cause().downcast_ref::<arf_libr::RError>() {
+                        Some(arf_libr::RError::LibraryNotFound(message)) => Some(message.clone()),
+                        _ => None,
+                    },
+                )
+                .flatten();
+            let message = match disabled_message {
+                Some(cause) => format!("Warning: {cause}"),
+                None => format!("Warning: Failed to determine R_HOME from PATH: {error}"),
             };
             report
                 .diagnostics

--- a/crates/arf-console/src/cli/shared.rs
+++ b/crates/arf-console/src/cli/shared.rs
@@ -53,6 +53,13 @@ pub struct RSourceArgs {
     /// Config: [experimental].r_source_overrides
     #[arg(long = "no-r-source-overrides")]
     pub no_r_source_overrides: bool,
+
+    /// Test-support flag for reproducing a machine with no R installed
+    ///
+    /// Integration tests spawn the real binary as a child process, so no in-process injection
+    /// point works. Using this normally breaks the fidelity of `arf r resolve`, so it is hidden.
+    #[arg(long = "no-r-auto-discovery", hide = true)]
+    pub no_r_auto_discovery: bool,
 }
 
 /// R-compatible flags that let `arf` act as a drop-in replacement for the `R` binary for vscode-R

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -65,6 +65,15 @@ fn run() -> Result<()> {
     let matches = command.clone().get_matches();
     validate_top_level_scope(&command, &matches);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    let no_r_auto_discovery = match &cli.command {
+        Some(Commands::Headless(args)) => args.r_source.no_r_auto_discovery,
+        Some(Commands::R(args)) => {
+            let RCommand::Resolve(resolve_args) = &args.command;
+            resolve_args.r_source.no_r_auto_discovery
+        }
+        _ => cli.r_source.no_r_auto_discovery,
+    };
+    arf_libr::set_r_auto_discovery_disabled(no_r_auto_discovery);
 
     // Reject combinations of -f/--file or -e/--eval with a subcommand.
     // clap cannot enforce this via conflicts_with because subcommand fields are

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_bash.snap
@@ -201,7 +201,7 @@ _arf() {
 
     case "${cmd}" in
         arf)
-            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --r-home --with-r-version --no-r-source-overrides --no-banner --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --quiet --no-save --save --no-restore --no-restore-data --restore-data --interactive --no-echo --slave --restore --verbose --encoding --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --ipc-bind --ipc-pid-file --no-auto-match --no-completion --history-dir --no-history --help --version completions config history ipc headless r help"
+            opts="-e -f -c -q -d -g -h -V --eval --file --reprex --auto-format --config --r-home --with-r-version --no-r-source-overrides --no-r-auto-discovery --no-banner --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --quiet --no-save --save --no-restore --no-restore-data --restore-data --interactive --no-echo --slave --restore --verbose --encoding --debugger --debugger-args --gui --arch --args --no-readline --no-restore-history --with-ipc --ipc-bind --ipc-pid-file --no-auto-match --no-completion --history-dir --no-history --help --version completions config history ipc headless r help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -517,7 +517,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__headless)
-            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --ipc-bind --ipc-pid-file --quiet --json --log-file --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --history-dir --no-history --help"
+            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --no-r-auto-discovery --ipc-bind --ipc-pid-file --quiet --json --log-file --vanilla --no-environ --no-site-file --no-init-file --max-connections --max-ppsize --min-nsize --min-vsize --history-dir --no-history --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1406,7 +1406,7 @@ _arf() {
             return 0
             ;;
         arf__subcmd__r__subcmd__resolve)
-            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --help"
+            opts="-c -h --config --r-home --with-r-version --no-r-source-overrides --no-r-auto-discovery --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
@@ -4,7 +4,7 @@ expression: completions
 ---
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_arf_global_optspecs
-    string join \n e/eval= f/file= reprex auto-format c/config= r-home= with-r-version= no-r-source-overrides no-banner vanilla no-environ no-site-file no-init-file max-connections= max-ppsize= min-nsize= min-vsize= q/quiet no-save save no-restore no-restore-data restore-data interactive no-echo slave restore verbose encoding= d/debugger= debugger-args= g/gui= arch= args no-readline no-restore-history with-ipc ipc-bind= ipc-pid-file= no-auto-match no-completion history-dir= no-history h/help V/version
+    string join \n e/eval= f/file= reprex auto-format c/config= r-home= with-r-version= no-r-source-overrides no-r-auto-discovery no-banner vanilla no-environ no-site-file no-init-file max-connections= max-ppsize= min-nsize= min-vsize= q/quiet no-save save no-restore no-restore-data restore-data interactive no-echo slave restore verbose encoding= d/debugger= debugger-args= g/gui= arch= args no-readline no-restore-history with-ipc ipc-bind= ipc-pid-file= no-auto-match no-completion history-dir= no-history h/help V/version
 end
 
 function __fish_arf_needs_command
@@ -48,6 +48,7 @@ complete -c arf -n "__fish_arf_needs_command" -l history-dir -d 'Custom history 
 complete -c arf -n "__fish_arf_needs_command" -l reprex -d 'Enable reprex mode (no prompt, output prefixed with #>)'
 complete -c arf -n "__fish_arf_needs_command" -l auto-format -d 'Enable auto-formatting of R code in reprex mode (requires Air CLI)'
 complete -c arf -n "__fish_arf_needs_command" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
+complete -c arf -n "__fish_arf_needs_command" -l no-r-auto-discovery -d 'Test-support flag for reproducing a machine with no R installed'
 complete -c arf -n "__fish_arf_needs_command" -l no-banner -d 'Suppress the startup banner'
 complete -c arf -n "__fish_arf_needs_command" -l vanilla -d 'Start R in vanilla mode (no init files, no save/restore)'
 complete -c arf -n "__fish_arf_needs_command" -l no-environ -d '[R] Don\'t read the site and user environment files'
@@ -162,6 +163,7 @@ complete -c arf -n "__fish_arf_using_subcommand headless" -l min-nsize -d '[R] S
 complete -c arf -n "__fish_arf_using_subcommand headless" -l min-vsize -d '[R] Set vector heap minimum to N bytes; \'4M\' = 4 MegaB' -r
 complete -c arf -n "__fish_arf_using_subcommand headless" -l history-dir -d 'Custom history directory (overrides default XDG location)' -r -f -a "(__fish_complete_directories)"
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
+complete -c arf -n "__fish_arf_using_subcommand headless" -l no-r-auto-discovery -d 'Test-support flag for reproducing a machine with no R installed'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l quiet -d 'Suppress status messages on stderr (IPC path, ready, shutdown)'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l json -d 'Print session info as JSON to stdout when ready'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l vanilla -d 'Start R in vanilla mode (no init files, no save/restore)'
@@ -177,6 +179,7 @@ complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_fr
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from resolve" -l r-home -d 'Highest-priority R source: use this explicit R_HOME path' -r -f -a "(__fish_complete_directories)"
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from resolve" -l with-r-version -d 'Highest-priority R source: use this R version via rig' -r
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from resolve" -l no-r-source-overrides -d 'Disable experimental directory-level R source overrides'
+complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from resolve" -l no-r-auto-discovery -d 'Test-support flag for reproducing a machine with no R installed'
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from resolve" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from help" -f -a "resolve" -d 'Resolve the R installation arf would use without starting R'
 complete -c arf -n "__fish_arf_using_subcommand r; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
@@ -50,6 +50,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--reprex', '--reprex', [CompletionResultType]::ParameterName, 'Enable reprex mode (no prompt, output prefixed with #>)')
             [CompletionResult]::new('--auto-format', '--auto-format', [CompletionResultType]::ParameterName, 'Enable auto-formatting of R code in reprex mode (requires Air CLI)')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
+            [CompletionResult]::new('--no-r-auto-discovery', '--no-r-auto-discovery', [CompletionResultType]::ParameterName, 'Test-support flag for reproducing a machine with no R installed')
             [CompletionResult]::new('--no-banner', '--no-banner', [CompletionResultType]::ParameterName, 'Suppress the startup banner')
             [CompletionResult]::new('--vanilla', '--vanilla', [CompletionResultType]::ParameterName, 'Start R in vanilla mode (no init files, no save/restore)')
             [CompletionResult]::new('--no-environ', '--no-environ', [CompletionResultType]::ParameterName, '[R] Don''t read the site and user environment files')
@@ -282,6 +283,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--min-vsize', '--min-vsize', [CompletionResultType]::ParameterName, '[R] Set vector heap minimum to N bytes; ''4M'' = 4 MegaB')
             [CompletionResult]::new('--history-dir', '--history-dir', [CompletionResultType]::ParameterName, 'Custom history directory (overrides default XDG location)')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
+            [CompletionResult]::new('--no-r-auto-discovery', '--no-r-auto-discovery', [CompletionResultType]::ParameterName, 'Test-support flag for reproducing a machine with no R installed')
             [CompletionResult]::new('--quiet', '--quiet', [CompletionResultType]::ParameterName, 'Suppress status messages on stderr (IPC path, ready, shutdown)')
             [CompletionResult]::new('--json', '--json', [CompletionResultType]::ParameterName, 'Print session info as JSON to stdout when ready')
             [CompletionResult]::new('--vanilla', '--vanilla', [CompletionResultType]::ParameterName, 'Start R in vanilla mode (no init files, no save/restore)')
@@ -306,6 +308,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--r-home', '--r-home', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this explicit R_HOME path')
             [CompletionResult]::new('--with-r-version', '--with-r-version', [CompletionResultType]::ParameterName, 'Highest-priority R source: use this R version via rig')
             [CompletionResult]::new('--no-r-source-overrides', '--no-r-source-overrides', [CompletionResultType]::ParameterName, 'Disable experimental directory-level R source overrides')
+            [CompletionResult]::new('--no-r-auto-discovery', '--no-r-auto-discovery', [CompletionResultType]::ParameterName, 'Test-support flag for reproducing a machine with no R installed')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -44,6 +44,7 @@ _arf() {
 '--reprex[Enable reprex mode (no prompt, output prefixed with #>)]' \
 '--auto-format[Enable auto-formatting of R code in reprex mode (requires Air CLI)]' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
+'--no-r-auto-discovery[Test-support flag for reproducing a machine with no R installed]' \
 '--no-banner[Suppress the startup banner]' \
 '--vanilla[Start R in vanilla mode (no init files, no save/restore)]' \
 '--no-environ[\[R\] Don'\''t read the site and user environment files]' \
@@ -358,6 +359,7 @@ _arguments "${_arguments_options[@]}" : \
 '--min-vsize=[\[R\] Set vector heap minimum to N bytes; '\''4M'\'' = 4 MegaB]:MIN_VSIZE:_default' \
 '--history-dir=[Custom history directory (overrides default XDG location)]:HISTORY_DIR:_files -/' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
+'--no-r-auto-discovery[Test-support flag for reproducing a machine with no R installed]' \
 '--quiet[Suppress status messages on stderr (IPC path, ready, shutdown)]' \
 '--json[Print session info as JSON to stdout when ready]' \
 '--vanilla[Start R in vanilla mode (no init files, no save/restore)]' \
@@ -390,6 +392,7 @@ _arguments "${_arguments_options[@]}" : \
 '(--with-r-version)--r-home=[Highest-priority R source\: use this explicit R_HOME path]:R_HOME:_files -/' \
 '(--r-home)--with-r-version=[Highest-priority R source\: use this R version via rig]:R_VERSION:_default' \
 '--no-r-source-overrides[Disable experimental directory-level R source overrides]' \
+'--no-r-auto-discovery[Test-support flag for reproducing a machine with no R installed]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 struct RLessEnvironment {
     _temp: tempfile::TempDir,
     bin_dir: PathBuf,
+    home_dir: PathBuf,
     fake_r_home: PathBuf,
 }
 
@@ -91,6 +92,8 @@ impl RLessEnvironment {
         let temp = tempfile::tempdir().unwrap();
         let bin_dir = temp.path().join("bin");
         std::fs::create_dir(&bin_dir).unwrap();
+        let home_dir = temp.path().join("home");
+        std::fs::create_dir(&home_dir).unwrap();
         let fake_r_home = {
             let fake_r_home = temp.path().join("fake-r-home");
             let fake_r_library = arf_libr::r_library_path(&fake_r_home);
@@ -118,10 +121,22 @@ exit 1
         Self {
             _temp: temp,
             bin_dir,
+            home_dir,
             fake_r_home,
         }
     }
 
+    /// Build a command that sees neither an R installation nor the developer's
+    /// own configuration.
+    ///
+    /// Pointing `HOME` at an empty directory and clearing the XDG variables
+    /// isolates the global `arf.toml`, which `dirs::config_dir()` resolves from
+    /// `$XDG_CONFIG_HOME` or `$HOME` depending on the platform. Without this, a
+    /// developer or CI image that configures `startup.r_source` would resolve an
+    /// R installation and make these tests environment-dependent. The
+    /// configuration cannot be isolated with `--config` here, because arf
+    /// rejects that flag when it appears before a subcommand and this helper
+    /// does not know which subcommand the caller will add.
     fn command(&self) -> Command {
         let mut command = Command::new(env!("CARGO_BIN_EXE_arf"));
         #[cfg(unix)]
@@ -132,6 +147,10 @@ exit 1
             .env_remove("R_HOME")
             .env_remove("ARF_R_HOME")
             .env_remove("ARF_R_VERSION")
+            .env_remove("XDG_CONFIG_HOME")
+            .env_remove("XDG_DATA_HOME")
+            .env_remove("XDG_CACHE_HOME")
+            .env("HOME", &self.home_dir)
             .env("PATH", std::env::join_paths(path_entries).unwrap());
         command
     }
@@ -486,7 +505,12 @@ fn resolve_not_found_is_successful_false_descriptor() {
     let environment = RLessEnvironment::new();
     let output = environment
         .command()
-        .args(["r", "resolve", "--no-r-auto-discovery"])
+        .args([
+            "r",
+            "resolve",
+            "--no-r-auto-discovery",
+            "--no-r-source-overrides",
+        ])
         .output()
         .unwrap();
 

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -486,25 +486,45 @@ fn resolve_not_found_is_successful_false_descriptor() {
     let environment = RLessEnvironment::new();
     let output = environment
         .command()
-        .args(["r", "resolve", "--no-r-source-overrides"])
+        .args(["r", "resolve", "--no-r-auto-discovery"])
         .output()
         .unwrap();
 
     assert!(output.status.success(), "stderr: {:?}", output.stderr);
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    if value["resolved"] != false {
-        // This test silently no-ops (skips verification) when R is found in the environment.
-        // The root cause is that R_LIB_PATHS in crates/arf-libr/src/sys/discovery.rs is a
-        // hardcoded constant with no injection point; restricting PATH does not prevent it
-        // from being picked up. Integration tests spawn the real binary as a child process,
-        // so Rust closure-based dependency injection cannot help here. Making this deterministic
-        // requires a production-code mechanism to disable the default path search.
-        eprintln!("skipping unresolved discovery assertion because a built-in R was found");
-        return;
-    }
     assert_eq!(value["resolved"], false);
     assert!(value["target"].is_null());
-    assert!(value["diagnostics"].is_array());
+    assert!(
+        value["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| {
+                diagnostic["code"] == "r_discovery.failed"
+                    && diagnostic["message"]
+                        .as_str()
+                        .unwrap()
+                        .contains("R automatic discovery is disabled")
+            })
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn resolve_explicit_r_home_still_works_with_no_r_auto_discovery() {
+    let environment = RLessEnvironment::new();
+    let output = environment
+        .command()
+        .args(["r", "resolve", "--no-r-auto-discovery", "--r-home"])
+        .arg(&environment.fake_r_home)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["resolved"], true);
+    assert_descriptor_path(&value, &value["target"]["r_home"], &environment.fake_r_home);
+    assert_eq!(value["selected_by"]["kind"], "r_home");
 }
 
 #[test]

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -518,18 +518,18 @@ fn resolve_not_found_is_successful_false_descriptor() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["resolved"], false);
     assert!(value["target"].is_null());
-    assert!(
-        value["diagnostics"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|diagnostic| {
-                diagnostic["code"] == "r_discovery.failed"
-                    && diagnostic["message"]
-                        .as_str()
-                        .unwrap()
-                        .contains("R automatic discovery is disabled")
-            })
+    let diagnostic = value["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|diagnostic| diagnostic["code"] == "r_discovery.failed")
+        .expect("expected an r_discovery.failed diagnostic");
+    // Snapshot the whole message rather than checking a substring, which still
+    // passes when the message is wrapped in text describing a different
+    // failure, such as a missing path or a PATH search that never ran.
+    insta::assert_snapshot!(
+        diagnostic["message"].as_str().unwrap(),
+        @"R automatic discovery is disabled. Set R_HOME, pass --r-home, or remove --no-r-auto-discovery."
     );
 }
 

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -31,11 +31,11 @@ pub use sys::ensure_ld_library_path_with_pre_exec;
 pub use sys::{
     clear_r_interrupt_pending, clear_write_console_callback, command_had_error,
     ensure_ld_library_path, find_r_library, finish_ipc_capture, flush_reprex_buffer, get_r_home,
-    global_error_handler_code, initialize_r, initialize_r_with_args, is_r_awaiting_console_input,
-    is_r_interrupt_flag_available, is_spinner_active, mark_error_condition,
-    mark_global_error_handler_initialized, process_r_events, r_home_from_library_path,
-    r_library_path, reset_command_error_state, restore_stderr, run_r_mainloop,
-    set_r_interrupt_pending, set_read_console_callback, set_reprex_mode, set_spinner_color,
-    set_spinner_frames, set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner,
-    suppress_stderr,
+    global_error_handler_code, initialize_r, initialize_r_with_args, is_r_auto_discovery_disabled,
+    is_r_awaiting_console_input, is_r_interrupt_flag_available, is_spinner_active,
+    mark_error_condition, mark_global_error_handler_initialized, process_r_events,
+    r_home_from_library_path, r_library_path, reset_command_error_state, restore_stderr,
+    run_r_mainloop, set_r_auto_discovery_disabled, set_r_interrupt_pending,
+    set_read_console_callback, set_reprex_mode, set_spinner_color, set_spinner_frames,
+    set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
 };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -13,7 +13,8 @@ pub use askpass::askpass_handler_code;
 #[cfg(unix)]
 pub use discovery::ensure_ld_library_path_with_pre_exec;
 pub use discovery::{
-    ensure_ld_library_path, find_r_library, get_r_home, r_home_from_library_path, r_library_path,
+    ensure_ld_library_path, find_r_library, get_r_home, is_r_auto_discovery_disabled,
+    r_home_from_library_path, r_library_path, set_r_auto_discovery_disabled,
 };
 pub use error_state::{
     command_had_error, global_error_handler_code, mark_error_condition,

--- a/crates/arf-libr/src/sys/discovery.rs
+++ b/crates/arf-libr/src/sys/discovery.rs
@@ -2,6 +2,19 @@ use crate::error::{RError, RResult};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static R_AUTO_DISCOVERY_DISABLED: AtomicBool = AtomicBool::new(false);
+
+/// Set whether automatic R discovery is disabled for this process.
+pub fn set_r_auto_discovery_disabled(disabled: bool) {
+    R_AUTO_DISCOVERY_DISABLED.store(disabled, Ordering::Relaxed);
+}
+
+/// Return whether automatic R discovery is disabled for this process.
+pub fn is_r_auto_discovery_disabled() -> bool {
+    R_AUTO_DISCOVERY_DISABLED.load(Ordering::Relaxed)
+}
 
 /// Default R library paths by platform.
 #[cfg(target_os = "linux")]
@@ -55,6 +68,10 @@ pub fn find_r_library() -> RResult<PathBuf> {
         }
     }
 
+    if is_r_auto_discovery_disabled() {
+        return Err(RError::LibraryNotFound(no_r_auto_discovery_message()));
+    }
+
     // Try to get R_HOME from R itself
     #[cfg(unix)]
     let r_cmd = "R";
@@ -82,6 +99,11 @@ pub fn find_r_library() -> RResult<PathBuf> {
     Err(RError::LibraryNotFound(
         "Could not find R library. Please set R_HOME or ensure R is in PATH.".to_string(),
     ))
+}
+
+fn no_r_auto_discovery_message() -> String {
+    "R automatic discovery is disabled. Set R_HOME, pass --r-home, or remove --no-r-auto-discovery."
+        .to_string()
 }
 
 /// Get the R library filename for the current platform.
@@ -124,6 +146,10 @@ pub fn get_r_home() -> RResult<PathBuf> {
     // Check environment variable first
     if let Ok(r_home) = env::var("R_HOME") {
         return Ok(PathBuf::from(r_home));
+    }
+
+    if is_r_auto_discovery_disabled() {
+        return Err(RError::LibraryNotFound(no_r_auto_discovery_message()));
     }
 
     // Try to get from R command


### PR DESCRIPTION
`resolve_not_found_is_successful_false_descriptor` verified nothing on any machine with R installed. It printed a message and returned early whenever discovery succeeded, so the contract that `arf r resolve` exits 0 with `resolved: false` when no R exists was never checked.

R discovery searches `R_HOME`, then `R RHOME` from `PATH`, then a hardcoded list of default library paths. That list has no injection point, and integration tests spawn the real binary, so the closure-based dependency injection already in the codebase cannot reach it.

This adds a hidden `--no-r-auto-discovery` flag that disables the two automatic stages, the `R RHOME` probe and the compiled-in defaults, while leaving `R_HOME`, `--r-home`, and `--with-r-version` selection untouched. The CLI sets a process-global in `arf-libr` right after parsing. No environment variable is used: the flag survives the Unix re-exec because `ensure_ld_library_path` rebuilds argv from `env::args_os()`. An environment variable would let a parent process or shell rc file disable discovery silently, leaving interactive mode to start with R evaluation unavailable.

The flag is hidden and undocumented on purpose. Explicit selection already short-circuits discovery, so the flag only changes behavior when nothing was selected, and using it would make `arf r resolve` report an R that plain `arf` would not use.

Reporting a failed `PATH` search is misleading when no search ran, so the diagnostic now names the disabled discovery.

The second commit fixes a separate way the same test depended on its environment. The helper cleared the R environment variables and restricted `PATH` but left the global `arf.toml` in place, so a machine configuring `startup.r_source` would resolve an R installation. `HOME` now points at an empty directory with the XDG variables cleared, covering both paths `dirs::config_dir()` resolves. It is done in the helper rather than in one test, so the next test to use it does not inherit the problem. `--config` cannot serve here, because `arf` rejects it before a subcommand and the helper does not know what the caller will append.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test` (1081 passed, 0 failed)
- [x] Making the process-global setter a no-op fails the test with `resolved: true`; restoring it passes
- [x] With a hostile `XDG_CONFIG_HOME` setting `startup.r_source`, removing the isolation fails the test the same way
- [x] An explicit `--r-home` still resolves while the flag is set
- [x] The flag is absent from `--help` for the top-level command, `headless`, and `r resolve`

A known limitation: `clap_complete` does not filter hidden arguments, so the flag still appears in the generated completion scripts for all four shells. There is no public API to remove an argument from a `clap::Command`, and upstream deprioritized filtering for the static generators. It is tracked as follow-up work alongside the existing TODO about migrating to dynamic completions, which resolves it as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
