### PR TITLE
chore: prepare release 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-08-01
+
 ### Added
 
-- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default.
+- **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default (#271, #288).
   It is opt-in through `experimental.r_source_overrides` in the `arf.toml` config.
 
   For example, the following configuration looks for two TOML files named `rproject.toml` and `rproj.toml` in the current directory, in order:
@@ -39,22 +41,22 @@
   For now, it seems neither of these formats is widely adopted, so arf introduces a generic `toml-key` type that allows us to specify the filename and key path and supports Cargo-style version ranges.
   Of course, we can also support other TOML files with different names and keys for specifying the R version.
 
-- `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables.
-- `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4`. Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
-- `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown.
-- `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown.
-- **Experimental:** `arf r resolve` lets external tools such as editors learn which R arf would use without starting R. It always emits JSON on success.
+- `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables (#271).
+- `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4` (#271). Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
+- `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown (#283).
+- `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown (#294).
+- **Experimental:** `arf r resolve` lets external tools such as editors learn which R arf would use without starting R. It always emits JSON on success (#290, #291, #293).
 
 ### Changed
 
-- Partial version numbers passed to `--with-r-version` and `:switch` (e.g. `4.4`) now match only that release series (`4.4.x`) instead of any version starting with the same text.
+- Partial version numbers passed to `--with-r-version` and `:switch` (e.g. `4.4`) now match only that release series (`4.4.x`) instead of any version starting with the same text (#271).
 
 ### Fixed
 
-- arf could fail to start a different R version when `R_HOME` was set in the environment to point at another R installation.
-- Switching R versions with `:switch` no longer leaves stale `.libPaths()` entries from the previous R version, including after a `:restart`. R-related variables you set before starting arf are kept, apart from `R_HOME` and `LD_LIBRARY_PATH`, which are always removed. `:restart` still leaves the environment untouched.
-- Flags placed before a subcommand no longer get silently ignored; arf now reports the error and explains where the flag belongs.
-- Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived.
+- arf could fail to start a different R version when `R_HOME` was set in the environment to point at another R installation (#295).
+- Switching R versions with `:switch` no longer leaves stale `.libPaths()` entries from the previous R version, including after a `:restart`. R-related variables you set before starting arf are kept, apart from `R_HOME` and `LD_LIBRARY_PATH`, which are always removed. `:restart` still leaves the environment untouched (#295).
+- Flags placed before a subcommand no longer get silently ignored; arf now reports the error and explains where the flag belongs (#275).
+- Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived (#268).
 - IPC requests containing incomplete R expressions are now rejected before they can enter the continuation prompt.
 
 ## [0.4.4] - 2026-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables (#271).
+- `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4` (#271). Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
 - **Experimental:** arf can now read the R version a project has pinned and start that version instead of the configured default (#271, #288).
   It is opt-in through `experimental.r_source_overrides` in the `arf.toml` config.
 
@@ -41,10 +43,8 @@
   For now, it seems neither of these formats is widely adopted, so arf introduces a generic `toml-key` type that allows us to specify the filename and key path and supports Cargo-style version ranges.
   Of course, we can also support other TOML files with different names and keys for specifying the R version.
 
-- `ARF_R_HOME` and `ARF_R_VERSION` can now select the R installation through environment variables (#271).
-- `--with-r-version` and `:switch` now accept version ranges (`^4.4`, `~4.4`, `>=4.3, <5.0`, `*`) in addition to exact and partial version numbers such as `4.4.2` and `4.4` (#271). Range operators come from the convention Cargo and npm use; R's own version numbers are plain `major.minor.patch` releases, so prerelease identifiers and build metadata are rejected.
-- `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown (#283).
-- `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown (#294).
+- **Experimental:** `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown (#283).
+- **Experimental:** `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown (#294).
 - **Experimental:** `arf r resolve` lets external tools such as editors learn which R arf would use without starting R. It always emits JSON on success (#290, #291, #293).
 
 ### Changed
@@ -56,8 +56,8 @@
 - arf could fail to start a different R version when `R_HOME` was set in the environment to point at another R installation (#295).
 - Switching R versions with `:switch` no longer leaves stale `.libPaths()` entries from the previous R version, including after a `:restart`. R-related variables you set before starting arf are kept, apart from `R_HOME` and `LD_LIBRARY_PATH`, which are always removed. `:restart` still leaves the environment untouched (#295).
 - Flags placed before a subcommand no longer get silently ignored; arf now reports the error and explains where the flag belongs (#275).
-- Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived (#268).
-- IPC requests containing incomplete R expressions are now rejected before they can enter the continuation prompt.
+- **Experimental:** Commands sent with `arf ipc send` are now recorded in the history database, so they can be recalled with Ctrl+R, the history browser, and the up arrow like typed commands. Previously they were echoed and evaluated but only saved in some cases, depending on when the request arrived (#268).
+- **Experimental:** IPC requests containing incomplete R expressions are now rejected before they can enter the continuation prompt.
 
 ## [0.4.4] - 2026-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "arf-console"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arf-libr",
  "insta",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1568,7 +1568,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "htmd",
 ]
@@ -1684,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9220c6cca64ee4a1590cbca66962dae9e6290bdfe89262f8cadeaf624b36f8ec"
+checksum = "76c4cde9afc9d1458c1c5c54f2a29a8e8acae078b6fe9650be824236e7c4ddcc"
 dependencies = [
  "rd-ast",
  "rd2qmd-mdast",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e61854dfdd6601bb77080abbada03b259980497bd4305fe17e8075838bdf3e"
+checksum = "3069aab7f4fe35981f750c2145f367c35427559bcb03cd65b665f6b9a8954005"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.4.4", path = "crates/arf-harp" }
-arf-libr = { version = "0.4.4", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.4.4", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.4.5", path = "crates/arf-harp" }
+arf-libr = { version = "0.4.5", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.4.5", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"
@@ -39,7 +39,7 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.3"
 
 # Rd to Markdown conversion
-rd2qmd-core = "0.5"
+rd2qmd-core = "0.5.1"
 rd-source = "0.1"
 rd-helpdb = "0.1"
 rd-rds = "0.1"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.4
+# arf console v0.4.5
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.4
+# arf console v0.4.5
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.4
+# arf console v0.4.5
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.4
+# arf console v0.4.5
 # Edit mode: emacs
 # Reprex mode: enabled | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.4.4
+# arf console v0.4.5
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/docs/r-resolve.md
+++ b/docs/r-resolve.md
@@ -27,7 +27,7 @@ arf r resolve
     "r_binary": "/opt/R/4.5.2/lib/R/bin/R",
     "resolved_version": "4.5.2"
   },
-  "resolver": { "name": "arf", "version": "0.4.4" },
+  "resolver": { "name": "arf", "version": "0.4.5" },
   "selected_by": {
     "kind": "version_request",
     "requested_r_home": null,


### PR DESCRIPTION
## Summary

- Bump the workspace and internal crate versions to 0.4.5.
- Update rd2qmd-core to 0.5.1 and the required rd2qmd-mdast lockfile entry.
- Finalize the 0.4.5 CHANGELOG, version references, and banner snapshots.

## Verification

- cargo insta test --accept -- banner
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked