### PR TITLE
fix: report a null `provider` when no R was resolved, and snapshot the descriptor

### DIFF
--- a/crates/arf-console/src/app/config_load.rs
+++ b/crates/arf-console/src/app/config_load.rs
@@ -150,7 +150,7 @@ pub(crate) fn load_config_collecting_diagnostics(
                 code,
                 message: format!(
                     "Failed to load config from {}: {}. Using default configuration.",
-                    mask_home_path(&path),
+                    path.display(),
                     message
                 ),
                 path,

--- a/crates/arf-console/src/app/resolve.rs
+++ b/crates/arf-console/src/app/resolve.rs
@@ -83,7 +83,7 @@ struct ResolveDescriptor {
     target: Option<Target>,
     resolver: Resolver,
     selected_by: SelectedBy,
-    provider: String,
+    provider: Option<String>,
     diagnostics: Vec<Diagnostic>,
 }
 
@@ -254,6 +254,7 @@ fn descriptor(
             resolved_version: resolved_version(resolution),
         }
     });
+    let resolved = target.is_some();
 
     let selected_by = selected_by(
         cwd,
@@ -271,7 +272,7 @@ fn descriptor(
 
     ResolveDescriptor {
         schema_version: 1,
-        resolved: target.is_some(),
+        resolved,
         cwd: cwd.display().to_string(),
         target,
         resolver: Resolver {
@@ -279,7 +280,7 @@ fn descriptor(
             version: env!("CARGO_PKG_VERSION"),
         },
         selected_by,
-        provider: provider(&resolution.status),
+        provider: resolved.then(|| provider(&resolution.status)),
         diagnostics,
     }
 }

--- a/crates/arf-console/src/app/setup/r_source.rs
+++ b/crates/arf-console/src/app/setup/r_source.rs
@@ -2,7 +2,9 @@
 
 use super::overrides::{OverrideResolution, setup_r_via_overrides};
 use super::rig::{ResolvedRSource, resolve_r_home_from_path, setup_r_via_rig};
-use crate::config::{RSource, RSourceMode, RSourceOverride, RSourceOverrideInfo, RSourceStatus};
+use crate::config::{
+    RSource, RSourceMode, RSourceOverride, RSourceOverrideInfo, RSourceStatus, mask_home_path,
+};
 use crate::external;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -127,7 +129,7 @@ impl RSourceResolutionReport {
         let block = self
             .diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.message.as_str())
+            .map(display_message)
             .collect::<Vec<_>>()
             .join("\n");
         eprintln!("{block}");
@@ -143,6 +145,15 @@ impl RSourceResolutionReport {
             resolved_version: self.resolved_version.clone()?,
         })
     }
+}
+
+fn display_message(diagnostic: &RSourceDiagnostic) -> String {
+    let Some(path) = diagnostic.path.as_ref() else {
+        return diagnostic.message.clone();
+    };
+
+    let raw_path = path.display().to_string();
+    diagnostic.message.replace(&raw_path, &mask_home_path(path))
 }
 
 /// Resolve R and return a report without changing the process environment.
@@ -446,6 +457,42 @@ pub(super) fn resolve_path_r_home_for_report_with<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn display_message_masks_its_own_path_and_leaves_pathless_messages_unchanged() {
+        let home = dirs::home_dir().expect("test requires a home directory");
+        let path = home.join("arf").join("broken.toml");
+        let diagnostic = RSourceDiagnostic {
+            code: "config.parse_failed",
+            severity: "warning",
+            message: format!(
+                r#"Failed to load config from {}: TOML parse error"#,
+                path.display()
+            ),
+            path: Some(path.clone()),
+        };
+        let pathless = RSourceDiagnostic {
+            code: "r_discovery.failed",
+            severity: "warning",
+            message: r#"R automatic discovery failed."#.to_owned(),
+            path: None,
+        };
+
+        // Assert the masking took effect rather than comparing against
+        // `mask_home_path` again, which would also pass if it stopped masking.
+        let masked = display_message(&diagnostic);
+        assert!(
+            masked.starts_with("Failed to load config from ~"),
+            "{masked}"
+        );
+        assert!(!masked.contains(&home.display().to_string()), "{masked}");
+        assert!(
+            masked.ends_with("broken.toml: TOML parse error"),
+            "{masked}"
+        );
+
+        assert_eq!(display_message(&pathless), pathless.message);
+    }
 
     #[test]
     fn explicit_rig_mode_reports_command_failure_without_install_guidance() {

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -196,6 +196,10 @@ fn resolve_found_emits_descriptor_with_target() {
         temp.path(),
     );
     assert!(value["diagnostics"].as_array().unwrap().is_empty());
+    insta::assert_snapshot!(
+        "resolve_found_emits_descriptor_with_target",
+        normalize_descriptor(&value)
+    );
 }
 
 #[test]
@@ -343,6 +347,10 @@ r_version = "4.4.2"
     );
     assert_eq!(value["selected_by"]["source"]["format"], "toml");
     assert_eq!(value["selected_by"]["source"]["key"], "project.r_version");
+    insta::assert_snapshot!(
+        "resolve_project_file_version_request_reports_toml_source",
+        normalize_descriptor(&value)
+    );
 }
 
 #[test]
@@ -384,6 +392,10 @@ r_source = { path = "fallback-r-home" }
     );
     assert_eq!(value["selected_by"]["source"]["format"], "text");
     assert!(value["selected_by"]["source"]["key"].is_null());
+    insta::assert_snapshot!(
+        "resolve_project_file_version_request_reports_text_source",
+        normalize_descriptor(&value)
+    );
 }
 
 /// Project configuration is a hint that may fall back, while an explicit
@@ -471,6 +483,10 @@ fn resolve_environment_version_reports_environment_source() {
         "environment_variable"
     );
     assert_eq!(value["selected_by"]["source"]["name"], "ARF_R_VERSION");
+    insta::assert_snapshot!(
+        "resolve_environment_version_reports_environment_source",
+        normalize_descriptor(&value)
+    );
 }
 
 #[test]
@@ -497,6 +513,10 @@ fn resolve_without_config_reports_built_in_default_source() {
     assert!(value["selected_by"]["source"]["path"].is_null());
     assert!(value["selected_by"]["source"]["format"].is_null());
     assert!(value["selected_by"]["source"]["key"].is_null());
+    insta::assert_snapshot!(
+        "resolve_without_config_reports_built_in_default_source",
+        normalize_descriptor(&value)
+    );
 }
 
 #[test]
@@ -532,6 +552,10 @@ fn resolve_not_found_is_successful_false_descriptor() {
     insta::assert_snapshot!(
         diagnostic["message"].as_str().unwrap(),
         @"R automatic discovery is disabled. Set R_HOME, pass --r-home, or remove --no-r-auto-discovery."
+    );
+    insta::assert_snapshot!(
+        "resolve_not_found_is_successful_false_descriptor",
+        normalize_descriptor(&value)
     );
 }
 
@@ -581,6 +605,10 @@ fn resolve_broken_config_falls_back_with_diagnostic() {
             .unwrap()
             .iter()
             .any(|diagnostic| diagnostic["code"] == "config.parse_failed")
+    );
+    insta::assert_snapshot!(
+        "resolve_broken_config_falls_back_with_diagnostic",
+        normalize_descriptor(&value)
     );
 }
 
@@ -677,6 +705,10 @@ fn resolve_rig_alias_is_accepted_before_version_spec_validation() {
         "command_line_argument"
     );
     assert_eq!(value["selected_by"]["source"]["name"], "--with-r-version");
+    insta::assert_snapshot!(
+        "resolve_rig_alias_is_accepted_before_version_spec_validation",
+        normalize_descriptor(&value)
+    );
 }
 
 #[test]
@@ -795,6 +827,83 @@ fn assert_selected_by_nullable_fields_are_present(value: &serde_json::Value) {
             source.contains_key(field),
             "missing selected_by.source.{field}"
         );
