### PR TITLE
feat: report `R_HOME` from the IPC interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
 - `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 - `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.
+- `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown.
 - **Experimental:** `arf r resolve` lets external tools such as editors learn which R arf would use without starting R. It always emits JSON on success.
 
 ### Changed

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -158,11 +158,14 @@ pub(crate) fn run_headless(
     let r_args = r_args_builder.build();
     let r_args_refs: Vec<&str> = r_args.iter().map(|s| s.as_str()).collect();
 
-    // Initialize R
+    // Initialize R. Note the directory beforehand: profiles run inside
+    // initialization on Unix and may call setwd(), which would move the base a
+    // relative R_HOME has to be resolved against.
+    let pre_init_dir = std::env::current_dir().ok();
     unsafe {
         arf_libr::initialize_r_with_args(&r_args_refs).context("Failed to initialize R")?;
     }
-    let r_home = crate::capture_runtime_r_home();
+    let r_home = crate::capture_runtime_r_home(pre_init_dir.as_deref());
 
     // Source R profile files (Windows only)
     #[cfg(windows)]

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 /// JSON output for `arf headless --json`.
 ///
 /// Contains session connection info and any warnings collected during startup.
-/// All keys are always present in the JSON output; `r_version`, `log_file`,
+/// All keys are always present in the JSON output; `r_version`, `r_home`, `log_file`,
 /// and `history_session_id` may be `null`. `warnings` is an array that may be
 /// empty.
 #[derive(Debug, Serialize)]
@@ -27,6 +27,7 @@ struct HeadlessInfo {
     pid: u32,
     socket_path: String,
     r_version: Option<String>,
+    r_home: Option<String>,
     cwd: String,
     started_at: String,
     log_file: Option<String>,
@@ -78,6 +79,7 @@ impl HeadlessInfo {
             pid: session.pid,
             socket_path: session.socket_path.clone(),
             r_version,
+            r_home: session.r_home.clone(),
             cwd: session.cwd.clone(),
             started_at: session.started_at.clone(),
             log_file: session.log_file.clone(),
@@ -226,8 +228,18 @@ pub(crate) fn run_headless(
             .display()
             .to_string()
     });
-    let session = ipc::start_server(bind, log_file_str, session_id_raw, SessionType::Headless)
-        .context("Failed to start IPC server")?;
+    let r_home_str = resolution
+        .r_home
+        .as_ref()
+        .map(|path| path.display().to_string());
+    let session = ipc::start_server(
+        bind,
+        r_home_str,
+        log_file_str,
+        session_id_raw,
+        SessionType::Headless,
+    )
+    .context("Failed to start IPC server")?;
     if !quiet {
         eprintln!("IPC server listening on: {}", session.socket_path);
     }
@@ -431,6 +443,29 @@ mod tests {
             assert!(value.get("requested_version").is_some());
             assert!(value.get("resolved_version").is_some());
         }
+    }
+
+    #[test]
+    fn headless_json_includes_r_home_from_session() {
+        let session = SessionInfo {
+            pid: 12345,
+            socket_path: "/tmp/arf.sock".to_string(),
+            r_version: Some("4.4.1".to_string()),
+            r_home: Some("/opt/R/4.4.1/lib/R".to_string()),
+            cwd: "/tmp".to_string(),
+            started_at: "2026-01-01T00:00:00+00:00".to_string(),
+            session_type: Some(SessionType::Headless),
+            log_file: None,
+            history_session_id: None,
+        };
+
+        let output = HeadlessInfo::from_session(
+            &session,
+            Vec::new(),
+            &report(RSourceOverrideState::NotConfigured),
+        );
+        let json = serde_json::to_value(output).unwrap();
+        assert_eq!(json["r_home"], "/opt/R/4.4.1/lib/R");
     }
 
     #[test]

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -162,6 +162,7 @@ pub(crate) fn run_headless(
     unsafe {
         arf_libr::initialize_r_with_args(&r_args_refs).context("Failed to initialize R")?;
     }
+    let r_home = crate::capture_runtime_r_home();
 
     // Source R profile files (Windows only)
     #[cfg(windows)]
@@ -228,10 +229,7 @@ pub(crate) fn run_headless(
             .display()
             .to_string()
     });
-    let r_home_str = resolution
-        .r_home
-        .as_ref()
-        .map(|path| path.display().to_string());
+    let r_home_str = r_home.map(|path| path.display().to_string());
     let session = ipc::start_server(
         bind,
         r_home_str,
@@ -447,7 +445,7 @@ mod tests {
 
     #[test]
     fn headless_json_includes_r_home_from_session() {
-        let session = SessionInfo {
+        let mut session = SessionInfo {
             pid: 12345,
             socket_path: "/tmp/arf.sock".to_string(),
             r_version: Some("4.4.1".to_string()),
@@ -466,6 +464,15 @@ mod tests {
         );
         let json = serde_json::to_value(output).unwrap();
         assert_eq!(json["r_home"], "/opt/R/4.4.1/lib/R");
+
+        session.r_home = None;
+        let output = HeadlessInfo::from_session(
+            &session,
+            Vec::new(),
+            &report(RSourceOverrideState::NotConfigured),
+        );
+        let json = serde_json::to_value(output).unwrap();
+        assert!(json["r_home"].is_null());
     }
 
     #[test]

--- a/crates/arf-console/src/cli/ipc.rs
+++ b/crates/arf-console/src/cli/ipc.rs
@@ -11,8 +11,8 @@ pub(crate) enum IpcAction {
     /// List active arf sessions as JSON
     ///
     /// Returns a JSON object with a `sessions` array. Each entry contains
-    /// pid, r_version, socket_path, cwd, started_at, session_type, log_file,
-    /// and history_session_id.
+    /// pid, r_version, r_home, socket_path, cwd, started_at, session_type,
+    /// log_file, and history_session_id.
     /// Returns `{"sessions": []}` when no sessions are running (exit 0).
     #[command(after_long_help = "\
 Examples:

--- a/crates/arf-console/src/ipc/mod.rs
+++ b/crates/arf-console/src/ipc/mod.rs
@@ -142,6 +142,7 @@ pub fn break_signal() -> Arc<AtomicBool> {
 /// default PID-based path.
 pub fn start_server(
     bind: Option<&str>,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
     session_type: session::SessionType,
@@ -162,6 +163,7 @@ pub fn start_server(
         tx,
         bind,
         &started_at,
+        r_home,
         log_file,
         history_session_id,
         session_type,
@@ -589,6 +591,7 @@ fn arf_session_base(meta: &SessionMeta) -> SessionResult {
         pid: std::process::id(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
+        r_home: meta.r_home.clone(),
         socket_path: meta.socket_path.clone(),
         started_at: meta.started_at.clone(),
         log_file: meta.log_file.clone(),
@@ -605,6 +608,7 @@ fn arf_session_base(meta: &SessionMeta) -> SessionResult {
 struct SessionMeta {
     socket_path: String,
     started_at: String,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
 }
@@ -809,12 +813,14 @@ fn save_to_headless_history(code: &str, exit_status: Option<i64>) {
 pub(in crate::ipc) fn set_session_meta(
     socket_path: String,
     started_at: String,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
 ) {
     let meta = SessionMeta {
         socket_path,
         started_at,
+        r_home,
         log_file,
         history_session_id,
     };
@@ -837,6 +843,7 @@ fn current_session_meta() -> SessionMeta {
         None => SessionMeta {
             socket_path: "<uninitialized_socket_path>".to_string(),
             started_at: "<uninitialized_started_at>".to_string(),
+            r_home: None,
             log_file: None,
             history_session_id: None,
         },

--- a/crates/arf-console/src/ipc/protocol.rs
+++ b/crates/arf-console/src/ipc/protocol.rs
@@ -141,6 +141,8 @@ pub struct SessionResult {
     pub pid: u32,
     pub os: String,
     pub arch: String,
+    /// R installation path selected by arf at startup, or `null` if no R was resolved.
+    pub r_home: Option<String>,
     pub socket_path: String,
     pub started_at: String,
     /// Log file path, or `null` if no log file is configured and output is sent to stderr.

--- a/crates/arf-console/src/ipc/server.rs
+++ b/crates/arf-console/src/ipc/server.rs
@@ -40,6 +40,7 @@ pub fn start_server(
     tx: mpsc::Sender<IpcRequest>,
     bind: Option<&str>,
     started_at: &str,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
     session_type: SessionType,
@@ -128,6 +129,7 @@ pub fn start_server(
 
     let path = socket_path.clone();
     let started_at_owned = started_at.to_string();
+    let r_home_clone = r_home.clone();
     let log_file_clone = log_file.clone();
     let history_session_id_clone = history_session_id;
     let cancel_token = CancellationToken::new();
@@ -149,6 +151,7 @@ pub fn start_server(
                 if let Err(e) = run_server(
                     &path,
                     &started_at_owned,
+                    r_home_clone,
                     log_file_clone,
                     history_session_id_clone,
                     tx,
@@ -215,6 +218,7 @@ pub fn start_server(
         pid,
         socket_path: socket_path.clone(),
         r_version,
+        r_home,
         cwd,
         started_at: started_at.to_string(),
         session_type: Some(session_type),
@@ -411,9 +415,11 @@ fn select_socket_dir(pid: u32, candidates: &[std::path::PathBuf]) -> Option<(Str
 
 /// Run the actual server loop.
 #[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
 async fn run_server(
     socket_path: &str,
     started_at: &str,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
     tx: mpsc::Sender<IpcRequest>,
@@ -447,6 +453,7 @@ async fn run_server(
             super::set_session_meta(
                 socket_path.to_string(),
                 started_at.to_string(),
+                r_home,
                 log_file,
                 history_session_id,
             );
@@ -490,9 +497,11 @@ async fn run_server(
 }
 
 #[cfg(windows)]
+#[allow(clippy::too_many_arguments)]
 async fn run_server(
     socket_path: &str,
     started_at: &str,
+    r_home: Option<String>,
     log_file: Option<String>,
     history_session_id: Option<i64>,
     tx: mpsc::Sender<IpcRequest>,
@@ -512,6 +521,7 @@ async fn run_server(
             super::set_session_meta(
                 socket_path.to_string(),
                 started_at.to_string(),
+                r_home,
                 log_file,
                 history_session_id,
             );

--- a/crates/arf-console/src/ipc/server/tests.rs
+++ b/crates/arf-console/src/ipc/server/tests.rs
@@ -166,6 +166,7 @@ fn test_session_result_includes_log_file() {
     super::super::set_session_meta(
         "/tmp/test.sock".to_string(),
         "2026-01-01T00:00:00+00:00".to_string(),
+        Some("/opt/R/4.4.1/lib/R".to_string()),
         Some("/tmp/arf.log".to_string()),
         None,
     );
@@ -176,6 +177,7 @@ fn test_session_result_includes_log_file() {
     super::super::set_session_meta(
         "/tmp/test.sock".to_string(),
         "2026-01-01T00:00:00+00:00".to_string(),
+        None,
         None,
         None,
     );
@@ -194,6 +196,39 @@ fn test_session_result_includes_log_file() {
     );
 }
 
+/// Tests that `r_home` in `SessionResult` reflects what was passed to
+/// `set_session_meta`.
+#[test]
+#[serial_test::serial]
+fn test_session_result_includes_r_home() {
+    super::super::set_session_meta(
+        "/tmp/test.sock".to_string(),
+        "2026-01-01T00:00:00+00:00".to_string(),
+        Some("/opt/R/4.4.1/lib/R".to_string()),
+        None,
+        None,
+    );
+    let result = super::super::collect_session_result(false, "test");
+    assert_eq!(result.r_home.as_deref(), Some("/opt/R/4.4.1/lib/R"));
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert_eq!(json["r_home"], "/opt/R/4.4.1/lib/R");
+
+    super::super::set_session_meta(
+        "/tmp/test.sock".to_string(),
+        "2026-01-01T00:00:00+00:00".to_string(),
+        None,
+        None,
+        None,
+    );
+    let result = super::super::collect_session_result(false, "test");
+    assert_eq!(result.r_home, None);
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert!(json.get("r_home").is_some());
+    assert!(json["r_home"].is_null());
+}
+
 /// Tests that `history_session_id` in `SessionResult` reflects what was passed to
 /// `set_session_meta`.
 #[test]
@@ -204,6 +239,7 @@ fn test_session_result_includes_history_session_id() {
     super::super::set_session_meta(
         "/tmp/test.sock".to_string(),
         "2026-01-01T00:00:00+00:00".to_string(),
+        None,
         None,
         Some(session_id),
     );
@@ -218,6 +254,7 @@ fn test_session_result_includes_history_session_id() {
     super::super::set_session_meta(
         "/tmp/test.sock".to_string(),
         "2026-01-01T00:00:00+00:00".to_string(),
+        None,
         None,
         None,
     );

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -299,6 +299,14 @@ mod tests {
 
         let info: SessionInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.r_home, None);
+
+        // Listing such a session reports `r_home` as null rather than omitting
+        // it, so a client sees one shape whether the path is unknown because
+        // the session predates the field or because the session has no R. Both
+        // mean the same thing to a caller: no R installation to rely on.
+        let listed = serde_json::to_value(&info).unwrap();
+        assert!(listed.as_object().unwrap().contains_key("r_home"));
+        assert!(listed["r_home"].is_null());
     }
 
     #[test]

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -31,6 +31,10 @@ pub struct SessionInfo {
     pub pid: u32,
     pub socket_path: String,
     pub r_version: Option<String>,
+    /// R installation path selected by arf at startup, or `None` if no R was resolved.
+    /// The field is absent in session files written by older arf versions.
+    #[serde(default)]
+    pub r_home: Option<String>,
     pub cwd: String,
     pub started_at: String,
     /// Whether this session is headless or interactive, or `None` for session
@@ -242,6 +246,7 @@ mod tests {
             pid: 12345,
             socket_path: "/tmp/arf.sock".to_string(),
             r_version: Some("4.4.1".to_string()),
+            r_home: None,
             cwd: "/tmp".to_string(),
             started_at: "2026-01-01T00:00:00+00:00".to_string(),
             session_type,
@@ -252,13 +257,16 @@ mod tests {
 
     #[test]
     fn session_type_serializes_and_round_trips() {
-        let info = session_info(Some(SessionType::Headless));
+        let mut info = session_info(Some(SessionType::Headless));
+        info.r_home = Some("/opt/R/4.4.1/lib/R".to_string());
         let json = serde_json::to_value(&info).unwrap();
 
         assert_eq!(json["session_type"], "headless");
+        assert_eq!(json["r_home"], "/opt/R/4.4.1/lib/R");
 
         let restored: SessionInfo = serde_json::from_value(json).unwrap();
         assert_eq!(restored.session_type, Some(SessionType::Headless));
+        assert_eq!(restored.r_home.as_deref(), Some("/opt/R/4.4.1/lib/R"));
     }
 
     #[test]
@@ -275,6 +283,22 @@ mod tests {
 
         let info: SessionInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.session_type, None);
+    }
+
+    #[test]
+    fn legacy_session_without_r_home_deserializes_as_unknown() {
+        let json = r#"
+        {
+            "pid": 12345,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": "4.4.1",
+            "cwd": "/tmp",
+            "started_at": "2026-01-01T00:00:00+00:00"
+        }
+        "#;
+
+        let info: SessionInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.r_home, None);
     }
 
     #[test]

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -31,7 +31,7 @@ pub struct SessionInfo {
     pub pid: u32,
     pub socket_path: String,
     pub r_version: Option<String>,
-    /// R installation path selected by arf at startup, or `None` if no R was resolved.
+    /// R installation path reported by the running R at startup, or `None` if R is unavailable.
     /// The field is absent in session files written by older arf versions.
     #[serde(default)]
     pub r_home: Option<String>,

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -316,11 +316,15 @@ fn run() -> Result<()> {
 
     // Initialize R with CLI-specified flags
     log::info!("Initializing R...");
+    // Note the directory before initializing: on Unix, profiles run inside
+    // initialization and may call setwd(), which would move the base a
+    // relative R_HOME has to be resolved against.
+    let pre_init_dir = std::env::current_dir().ok();
     let (r_initialized, r_home) = unsafe {
         match arf_libr::initialize_r_with_args(&r_args_refs) {
             Ok(()) => {
                 log::info!("R initialized successfully");
-                (true, capture_runtime_r_home())
+                (true, capture_runtime_r_home(pre_init_dir.as_deref()))
             }
             Err(e) => {
                 eprintln!("Warning: Failed to initialize R: {}", e);
@@ -444,7 +448,10 @@ fn run() -> Result<()> {
 /// This is intentionally called only after successful R initialization. The
 /// startup resolution report is a prediction, while `R.home()` is a fact from
 /// the runtime that is actually in use.
-fn capture_runtime_r_home() -> Option<PathBuf> {
+///
+/// `base_dir` is the working directory from before initialization, used to
+/// resolve a relative R_HOME. See [`absolutize_runtime_r_home`].
+fn capture_runtime_r_home(base_dir: Option<&std::path::Path>) -> Option<PathBuf> {
     let r_home = match unsafe { arf_harp::eval_r_to_string(r#"base::R.home()"#) } {
         Ok(Some(r_home)) => r_home,
         Ok(None) => {
@@ -457,16 +464,39 @@ fn capture_runtime_r_home() -> Option<PathBuf> {
         }
     };
 
-    let r_home = PathBuf::from(r_home);
+    absolutize_runtime_r_home(PathBuf::from(r_home), base_dir)
+}
+
+/// Resolve a relative R_HOME against the directory R started in.
+///
+/// R stores whatever R_HOME string it was given, so `R.home()` can be
+/// relative. The base has to be the working directory from before
+/// initialization: a `.Rprofile` runs during initialization on Unix and may
+/// call `setwd()`, and resolving against the directory afterwards would name a
+/// different location than the one R loaded from. Without a base, a relative
+/// path is dropped rather than guessed at.
+///
+/// Paths are joined, never canonicalized: resolving symlinks would report an
+/// R_HOME other than the one in use. `arf r resolve` joins for the same reason.
+///
+/// In practice R fails to initialize with a relative R_HOME, so this is
+/// defensive. It is kept because arf does not reject relative input either: an
+/// explicit `--r-home` is returned unchanged when the path has no `bin/R`.
+fn absolutize_runtime_r_home(
+    r_home: PathBuf,
+    base_dir: Option<&std::path::Path>,
+) -> Option<PathBuf> {
     if r_home.is_absolute() {
-        Some(r_home)
-    } else {
-        match std::env::current_dir() {
-            Ok(cwd) => Some(cwd.join(r_home)),
-            Err(error) => {
-                log::warn!("Could not make R.home() absolute: {error}");
-                None
-            }
+        return Some(r_home);
+    }
+    match base_dir {
+        Some(base) => Some(base.join(r_home)),
+        None => {
+            log::warn!(
+                "Could not make R.home() absolute: the directory R started in is unknown ({})",
+                r_home.display()
+            );
+            None
         }
     }
 }
@@ -590,4 +620,41 @@ fn is_history_option_allowed(path: &[String], long: &str) -> bool {
         && path.len() == 2
         && path[0] == "history"
         && matches!(path[1].as_str(), "import" | "export")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::absolutize_runtime_r_home;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn absolute_runtime_r_home_is_left_alone() {
+        let r_home = PathBuf::from(if cfg!(windows) {
+            r"C:\opt\R\lib\R"
+        } else {
+            r"/opt/R/lib/R"
+        });
+        assert_eq!(
+            absolutize_runtime_r_home(r_home.clone(), Some(Path::new("/elsewhere"))),
+            Some(r_home)
+        );
+    }
+
+    #[test]
+    fn relative_runtime_r_home_resolves_against_the_startup_directory() {
+        // The point of taking the base as an argument: a setwd() during
+        // initialization cannot influence the result.
+        assert_eq!(
+            absolutize_runtime_r_home(PathBuf::from("lib/R"), Some(Path::new("/start"))),
+            Some(PathBuf::from("/start/lib/R"))
+        );
+    }
+
+    #[test]
+    fn relative_runtime_r_home_without_a_base_is_dropped() {
+        assert_eq!(
+            absolutize_runtime_r_home(PathBuf::from("lib/R"), None),
+            None
+        );
+    }
 }

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -275,6 +275,7 @@ fn run() -> Result<()> {
         cli.r_source.no_r_source_overrides,
     )?;
     resolution.emit_diagnostics();
+    let r_home = resolution.r_home.clone();
     let r_source_status = resolution.status;
     log::debug!("R source status: {:?}", r_source_status);
 
@@ -394,6 +395,7 @@ fn run() -> Result<()> {
     if cli.with_ipc {
         match ipc::start_server(
             cli.ipc_bind.as_deref(),
+            r_home.as_ref().map(|path| path.display().to_string()),
             None,
             session_id_raw,
             ipc::session::SessionType::Interactive,
@@ -421,6 +423,7 @@ fn run() -> Result<()> {
         config_path,
         config_status,
         r_source_status,
+        r_home,
         session_id,
     )?;
     let repl_result = repl.run();

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -41,6 +41,7 @@ use pid_file::{
     absolute_pid_file_path, cleanup_ipc_pid_file, register_ipc_pid_file_atexit, write_pid_file,
 };
 use repl::Repl;
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -275,7 +276,6 @@ fn run() -> Result<()> {
         cli.r_source.no_r_source_overrides,
     )?;
     resolution.emit_diagnostics();
-    let r_home = resolution.r_home.clone();
     let r_source_status = resolution.status;
     log::debug!("R source status: {:?}", r_source_status);
 
@@ -316,18 +316,17 @@ fn run() -> Result<()> {
 
     // Initialize R with CLI-specified flags
     log::info!("Initializing R...");
-    #[allow(unused_variables)]
-    let r_initialized = unsafe {
+    let (r_initialized, r_home) = unsafe {
         match arf_libr::initialize_r_with_args(&r_args_refs) {
             Ok(()) => {
                 log::info!("R initialized successfully");
-                true
+                (true, capture_runtime_r_home())
             }
             Err(e) => {
                 eprintln!("Warning: Failed to initialize R: {}", e);
                 eprintln!("R evaluation will not be available.");
                 eprintln!("Make sure R is installed and R_HOME is set correctly.\n");
-                false
+                (false, None)
             }
         }
     };
@@ -438,6 +437,38 @@ fn run() -> Result<()> {
     }
 
     repl_result
+}
+
+/// Capture the R_HOME reported by the initialized R runtime.
+///
+/// This is intentionally called only after successful R initialization. The
+/// startup resolution report is a prediction, while `R.home()` is a fact from
+/// the runtime that is actually in use.
+fn capture_runtime_r_home() -> Option<PathBuf> {
+    let r_home = match unsafe { arf_harp::eval_r_to_string(r#"base::R.home()"#) } {
+        Ok(Some(r_home)) => r_home,
+        Ok(None) => {
+            log::warn!("R.home() returned NULL after R initialization");
+            return None;
+        }
+        Err(error) => {
+            log::warn!("Could not evaluate R.home() after R initialization: {error}");
+            return None;
+        }
+    };
+
+    let r_home = PathBuf::from(r_home);
+    if r_home.is_absolute() {
+        Some(r_home)
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => Some(cwd.join(r_home)),
+            Err(error) => {
+                log::warn!("Could not make R.home() absolute: {error}");
+                None
+            }
+        }
+    }
 }
 
 fn r_source_origin(matches: &ArgMatches) -> Option<RSourceOrigin> {

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -45,6 +45,7 @@ pub fn process_meta_command(
     r_source_status: &RSourceStatus,
     dir_stack: &mut Vec<PathBuf>,
     history_session_id: Option<i64>,
+    r_home: Option<&std::path::Path>,
 ) -> Option<MetaCommandResult> {
     let trimmed = input.trim();
     if !trimmed.starts_with(':') {
@@ -246,6 +247,7 @@ pub fn process_meta_command(
             match subcmd {
                 "start" => match crate::ipc::start_server(
                     None,
+                    r_home.map(|path| path.display().to_string()),
                     None,
                     history_session_id,
                     crate::ipc::session::SessionType::Interactive,
@@ -547,6 +549,7 @@ mod tests {
             shell_history_path,
             status,
             &mut dir_stack,
+            None,
             None,
         )
     }
@@ -859,6 +862,7 @@ mod tests {
             &status,
             &mut dir_stack,
             None,
+            None,
         );
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
     }
@@ -879,6 +883,7 @@ mod tests {
             &status,
             &mut dir_stack,
             None,
+            None,
         );
         assert!(matches!(result, Some(MetaCommandResult::Handled)));
         assert_eq!(dir_stack.len(), 1);
@@ -890,6 +895,7 @@ mod tests {
             &None,
             &status,
             &mut dir_stack,
+            None,
             None,
         );
         assert!(matches!(result, Some(MetaCommandResult::Handled)));

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -224,6 +224,8 @@ pub struct Repl {
     config_status: ConfigStatus,
     /// How R was resolved at startup (determines if :switch is available).
     r_source_status: RSourceStatus,
+    /// R_HOME selected by arf at startup, if one was resolved.
+    r_home: Option<std::path::PathBuf>,
     r_initialized: bool,
     prompt_formatter: PromptFormatter,
     /// Session ID for history isolation (shared across R and shell history).
@@ -243,6 +245,7 @@ impl Repl {
         config_path: Option<std::path::PathBuf>,
         config_status: ConfigStatus,
         r_source_status: RSourceStatus,
+        r_home: Option<std::path::PathBuf>,
         session_id: Option<HistorySessionId>,
     ) -> Result<Self> {
         // Check if R is initialized
@@ -261,6 +264,7 @@ impl Repl {
             config_path,
             config_status,
             r_source_status,
+            r_home,
             r_initialized,
             prompt_formatter,
             session_id,
@@ -552,6 +556,7 @@ impl Repl {
                 r_history_path,
                 shell_history_path,
                 r_source_status: self.r_source_status.clone(),
+                r_home: self.r_home.clone(),
                 forget_config: self.config.experimental.history_forget.clone(),
                 sponge_queue: state::SpongeQueue::new(),
                 dir_stack: Vec::new(),
@@ -771,6 +776,7 @@ impl Repl {
                         &self.r_source_status,
                         &mut dir_stack,
                         history_session_id,
+                        self.r_home.as_deref(),
                     ) {
                         // Clear duration so the previous R command's time
                         // does not persist in the prompt after a meta command.

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -224,7 +224,7 @@ pub struct Repl {
     config_status: ConfigStatus,
     /// How R was resolved at startup (determines if :switch is available).
     r_source_status: RSourceStatus,
-    /// R_HOME selected by arf at startup, if one was resolved.
+    /// R_HOME reported by the running R at startup, if R initialized successfully.
     r_home: Option<std::path::PathBuf>,
     r_initialized: bool,
     prompt_formatter: PromptFormatter,

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -242,6 +242,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         &state.r_source_status,
                         &mut state.dir_stack,
                         state.history_session_id.map(i64::from),
+                        state.r_home.as_deref(),
                     ) {
                         // Clear duration so the previous R command's time
                         // does not persist in the prompt after a meta command.

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -70,7 +70,7 @@ pub struct ReplState {
     pub shell_history_path: Option<PathBuf>,
     /// How R was resolved at startup (for :info display and :switch gating).
     pub r_source_status: RSourceStatus,
-    /// R_HOME selected by arf at startup, if one was resolved.
+    /// R_HOME reported by the running R at startup, if R initialized successfully.
     pub r_home: Option<PathBuf>,
     /// Configuration for the sponge-like "forget failed commands" feature.
     pub forget_config: HistoryForgetConfig,

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -70,6 +70,8 @@ pub struct ReplState {
     pub shell_history_path: Option<PathBuf>,
     /// How R was resolved at startup (for :info display and :switch gating).
     pub r_source_status: RSourceStatus,
+    /// R_HOME selected by arf at startup, if one was resolved.
+    pub r_home: Option<PathBuf>,
     /// Configuration for the sponge-like "forget failed commands" feature.
     pub forget_config: HistoryForgetConfig,
     /// Queue for the sponge feature (tracks commands to potentially delete).

--- a/crates/arf-console/tests/headless/mod.rs
+++ b/crates/arf-console/tests/headless/mod.rs
@@ -4,4 +4,5 @@ mod history;
 mod lifecycle_flags;
 mod output_encoding;
 mod platform;
+mod r_home;
 mod support;

--- a/crates/arf-console/tests/headless/r_home.rs
+++ b/crates/arf-console/tests/headless/r_home.rs
@@ -1,0 +1,58 @@
+use super::support::*;
+use std::path::{Path, PathBuf};
+
+/// Locate a directory holding a real `R` executable but no `rig`.
+///
+/// Restricting `PATH` to the first directory on it that contains `R` is not
+/// enough: rig installs its own `R` shim next to the `rig` binary, so that
+/// directory usually holds both and rig stays available. A session that can
+/// still reach rig never enters PATH mode, which is the mode under test.
+///
+/// Resolving the shim to its target gives the R installation's own `bin`
+/// directory, which does not contain rig.
+fn r_bin_dir_without_rig() -> Option<PathBuf> {
+    let r_command = if cfg!(windows) { "R.exe" } else { "R" };
+    let rig_command = if cfg!(windows) { "rig.exe" } else { "rig" };
+
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(r_command))
+        .filter(|r| r.is_file())
+        .filter_map(|r| std::fs::canonicalize(r).ok())
+        .filter_map(|r| r.parent().map(Path::to_path_buf))
+        .find(|dir| !dir.join(rig_command).exists())
+}
+
+/// The R_HOME reported over IPC must come from the running R, not from the
+/// startup resolution, which leaves it unset in PATH mode.
+#[test]
+fn test_headless_json_reports_runtime_r_home_in_path_mode() {
+    let Some(r_bin_dir) = r_bin_dir_without_rig() else {
+        panic!("this test needs a directory on PATH holding R but not rig");
+    };
+    let restricted_path = r_bin_dir.to_str().expect("R path should be UTF-8");
+
+    let process =
+        HeadlessProcess::spawn_with_args_and_env(&["--json"], &[("PATH", restricted_path)])
+            .expect("Failed to spawn headless in PATH mode");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while process.stdout_output().trim().is_empty() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Timed out waiting for JSON on stdout. stderr: {}",
+            process.stderr_output()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let stdout = process.stdout_output();
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|error| panic!("Invalid JSON: {error}\nstdout: {stdout}"));
+    let r_home = json["r_home"]
+        .as_str()
+        .expect("PATH mode should report a runtime r_home");
+    assert!(
+        Path::new(r_home).is_absolute(),
+        "runtime r_home should be absolute: {r_home}"
+    );
+}

--- a/crates/arf-console/tests/headless/support.rs
+++ b/crates/arf-console/tests/headless/support.rs
@@ -120,6 +120,14 @@ impl HeadlessProcess {
         Self::spawn_inner(extra_args, &[], None, None)
     }
 
+    /// Spawn `arf headless` with additional environment variables.
+    pub(crate) fn spawn_with_args_and_env(
+        extra_args: &[&str],
+        env_overrides: &[(&str, &str)],
+    ) -> Result<Self, String> {
+        Self::spawn_inner(extra_args, env_overrides, None, None)
+    }
+
     /// Spawn `arf headless` with OS-string arguments.
     #[cfg(unix)]
     pub(crate) fn spawn_with_os_args(extra_args: &[&OsStr]) -> Result<Self, String> {

--- a/crates/arf-harp/src/help.rs
+++ b/crates/arf-harp/src/help.rs
@@ -184,13 +184,18 @@ fn extract_help_topics(index: &RObject) -> Vec<HelpTopic> {
 
 /// Evaluate R code and return the result as an optional String.
 ///
-/// This is an internal helper that handles the common pattern of:
+/// This shared helper handles the common pattern of:
 /// parsing R code, evaluating it via `R_ToplevelExec`, and extracting
 /// a character string result.
 ///
 /// Returns `Ok(Some(text))` if evaluation produces a character result,
 /// `Ok(None)` if the result is `NULL`, or `Err` on failure.
-unsafe fn eval_r_to_string(code: &str) -> HarpResult<Option<String>> {
+///
+/// # Safety
+///
+/// R must already be initialized and the caller must ensure that evaluation
+/// happens on R's thread.
+pub unsafe fn eval_r_to_string(code: &str) -> HarpResult<Option<String>> {
     let lib = r_library()?;
     let mut protect = RProtect::new();
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -73,7 +73,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version`, `r_home`, `log_file`, and `history_session_id` may be `null`. `r_home` is the R installation the session is using, or `null` when the session has no R. A session started by an older arf may omit `r_home`; clients should treat that as unknown. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `r_home`, `log_file`, and `history_session_id` may be `null`. `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
 
 The IPC `r_version` is measured from a live R session; `arf r resolve` reports `resolved_version`, a prediction made before R starts.
 
@@ -320,10 +320,14 @@ REPL. A `null` value means the session was created by an older arf that did not
 record its type. Clients must treat `null` as unknown and must not send
 `shutdown` to that session.
 
-The `r_home` field is the R installation the session is using, or `null` when the
-session has no R. A session started by an older arf omits this field; clients
-should treat its absence as unknown. `r_version`, `r_home`, `session_type`,
-`log_file`, and `history_session_id` may be `null` in current session files.
+The `r_home` field is the R installation the session is using. A `null` value
+means either that the session has no R, or that it was created by an older arf
+that did not record the path: a session file written before this field existed
+is listed with `r_home` set to `null`, like any other unset field. Clients must
+treat `null` as unknown and must not assume an R installation is available.
+
+`r_version`, `r_home`, `session_type`, `log_file`, and `history_session_id` may
+all be `null`.
 
 ### `arf ipc history` — Query Command History
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -56,6 +56,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
   "pid": 12345,
   "socket_path": "/run/user/1000/arf/12345.sock",
   "r_version": "4.4.2",
+  "r_home": "/opt/R/4.4.2/lib/R",
   "cwd": "/workspace",
   "started_at": "2026-03-22T10:00:00+09:00",
   "log_file": null,
@@ -72,7 +73,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version`, `log_file`, and `history_session_id` may be `null`. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `r_home`, `log_file`, and `history_session_id` may be `null`. `r_home` is the R installation the session is using, or `null` when the session has no R. A session started by an older arf may omit `r_home`; clients should treat that as unknown. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
 
 The IPC `r_version` is measured from a live R session; `arf r resolve` reports `resolved_version`, a prediction made before R starts.
 
@@ -253,6 +254,7 @@ The response always has the same shape. When R is busy, the `r` field is `null` 
   "pid": 12345,
   "os": "linux",
   "arch": "x86_64",
+  "r_home": "/opt/R/4.4.2/lib/R",
   "socket_path": "/run/user/1000/arf/12345.sock",
   "started_at": "2026-03-22T10:00:00+09:00",
   "log_file": null,
@@ -261,6 +263,11 @@ The response always has the same shape. When R is busy, the `r` field is `null` 
   "hint": null
 }
 ```
+
+All top-level keys are always present. `r_home` is the R installation the session is using, or
+`null` when the session has no R. The `r` object contains information collected by evaluating R
+and may be `null` while R is busy or unavailable. `arch` is the architecture of the arf process,
+not the R installation.
 
 When R is idle, the `r` field contains session details (other top-level fields omitted for brevity):
 
@@ -293,6 +300,7 @@ arf ipc list
 #     {
 #       "pid": 12345,
 #       "r_version": "4.4.1",
+#       "r_home": "/opt/R/4.4.1/lib/R",
 #       "socket_path": "/run/user/1000/arf/12345.sock",
 #       "cwd": "/workspace",
 #       "started_at": "2026-03-22T10:00:00+09:00",
@@ -311,6 +319,11 @@ The `session_type` field is `"headless"` for sessions started with
 REPL. A `null` value means the session was created by an older arf that did not
 record its type. Clients must treat `null` as unknown and must not send
 `shutdown` to that session.
+
+The `r_home` field is the R installation the session is using, or `null` when the
+session has no R. A session started by an older arf omits this field; clients
+should treat its absence as unknown. `r_version`, `r_home`, `session_type`,
+`log_file`, and `history_session_id` may be `null` in current session files.
 
 ### `arf ipc history` — Query Command History
 


### PR DESCRIPTION
An editor talking to a running arf session had no way to learn which R that session uses. `arf r resolve` answers this before R starts; nothing answered it afterwards, so a client had to discover an installation itself and could pick a different one.

`arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`. It sits at the top level rather than inside the `r` object, which is collected by evaluating R and is null whenever R is busy or unavailable; R_HOME is known without R. A session file written by an older arf has no such field, so clients must treat its absence as unknown.

The value is what the running R reports, captured once by evaluating `base::R.home()` after initialization succeeds. Publishing the startup resolution instead would have been wrong three ways, each reproduced before fixing:

In PATH mode, the default whenever rig is absent, resolution leaves R_HOME unset and defers to discovery during initialization, so the field would be null while R runs fine. Interactive startup continues after a failed initialization, and would have advertised an R the session is not using. Relative paths would have been published unnormalized.

`arf_libr::get_r_home()` is not usable as the source: it reads the environment variable or spawns `R RHOME`, never consulting the loaded library, and `find_r_library()` additionally searches compiled-in default paths that it does not, so the two are separate searches with no guarantee of agreeing. R derives its own home from the environment rather than from the library it loaded, so no arf-side lookup can stand in for asking R.

`R.home()` can be relative, since R stores whatever string it was given. It is made absolute against the directory captured before initialization, because a `.Rprofile` runs during initialization on Unix and may call `setwd()`. Paths are joined, never canonicalized, which would resolve symlinks and name a different R_HOME than the one in use. `:ipc start` reuses the startup value rather than evaluating again, since R code can set R_HOME afterwards.

Existing field names are left alone. `r_version` and the `r` object's `version` are measured from a running R, while the resolve descriptor's `resolved_version` is a prediction; naming them alike would invite treating one as the other. The docs also now state that `arch` is the architecture of the arf process, not of R, since it sits next to `r_home` and invites that misreading.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test` (all suites pass, 0 failed)
- [x] All three outputs checked against a live session, reporting the same path as `arf r resolve`
- [x] PATH mode checked with rig off `PATH`: null before, absolute path after
- [x] Integration test for PATH mode fails when the value is taken from the resolution again
- [x] Session file lacking `r_home` still deserializes, defaulting to unknown
- [x] Relative-path joining covered by unit tests: absolute unchanged, relative resolved against the given base, no base dropped

No integration test covers the relative-path branch. R fails to initialize with a relative R_HOME, so it cannot be reached end to end, and a test using a profile that changes directory would pass without exercising it. The branch is kept because arf does not reject relative input: an explicit `--r-home` is returned unchanged when the path has no `bin/R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