+    }
+}
+
+fn normalize_descriptor(value: &serde_json::Value) -> String {
+    let mut normalized = value.clone();
+    let descriptor = normalized.as_object_mut().unwrap();
+
+    replace_non_null(descriptor.get_mut("cwd"), "<cwd>");
+    if let Some(resolver) = descriptor
+        .get_mut("resolver")
+        .and_then(|resolver| resolver.as_object_mut())
+    {
+        replace_non_null(resolver.get_mut("version"), "<arf-version>");
+    }
+
+    if let Some(target) = descriptor
+        .get_mut("target")
+        .and_then(|target| target.as_object_mut())
+    {
+        replace_non_null(target.get_mut("r_home"), "<r-home>");
+        replace_non_null(target.get_mut("r_binary"), "<r-binary>");
+        // The fake rig fixture used by every snapshot with a resolved version
+        // always reports 4.4.2, so retaining that value pins the fixture's
+        // deterministic version selection.
+    }
+
+    if let Some(selected_by) = descriptor
+        .get_mut("selected_by")
+        .and_then(|selected_by| selected_by.as_object_mut())
+    {
+        replace_non_null(
+            selected_by.get_mut("requested_r_home"),
+            "<requested-r-home>",
+        );
+        if let Some(source) = selected_by
+            .get_mut("source")
+            .and_then(|source| source.as_object_mut())
+        {
+            replace_non_null(source.get_mut("path"), "<source-path>");
+        }
+    }
+
+    if let Some(diagnostics) = descriptor
+        .get_mut("diagnostics")
+        .and_then(|diagnostics| diagnostics.as_array_mut())
+    {
+        let absolute_path_regex =
+            regex::Regex::new(r#"(?i)(?:[a-z]:[\\/][^\s,;!?\"']+|/(?:[^/\s]+/)+[^/\s,:;!?\"']+)"#)
+                .unwrap();
+        for diagnostic in diagnostics {
+            if let Some(diagnostic) = diagnostic.as_object_mut() {
+                replace_non_null(diagnostic.get_mut("path"), "<diagnostic-path>");
+                let message = diagnostic
+                    .get_mut("message")
+                    .and_then(|message| message.as_str())
+                    .map(str::to_owned);
+                if let Some(message) = message {
+                    let normalized_message = absolute_path_regex
+                        .replace_all(&message, "<path>")
+                        .into_owned();
+                    diagnostic.insert(
+                        "message".to_owned(),
+                        serde_json::Value::String(normalized_message),
+                    );
+                }
+            }
+        }
+    }
+
+    serde_json::to_string_pretty(&normalized).unwrap()
+}
+
+fn replace_non_null(value: Option<&mut serde_json::Value>, placeholder: &str) {
+    if let Some(value) = value
+        && !value.is_null()
+    {
+        *value = serde_json::Value::String(placeholder.to_owned());
     }
 }
 

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -873,30 +873,64 @@ fn normalize_descriptor(value: &serde_json::Value) -> String {
         .get_mut("diagnostics")
         .and_then(|diagnostics| diagnostics.as_array_mut())
     {
-        let absolute_path_regex =
-            regex::Regex::new(r#"(?i)(?:[a-z]:[\\/][^\s,;!?\"']+|/(?:[^/\s]+/)+[^/\s,:;!?\"']+)"#)
-                .unwrap();
         for diagnostic in diagnostics {
             if let Some(diagnostic) = diagnostic.as_object_mut() {
-                replace_non_null(diagnostic.get_mut("path"), "<diagnostic-path>");
+                // A message that names a path names the diagnostic's own path,
+                // so substitute that exact string. Recognizing paths by their
+                // syntax instead cannot be made reliable: a pattern that ends a
+                // Windows path at the wrong character produces a snapshot that
+                // differs from the one committed on Unix, and drive letters,
+                // `~`, UNC prefixes and spaces in paths each break it
+                // differently.
+                let path = diagnostic
+                    .get("path")
+                    .and_then(|path| path.as_str())
+                    .map(str::to_owned);
                 let message = diagnostic
-                    .get_mut("message")
+                    .get("message")
                     .and_then(|message| message.as_str())
                     .map(str::to_owned);
-                if let Some(message) = message {
-                    let normalized_message = absolute_path_regex
-                        .replace_all(&message, "<path>")
-                        .into_owned();
+                if let (Some(path), Some(message)) = (path.as_deref(), message) {
                     diagnostic.insert(
                         "message".to_owned(),
-                        serde_json::Value::String(normalized_message),
+                        serde_json::Value::String(message.replace(path, "<path>")),
                     );
                 }
+                replace_non_null(diagnostic.get_mut("path"), "<diagnostic-path>");
             }
         }
     }
 
     serde_json::to_string_pretty(&normalized).unwrap()
+}
+
+/// The descriptor snapshots are shared across platforms, so normalizing a
+/// diagnostic must not depend on how the platform spells a path. Windows CI is
+/// the only place a regression here would surface, so exercise the shapes it
+/// produces directly.
+#[test]
+fn normalize_descriptor_handles_paths_from_any_platform() {
+    for path in [
+        r"/tmp/.tmpABC/broken.toml",
+        r"C:\Users\runner\AppData\Local\Temp\.tmpABC\broken.toml",
+        r"\\server\share\broken.toml",
+        r"C:\Program Files\arf config\broken.toml",
+    ] {
+        let value = serde_json::json!({
+            "diagnostics": [{
+                "code": "config.parse_failed",
+                "severity": "warning",
+                "message": format!("Failed to load config from {path}: TOML parse error"),
+                "path": path,
+            }],
+        });
+        let normalized = normalize_descriptor(&value);
+        assert!(
+            normalized.contains(r"<path>: TOML parse error"),
+            "path {path} normalized to: {normalized}"
+        );
+        assert!(!normalized.contains("broken.toml"), "leaked {path}");
+    }
 }
 
 fn replace_non_null(value: Option<&mut serde_json::Value>, placeholder: &str) {

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -518,6 +518,8 @@ fn resolve_not_found_is_successful_false_descriptor() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["resolved"], false);
     assert!(value["target"].is_null());
+    assert!(value.as_object().unwrap().contains_key("provider"));
+    assert!(value["provider"].is_null());
     let diagnostic = value["diagnostics"]
         .as_array()
         .unwrap()
@@ -548,6 +550,7 @@ fn resolve_explicit_r_home_still_works_with_no_r_auto_discovery() {
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["resolved"], true);
     assert_descriptor_path(&value, &value["target"]["r_home"], &environment.fake_r_home);
+    assert_eq!(value["provider"], "explicit_path");
     assert_eq!(value["selected_by"]["kind"], "r_home");
 }
 

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -931,6 +931,34 @@ fn normalize_descriptor_handles_paths_from_any_platform() {
         );
         assert!(!normalized.contains("broken.toml"), "leaked {path}");
     }
+
+    let absolute_path = r"C:\Users\runner\AppData\Local\Temp\.tmpABC\broken.toml";
+    let home_relative_path = r"~\AppData\Local\Temp\.tmpABC\broken.toml";
+    let value = serde_json::json!({
+        "diagnostics": [{
+            "code": "config.parse_failed",
+            "severity": "warning",
+            "message": format!("Failed to load config from {home_relative_path}: TOML parse error"),
+            "path": absolute_path,
+        }],
+    });
+    // Normalization can only substitute a spelling it is given, so it depends on
+    // the producer using the same one in both fields. Pin that dependency: when
+    // they disagree, the message keeps a path the snapshot cannot absorb, and the
+    // snapshot turns platform-specific. This is why a diagnostic is built with
+    // the raw path and masked only when rendered for a person. Windows is where
+    // divergence would show, because its temporary directories sit under the
+    // user profile and Unix ones do not.
+    let normalized: serde_json::Value =
+        serde_json::from_str(&normalize_descriptor(&value)).unwrap();
+    assert_eq!(
+        normalized["diagnostics"][0]["message"],
+        serde_json::Value::String(format!(
+            "Failed to load config from {home_relative_path}: TOML parse error"
+        )),
+        "expected the mismatched spelling to survive, so this test keeps \
+         documenting why the two fields must agree"
+    );
 }
 
 fn replace_non_null(value: Option<&mut serde_json::Value>, placeholder: &str) {

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_broken_config_falls_back_with_diagnostic.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_broken_config_falls_back_with_diagnostic.snap
@@ -1,0 +1,39 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [
+    {
+      "code": "config.parse_failed",
+      "message": "Failed to load config from <path>: TOML parse error at line 1, column 5\n  |\n1 | not valid = [toml\n  |     ^\nkey with no value, expected `=`\n. Using default configuration.",
+      "path": "<diagnostic-path>",
+      "severity": "warning"
+    }
+  ],
+  "provider": "explicit_path",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "r_home",
+    "requested_r_home": "<requested-r-home>",
+    "requested_version": null,
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "command_line_argument",
+      "name": "--r-home",
+      "path": null
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": null
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_environment_version_reports_environment_source.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_environment_version_reports_environment_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "version_request",
+    "requested_r_home": null,
+    "requested_version": "4.4.2",
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "environment_variable",
+      "name": "ARF_R_VERSION",
+      "path": null
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_found_emits_descriptor_with_target.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_found_emits_descriptor_with_target.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "explicit_path",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "r_home",
+    "requested_r_home": "<requested-r-home>",
+    "requested_version": null,
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "command_line_argument",
+      "name": "--r-home",
+      "path": null
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": null
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_not_found_is_successful_false_descriptor.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_not_found_is_successful_false_descriptor.snap
@@ -1,0 +1,35 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [
+    {
+      "code": "r_discovery.failed",
+      "message": "R automatic discovery is disabled. Set R_HOME, pass --r-home, or remove --no-r-auto-discovery.",
+      "path": null,
+      "severity": "warning"
+    }
+  ],
+  "provider": null,
+  "resolved": false,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "default",
+    "requested_r_home": null,
+    "requested_version": null,
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "built_in_default",
+      "name": null,
+      "path": null
+    }
+  },
+  "target": null
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_text_source.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_text_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "version_request",
+    "requested_r_home": null,
+    "requested_version": "4.4.2",
+    "source": {
+      "format": "text",
+      "key": null,
+      "kind": "project_file",
+      "name": null,
+      "path": "<source-path>"
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_toml_source.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_toml_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "version_request",
+    "requested_r_home": null,
+    "requested_version": "4.4.2",
+    "source": {
+      "format": "toml",
+      "key": "project.r_version",
+      "kind": "project_file",
+      "name": null,
+      "path": "<source-path>"
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_rig_alias_is_accepted_before_version_spec_validation.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_rig_alias_is_accepted_before_version_spec_validation.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "version_request",
+    "requested_r_home": null,
+    "requested_version": "my-proj",
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "command_line_argument",
+      "name": "--with-r-version",
+      "path": null
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_without_config_reports_built_in_default_source.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_without_config_reports_built_in_default_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "default",
+    "requested_r_home": null,
+    "requested_version": null,
+    "source": {
+      "format": null,
+      "key": null,
+      "kind": "built_in_default",
+      "name": null,
+      "path": null
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/docs/r-resolve.md
+++ b/docs/r-resolve.md
@@ -47,9 +47,9 @@ arf r resolve
 
 ## JSON Descriptor
 
-Every key is always present. A value is `null` when it does not apply, so consumers can rely on the key set being stable. `resolved` is `false` and `target` is `null` exactly when no R installation could be found. That is not an error: the command still exits 0, because normal arf startup also continues in that state with R evaluation unavailable.
+Every key is always present. A value is `null` when it does not apply, so consumers can rely on the key set being stable. `resolved` is `false`, and `target` and `provider` are `null`, exactly when no R installation could be found. That is not an error: the command still exits 0, because normal arf startup also continues in that state with R evaluation unavailable.
 
-`resolver` names the tool that produced the descriptor, so resolution could later move behind a separate tool without breaking readers. `provider` identifies the mechanism that located the installation; current values are `rig`, `path`, and `explicit_path`. `resolved_version` is deliberately not called `r_version`: it is a prediction made before R starts, unlike the versions reported from a running session by the IPC layer. See [IPC session information](ipc.md#arf-ipc-session--get-session-info) for those runtime values.
+`resolver` names the tool that produced the descriptor, so resolution could later move behind a separate tool without breaking readers. `provider` identifies the mechanism that located the installation and is `null` when nothing was located; current values are `rig`, `path`, and `explicit_path`. `resolved_version` is deliberately not called `r_version`: it is a prediction made before R starts, unlike the versions reported from a running session by the IPC layer. See [IPC session information](ipc.md#arf-ipc-session--get-session-info) for those runtime values.
 
 ### `selected_by` and `source`
 


### PR DESCRIPTION
`arf r resolve` emitted a non-null `provider` even when `resolved` was `false` and `target` was `null`, which is wrong because `provider` names where the installation was located, and it broke the descriptor's contract that every key is present and null when it does not apply. It is now derived from the same condition that decides `resolved`, so the two cannot drift apart.

Nothing verified that contract mechanically. Per-field assertions say nothing about the fields they do not name, so a missing or extra key goes unnoticed; one omitted key was only caught by reading a diff. The descriptor is now snapshotted for the eight shapes it can take, alongside the existing assertions rather than in place of them: the assertions prove the wiring, the snapshots pin the shape.

Machine-dependent values are normalized in the test rather than through insta's redaction feature. Normalization replaces only non-null values, so a null still reads as null, preserving the distinction the contract depends on.

Two rounds of review then found the same class of problem in how a diagnostic's path was handled, both only reproducible on Windows CI:

A pattern that located paths inside a diagnostic message was asymmetric, letting a drive-letter path run past the message's trailing colon. Recognizing paths by shape is unreliable, so the pattern is gone: a message that names a path now substitutes the diagnostic's own path string directly.

The message and the `path` field also disagreed: the message spelled the path with `~` while `path` held the absolute one, so on Windows, where temporary directories sit under the user profile, substitution found nothing. A client also could not correlate the two fields, and `~` is unresolvable for a client that does not know whose home it refers to. The message is now built with the raw path, and masking moved to the human-facing renderer. Terminal output is unchanged.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test` (all suites pass, 0 failed)
- [x] Restoring the unconditional `provider` fails the unresolved test
- [x] Adding a field to the descriptor fails the snapshots; omitting an always-present key fails them too, verified with the field assertion removed so the snapshot alone had to catch it
- [x] The old path pattern fails the new cross-platform normalization test on its drive-letter case
- [x] Disabling home masking fails the renderer's unit test
- [x] `arf r resolve` against a broken config under the home directory returns the raw path in JSON while the terminal warning shows the masked one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
