### PR TITLE
test: unify the guards for process-global test state

### DIFF
--- a/crates/arf-console/src/app/session_id.rs
+++ b/crates/arf-console/src/app/session_id.rs
@@ -48,6 +48,8 @@ mod session_id_tests {
 
     #[test]
     fn test_create_session_id_respects_default_history_dir() {
+        // create_session_id reads HOME/XDG variables indirectly through history_dir.
+        let _guard = crate::test_utils::lock_env();
         // With default config (history.dir = None), session ID depends on
         // whether the platform provides a data directory via history_dir().
         let config = Config::default();

--- a/crates/arf-console/src/app/setup/overrides.rs
+++ b/crates/arf-console/src/app/setup/overrides.rs
@@ -501,6 +501,8 @@ mod r_source_override_tests {
     #[test]
     #[serial_test::serial]
     fn resolve_r_source_does_not_mutate_r_home() {
+        // Hold the lock to keep concurrent environment writers out while reading R_HOME.
+        let _guard = crate::test_utils::lock_env();
         let original = std::env::var_os("R_HOME");
         let temp = tempfile::tempdir().unwrap();
 
@@ -583,6 +585,8 @@ mod r_source_override_tests {
     #[test]
     #[serial_test::serial]
     fn apply_r_source_does_not_set_r_home_for_path_mode() {
+        // Hold the lock to keep concurrent environment writers out while reading R_HOME.
+        let _guard = crate::test_utils::lock_env();
         let original = std::env::var_os("R_HOME");
         let report = RSourceResolutionReport {
             status: RSourceStatus::Path,

--- a/crates/arf-console/src/app/setup/overrides.rs
+++ b/crates/arf-console/src/app/setup/overrides.rs
@@ -499,7 +499,6 @@ mod r_source_override_tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn resolve_r_source_does_not_mutate_r_home() {
         // Hold the lock to keep concurrent environment writers out while reading R_HOME.
         let _guard = crate::test_utils::lock_env();
@@ -583,7 +582,6 @@ mod r_source_override_tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn apply_r_source_does_not_set_r_home_for_path_mode() {
         // Hold the lock to keep concurrent environment writers out while reading R_HOME.
         let _guard = crate::test_utils::lock_env();

--- a/crates/arf-console/src/app/setup/r_source.rs
+++ b/crates/arf-console/src/app/setup/r_source.rs
@@ -460,6 +460,8 @@ mod tests {
 
     #[test]
     fn display_message_masks_its_own_path_and_leaves_pathless_messages_unchanged() {
+        // display_message reads HOME indirectly through dirs::home_dir and mask_home_path.
+        let _guard = crate::test_utils::lock_env();
         let home = dirs::home_dir().expect("test requires a home directory");
         let path = home.join("arf").join("broken.toml");
         let diagnostic = RSourceDiagnostic {

--- a/crates/arf-console/src/cli/mod.rs
+++ b/crates/arf-console/src/cli/mod.rs
@@ -292,7 +292,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_help_headless_snapshot() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -314,10 +313,9 @@ mod tests {
 
     // clap renders the current value of an option's environment variable into
     // the long help, so this snapshot only holds if those variables are unset.
-    // Clearing them keeps the test independent of the surrounding environment,
-    // and serializing keeps the tests below from setting them concurrently.
+    // Clearing them keeps the test independent of the surrounding environment;
+    // the environment guard keeps the tests below from setting them concurrently.
     #[test]
-    #[serial_test::serial]
     fn test_help_long_snapshot() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -331,7 +329,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_history_dir_rejects_empty_string() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -341,7 +338,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_no_r_source_overrides_flag_is_available_on_normal_cli() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -351,7 +347,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_no_r_source_overrides_flag_is_available_on_headless_cli() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -364,7 +359,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_r_resolve_subcommand_has_its_own_resolution_flags() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -393,7 +387,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_no_r_source_overrides_does_not_conflict_with_r_home() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -404,7 +397,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_arf_r_home_has_same_precedence_as_r_home() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -419,7 +411,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_arf_r_version_has_same_precedence_as_with_r_version() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -431,7 +422,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_cli_value_wins_over_r_source_environment_value() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -450,7 +440,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_arf_r_home_conflicts_with_with_r_version() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");
@@ -462,7 +451,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_headless_r_source_flags_read_environment_values() {
         let mut guard = crate::test_utils::lock_env();
         guard.set("ARF_R_HOME", "/env/r-home");
@@ -484,7 +472,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_headless_r_source_flags_conflict_with_environment_values() {
         let mut guard = crate::test_utils::lock_env();
         guard.set("ARF_R_HOME", "/env/r-home");
@@ -497,7 +484,6 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
     fn test_headless_history_dir_reads_environment_value() {
         let mut guard = crate::test_utils::lock_env();
         guard.unset("ARF_R_HOME");

--- a/crates/arf-console/src/cli/mod.rs
+++ b/crates/arf-console/src/cli/mod.rs
@@ -251,40 +251,6 @@ Examples:
 mod tests {
     use super::*;
 
-    struct EnvVarGuard {
-        name: &'static str,
-        original: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(name: &'static str, value: &str) -> Self {
-            let original = std::env::var_os(name);
-            // SAFETY: Tests serialize access to these process-global variables.
-            unsafe { std::env::set_var(name, value) };
-            Self { name, original }
-        }
-
-        fn unset(name: &'static str) -> Self {
-            let original = std::env::var_os(name);
-            // SAFETY: Tests serialize access to these process-global variables.
-            unsafe { std::env::remove_var(name) };
-            Self { name, original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: Tests serialize access to these process-global variables.
-            unsafe {
-                if let Some(value) = &self.original {
-                    std::env::set_var(self.name, value);
-                } else {
-                    std::env::remove_var(self.name);
-                }
-            }
-        }
-    }
-
     #[test]
     fn test_completions_bash_snapshot() {
         let completions = Cli::generate_completions_string(Shell::Bash);
@@ -328,9 +294,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_help_headless_snapshot() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _history_dir = EnvVarGuard::unset("ARF_HISTORY_DIR");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.unset("ARF_HISTORY_DIR");
         let help = Cli::generate_help_string(&["headless"]);
         insta::with_settings!({snapshot_path => "../snapshots"}, {
             insta::assert_snapshot!("help_headless", help);
@@ -352,9 +319,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_help_long_snapshot() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _history_dir = EnvVarGuard::unset("ARF_HISTORY_DIR");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.unset("ARF_HISTORY_DIR");
 
         let help = Cli::generate_help_string(&[]);
         insta::with_settings!({snapshot_path => "../snapshots"}, {
@@ -365,8 +333,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_history_dir_rejects_empty_string() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
         let result = Cli::try_parse_from(["arf", "--history-dir", ""]);
         assert!(result.is_err(), "empty --history-dir should be rejected");
     }
@@ -374,8 +343,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_no_r_source_overrides_flag_is_available_on_normal_cli() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
         let cli = Cli::try_parse_from(["arf", "--no-r-source-overrides"]).unwrap();
         assert!(cli.r_source.no_r_source_overrides);
     }
@@ -383,8 +353,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_no_r_source_overrides_flag_is_available_on_headless_cli() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
         let cli = Cli::try_parse_from(["arf", "headless", "--no-r-source-overrides"]).unwrap();
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");
@@ -395,8 +366,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_r_resolve_subcommand_has_its_own_resolution_flags() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
         let cli = Cli::try_parse_from([
             "arf",
             "r",
@@ -423,8 +395,9 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_no_r_source_overrides_does_not_conflict_with_r_home() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
         let cli =
             Cli::try_parse_from(["arf", "--no-r-source-overrides", "--r-home", "/tmp/r-home"]);
         assert!(cli.is_ok());
@@ -433,9 +406,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_arf_r_home_has_same_precedence_as_r_home() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _env = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.set("ARF_R_HOME", "/env/r-home");
         let cli = Cli::try_parse_from(["arf"]).unwrap();
 
         assert_eq!(
@@ -447,9 +421,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_arf_r_version_has_same_precedence_as_with_r_version() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _env = EnvVarGuard::set("ARF_R_VERSION", "4.5");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.set("ARF_R_VERSION", "4.5");
         let cli = Cli::try_parse_from(["arf"]).unwrap();
 
         assert_eq!(cli.r_source.r_version.as_deref(), Some("4.5"));
@@ -458,30 +433,29 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_cli_value_wins_over_r_source_environment_value() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        {
-            let _home_env = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
-            let home_cli = Cli::try_parse_from(["arf", "--r-home", "/cli/r-home"]).unwrap();
-            assert_eq!(
-                home_cli.r_source.r_home.as_deref(),
-                Some(std::path::Path::new("/cli/r-home"))
-            );
-        }
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.set("ARF_R_HOME", "/env/r-home");
+        let home_cli = Cli::try_parse_from(["arf", "--r-home", "/cli/r-home"]).unwrap();
+        assert_eq!(
+            home_cli.r_source.r_home.as_deref(),
+            Some(std::path::Path::new("/cli/r-home"))
+        );
 
-        {
-            let _version_env = EnvVarGuard::set("ARF_R_VERSION", "4.4");
-            let version_cli = Cli::try_parse_from(["arf", "--with-r-version", "4.5"]).unwrap();
-            assert_eq!(version_cli.r_source.r_version.as_deref(), Some("4.5"));
-        }
+        guard.unset("ARF_R_HOME");
+        guard.set("ARF_R_VERSION", "4.4");
+        let version_cli = Cli::try_parse_from(["arf", "--with-r-version", "4.5"]).unwrap();
+        assert_eq!(version_cli.r_source.r_version.as_deref(), Some("4.5"));
     }
 
     #[test]
     #[serial_test::serial]
     fn test_arf_r_home_conflicts_with_with_r_version() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _env = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.set("ARF_R_HOME", "/env/r-home");
         let result = Cli::try_parse_from(["arf", "--with-r-version", "4.5"]);
 
         assert!(result.is_err());
@@ -490,18 +464,17 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_headless_r_source_flags_read_environment_values() {
-        let _r_home = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.set("ARF_R_HOME", "/env/r-home");
+        guard.unset("ARF_R_VERSION");
         let cli = Cli::try_parse_from(["arf", "headless"]).unwrap();
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");
         };
         assert_eq!(args.r_source.r_home, Some(PathBuf::from("/env/r-home")));
 
-        drop(_r_home);
-        drop(_r_version);
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::set("ARF_R_VERSION", "4.5");
+        guard.unset("ARF_R_HOME");
+        guard.set("ARF_R_VERSION", "4.5");
         let cli = Cli::try_parse_from(["arf", "r", "resolve"]).unwrap();
         let Some(Commands::R(args)) = cli.command else {
             panic!("expected r command");
@@ -513,21 +486,23 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_headless_r_source_flags_conflict_with_environment_values() {
-        let _r_home = EnvVarGuard::set("ARF_R_HOME", "/env/r-home");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
+        let mut guard = crate::test_utils::lock_env();
+        guard.set("ARF_R_HOME", "/env/r-home");
+        guard.unset("ARF_R_VERSION");
         assert!(Cli::try_parse_from(["arf", "headless", "--with-r-version", "4.5"]).is_err());
 
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::set("ARF_R_VERSION", "4.5");
+        guard.unset("ARF_R_HOME");
+        guard.set("ARF_R_VERSION", "4.5");
         assert!(Cli::try_parse_from(["arf", "r", "resolve", "--r-home", "/cli"]).is_err());
     }
 
     #[test]
     #[serial_test::serial]
     fn test_headless_history_dir_reads_environment_value() {
-        let _r_home = EnvVarGuard::unset("ARF_R_HOME");
-        let _r_version = EnvVarGuard::unset("ARF_R_VERSION");
-        let _history_dir = EnvVarGuard::set("ARF_HISTORY_DIR", "/env/history");
+        let mut guard = crate::test_utils::lock_env();
+        guard.unset("ARF_R_HOME");
+        guard.unset("ARF_R_VERSION");
+        guard.set("ARF_HISTORY_DIR", "/env/history");
         let cli = Cli::try_parse_from(["arf", "headless"]).unwrap();
         let Some(Commands::Headless(args)) = cli.command else {
             panic!("expected headless command");

--- a/crates/arf-console/src/completion/path.rs
+++ b/crates/arf-console/src/completion/path.rs
@@ -307,6 +307,8 @@ mod tests {
 
     #[test]
     fn test_expand_tilde() {
+        // expand_tilde and the expected value read HOME through dirs::home_dir.
+        let _guard = crate::test_utils::lock_env();
         // Tilde with slash should expand
         let expanded = expand_tilde("~/Documents");
         if let Some(home) = dirs::home_dir() {

--- a/crates/arf-console/src/config/mod.rs
+++ b/crates/arf-console/src/config/mod.rs
@@ -903,6 +903,8 @@ show_banner = false
 
     #[test]
     fn test_mask_home_path_with_home_prefix() {
+        // mask_home_path reads HOME indirectly through dirs::home_dir.
+        let _guard = crate::test_utils::lock_env();
         if let Some(home) = dirs::home_dir() {
             let test_path = home.join("test").join("file.txt");
             let masked = mask_home_path(&test_path);
@@ -926,6 +928,8 @@ show_banner = false
 
     #[test]
     fn test_mask_home_path_without_home_prefix() {
+        // mask_home_path reads HOME indirectly through dirs::home_dir.
+        let _guard = crate::test_utils::lock_env();
         let test_path = PathBuf::from("/opt/R/4.5.0");
         let expected = test_path.display().to_string();
         let masked = mask_home_path(&test_path);
@@ -937,6 +941,8 @@ show_banner = false
 
     #[test]
     fn test_mask_home_path_exact_home() {
+        // mask_home_path reads HOME indirectly through dirs::home_dir.
+        let _guard = crate::test_utils::lock_env();
         if let Some(home) = dirs::home_dir() {
             let masked = mask_home_path(&home);
             // Should be just "~/" or "~\" depending on platform

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -336,6 +336,8 @@ mod tests {
 
     #[test]
     fn test_validator_complete_expressions() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         // Simple complete expressions
@@ -355,6 +357,8 @@ mod tests {
 
     #[test]
     fn test_validator_incomplete_expressions() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         // Unclosed parentheses
@@ -379,6 +383,8 @@ mod tests {
 
     #[test]
     fn test_validator_meta_commands_are_complete() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         // Meta commands should be treated as complete (even if they're not valid R)
@@ -397,6 +403,8 @@ mod tests {
 
     #[test]
     fn test_validator_empty_and_whitespace() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         assert!(is_complete(validator.validate("")));
@@ -406,6 +414,8 @@ mod tests {
 
     #[test]
     fn test_validator_raw_strings() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         // Complete raw strings
@@ -506,6 +516,8 @@ mod tests {
 
     #[test]
     fn test_validator_multiline() {
+        // validate reads R_TERM_VALIDATOR_DEBUG indirectly through debug_log.
+        let _guard = crate::test_utils::lock_env();
         let validator = RValidator::new();
 
         // Single open paren

--- a/crates/arf-console/src/history/import/tests/r_history_parsing.rs
+++ b/crates/arf-console/src/history/import/tests/r_history_parsing.rs
@@ -46,7 +46,8 @@ fn test_parse_r_history_preserves_leading_whitespace() {
 
 #[test]
 fn test_default_paths() {
-    // Hold the lock to keep concurrent environment writers out while reading R_HISTFILE.
+    // default_radian_path reads HOME through dirs::home_dir, and
+    // default_r_history_path reads R_HISTFILE through std::env::var.
     let _guard = crate::test_utils::lock_env();
     // These just verify the functions don't panic
     let radian_path = default_radian_path();

--- a/crates/arf-console/src/history/import/tests/r_history_parsing.rs
+++ b/crates/arf-console/src/history/import/tests/r_history_parsing.rs
@@ -46,6 +46,8 @@ fn test_parse_r_history_preserves_leading_whitespace() {
 
 #[test]
 fn test_default_paths() {
+    // Hold the lock to keep concurrent environment writers out while reading R_HISTFILE.
+    let _guard = crate::test_utils::lock_env();
     // These just verify the functions don't panic
     let radian_path = default_radian_path();
     assert!(radian_path.to_string_lossy().contains("radian_history"));

--- a/crates/arf-console/src/ipc/server/tests.rs
+++ b/crates/arf-console/src/ipc/server/tests.rs
@@ -14,9 +14,7 @@ fn test_extract_body_raw_json() {
 
 /// Tests that dispatch_request rejects both evaluate and user_input
 /// in alternate mode.
-///
-/// Serialized with `#[serial]` because all tests that touch the global
-/// `IN_ALTERNATE_MODE` / `R_IS_AT_PROMPT` atomics must not run concurrently.
+// Protects the process-global `IN_ALTERNATE_MODE` atomic.
 #[tokio::test]
 #[serial_test::serial]
 async fn test_dispatch_rejects_in_alternate_mode() {
@@ -59,6 +57,8 @@ async fn test_dispatch_rejects_in_alternate_mode() {
 
 /// Tests that `session` returns arf-only success (not an error) in alternate mode,
 /// with a context-appropriate `r_unavailable_reason`.
+// Protects the process-global `IN_ALTERNATE_MODE` atomic and `SESSION_META`
+// session-metadata cache.
 #[tokio::test]
 #[serial_test::serial]
 async fn test_session_returns_arf_only_in_alternate_mode() {
@@ -114,6 +114,8 @@ async fn test_session_returns_arf_only_in_alternate_mode() {
 
 /// Tests that `session` returns arf-only info when the main thread channel
 /// is broken (tx.send fails).
+// Protects the process-global `IN_ALTERNATE_MODE` atomic and `SESSION_META`
+// session-metadata cache.
 #[tokio::test]
 #[serial_test::serial]
 async fn test_session_fallback_on_channel_failure() {
@@ -159,6 +161,7 @@ async fn test_session_fallback_on_channel_failure() {
 }
 
 /// Tests that `log_file` in `SessionResult` reflects what was passed to `set_session_meta`.
+// Protects the process-global `SESSION_META` session-metadata cache.
 #[test]
 #[serial_test::serial]
 fn test_session_result_includes_log_file() {
@@ -198,6 +201,7 @@ fn test_session_result_includes_log_file() {
 
 /// Tests that `r_home` in `SessionResult` reflects what was passed to
 /// `set_session_meta`.
+// Protects the process-global `SESSION_META` session-metadata cache.
 #[test]
 #[serial_test::serial]
 fn test_session_result_includes_r_home() {
@@ -231,6 +235,7 @@ fn test_session_result_includes_r_home() {
 
 /// Tests that `history_session_id` in `SessionResult` reflects what was passed to
 /// `set_session_meta`.
+// Protects the process-global `SESSION_META` session-metadata cache.
 #[test]
 #[serial_test::serial]
 fn test_session_result_includes_history_session_id() {

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -313,6 +313,7 @@ mod tests {
     #[serial]
     fn clear_session_history_id_preserves_session_type() {
         let temp_dir = tempfile::tempdir().unwrap();
+        // clear_session_history_id reads ARF_IPC_SESSIONS_DIR through sessions_dir.
         let mut guard = crate::test_utils::lock_env();
         guard.set(ARF_IPC_SESSIONS_DIR, temp_dir.path());
 

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -239,7 +239,6 @@ fn is_process_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     fn session_info(session_type: Option<SessionType>) -> SessionInfo {
         SessionInfo {
@@ -310,7 +309,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn clear_session_history_id_preserves_session_type() {
         let temp_dir = tempfile::tempdir().unwrap();
         // clear_session_history_id reads ARF_IPC_SESSIONS_DIR through sessions_dir.

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -313,7 +313,8 @@ mod tests {
     #[serial]
     fn clear_session_history_id_preserves_session_type() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let _guard = crate::test_utils::lock_env_var(ARF_IPC_SESSIONS_DIR, temp_dir.path());
+        let mut guard = crate::test_utils::lock_env();
+        guard.set(ARF_IPC_SESSIONS_DIR, temp_dir.path());
 
         let pid = std::process::id();
         let info = SessionInfo {

--- a/crates/arf-console/src/ipc/tests.rs
+++ b/crates/arf-console/src/ipc/tests.rs
@@ -73,6 +73,8 @@ fn test_alternate_mode_flag_and_request_rejection() {
 
 /// Tests that `handle_request` returns arf-only session info (not an error)
 /// in various states: alternate mode, R busy, pending operation.
+// Protects the process-global `IN_ALTERNATE_MODE` / `R_IS_AT_PROMPT` atomics
+// and the `PENDING_IPC_OPERATION` static.
 #[test]
 #[serial]
 fn test_session_returns_arf_only_in_various_states() {

--- a/crates/arf-console/src/pager/history_schema.rs
+++ b/crates/arf-console/src/pager/history_schema.rs
@@ -700,6 +700,8 @@ mod tests {
 
     #[test]
     fn test_print_schema_runs() {
+        // print_schema reads HOME/XDG variables indirectly through history_dir.
+        let _guard = crate::test_utils::lock_env();
         // On systems with XDG support, this should succeed
         // On other systems (or in restrictive environments), it may fail
         let _ = print_schema();

--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -322,6 +322,8 @@ mod tests {
 
     #[test]
     fn test_mask_env_value_with_home() {
+        // Read HOME through dirs::home_dir and mask_env_value -> mask_home_path.
+        let _guard = crate::test_utils::lock_env();
         if let Some(home) = dirs::home_dir() {
             let home_str = home.display().to_string();
             let sep = std::path::MAIN_SEPARATOR;
@@ -340,6 +342,8 @@ mod tests {
 
     #[test]
     fn test_mask_env_value_without_home() {
+        // mask_env_value reads HOME indirectly through mask_home_path.
+        let _guard = crate::test_utils::lock_env();
         let test_value = "/opt/R/library";
         // mask_env_value round-trips through Path::display() which may normalize separators
         let expected = std::path::Path::new(test_value).display().to_string();
@@ -349,6 +353,8 @@ mod tests {
 
     #[test]
     fn test_mask_env_value_multiple_paths() {
+        // Read HOME through dirs::home_dir and mask_env_value -> mask_home_path.
+        let _guard = crate::test_utils::lock_env();
         if let Some(home) = dirs::home_dir() {
             let home_str = home.display().to_string();
             let path_sep = std::path::MAIN_SEPARATOR;
@@ -454,6 +460,8 @@ mod tests {
 
     #[test]
     fn test_generate_info_lines_config_path_none() {
+        // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
+        let _guard = crate::test_utils::lock_env();
         let config = default_prompt_config();
         let lines = generate_info_lines(
             &config,
@@ -476,6 +484,8 @@ mod tests {
 
     #[test]
     fn test_generate_info_lines_config_path_existing() {
+        // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
+        let _guard = crate::test_utils::lock_env();
         let config = default_prompt_config();
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let path = temp_file.path().to_path_buf();
@@ -511,6 +521,8 @@ mod tests {
 
     #[test]
     fn test_generate_info_lines_config_path_nonexistent() {
+        // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
+        let _guard = crate::test_utils::lock_env();
         let config = default_prompt_config();
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("nonexistent_config.toml");
@@ -535,6 +547,8 @@ mod tests {
 
     #[test]
     fn test_generate_info_lines_config_parse_error() {
+        // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
+        let _guard = crate::test_utils::lock_env();
         let config = default_prompt_config();
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let path = temp_file.path().to_path_buf();
@@ -559,6 +573,8 @@ mod tests {
 
     #[test]
     fn test_generate_info_lines_config_read_error() {
+        // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
+        let _guard = crate::test_utils::lock_env();
         let config = default_prompt_config();
         let temp_file = tempfile::NamedTempFile::new().unwrap();
         let path = temp_file.path().to_path_buf();

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -556,6 +556,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_not_meta() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta("print(x)", &mut config, &None, &None, &status);
@@ -564,6 +566,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_reprex_toggle() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         assert!(!config.is_reprex_enabled());
@@ -579,6 +583,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_commands() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":commands", &mut config, &None, &None, &status);
@@ -591,6 +597,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_info() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":info", &mut config, &None, &None, &status);
@@ -603,6 +611,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_quit() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":quit", &mut config, &None, &None, &status);
@@ -614,6 +624,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_unknown() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":unknown", &mut config, &None, &None, &status);
@@ -622,6 +634,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_empty_colon() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":", &mut config, &None, &None, &status);
@@ -630,6 +644,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_with_whitespace() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta("  :reprex  ", &mut config, &None, &None, &status);
@@ -639,6 +655,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_shell_enter() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         assert!(!config.is_shell_enabled());
@@ -650,6 +668,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_shell_exit_with_r() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         config.set_shell(true);
@@ -662,6 +682,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_shell_exit_with_uppercase_r() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         config.set_shell(true);
@@ -674,6 +696,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_r_when_not_in_shell() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         assert!(!config.is_shell_enabled());
@@ -685,6 +709,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_system() {
+        // create_test_prompt_config and execute_shell_command read SHELL indirectly.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":system echo hello", &mut config, &None, &None, &status);
@@ -693,6 +719,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_system_empty() {
+        // create_test_prompt_config and execute_shell_command read SHELL indirectly.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta(":system", &mut config, &None, &None, &status);
@@ -702,6 +730,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_requires_rig() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
 
         // With PATH mode (rig not enabled), :switch should show error
@@ -750,7 +780,8 @@ mod tests {
 
     #[test]
     fn test_meta_cd_tilde() {
-        let _guard = crate::test_utils::lock_cwd();
+        // meta_cd reads HOME through dirs::home_dir and changes the cwd.
+        let _guard = crate::test_utils::lock_env_and_cwd();
         let result = meta_cd("~");
 
         assert!(result.is_ok());
@@ -764,7 +795,8 @@ mod tests {
 
     #[test]
     fn test_meta_cd_no_args() {
-        let _guard = crate::test_utils::lock_cwd();
+        // meta_cd reads HOME through dirs::home_dir and changes the cwd.
+        let _guard = crate::test_utils::lock_env_and_cwd();
         let result = meta_cd("");
 
         assert!(result.is_ok());
@@ -848,7 +880,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_cd() {
-        let _guard = crate::test_utils::lock_cwd();
+        // create_test_prompt_config reads SHELL; this test also changes the cwd.
+        let _guard = crate::test_utils::lock_env_and_cwd();
         let tmp = tempfile::tempdir().unwrap();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
@@ -869,7 +902,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_pushd_popd() {
-        let _guard = crate::test_utils::lock_cwd();
+        // create_test_prompt_config reads SHELL; this test also changes the cwd.
+        let _guard = crate::test_utils::lock_env_and_cwd();
         let tmp = tempfile::tempdir().unwrap();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
@@ -934,6 +968,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_restart_force() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         // :restart! should skip confirmation and return Restart directly
@@ -943,6 +979,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_restart_force_with_whitespace() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         let result = call_meta("  :restart!  ", &mut config, &None, &None, &status);
@@ -951,6 +989,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_force() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
@@ -962,6 +1002,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_force_accepts_space_after_colon() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
@@ -978,6 +1020,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_force_accepts_spaced_version_range() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
@@ -1001,6 +1045,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_force_preserves_named_version() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
@@ -1017,6 +1063,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_switch_force_no_version() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status_rig = RSourceStatus::Rig {
             version: "4.4.0".to_string(),
@@ -1029,6 +1077,8 @@ mod tests {
 
     #[test]
     fn test_process_meta_command_unknown_with_bang() {
+        // create_test_prompt_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_prompt_config();
         let status = default_r_source_status();
         // :shell! is not a valid command (! only supported on restart/switch)

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -636,6 +636,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_build_main_prompt() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let config = create_test_config(false, false);
         let prompt = config.build_main_prompt();
         assert_eq!(prompt.render_prompt_left(), "r> ");
@@ -643,6 +645,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_reprex_mode_indicator() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let config = create_test_config(true, false);
         let prompt = config.build_main_prompt();
         assert_eq!(prompt.render_prompt_left(), "[reprex] r> ");
@@ -650,6 +654,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_toggle_reprex() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_config(false, false);
 
         assert!(!config.is_reprex_enabled());
@@ -661,6 +667,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_set_reprex_with_comment() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_config(false, false);
 
         config.set_reprex(true, Some("## "));
@@ -670,6 +678,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_shell_mode_prompt() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_config(false, false);
 
         // Initially R mode prompt
@@ -694,6 +704,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_autoformat_mode_indicator() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_config(false, false);
 
         // Initially no indicator
@@ -728,6 +740,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_custom_autoformat_indicator() {
+        // create_test_config_with_indicators reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let indicators = Indicators {
             autoformat: "[AIR] ".to_string(),
             ..Indicators::default()
@@ -742,6 +756,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_cwd_placeholder_expansion() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         // Test that {cwd} and {cwd_short} placeholders are expanded dynamically
         let config = PromptRuntimeConfig::builder(
             PromptFormatter::default(),
@@ -770,7 +786,8 @@ mod tests {
 
     #[test]
     fn test_prompt_runtime_config_dynamic_cwd_update() {
-        let _guard = crate::test_utils::lock_cwd();
+        // PromptFormatter::new reads SHELL; the test also changes the cwd.
+        let _guard = crate::test_utils::lock_env_and_cwd();
 
         // Test that build_main_prompt() returns updated cwd after directory change
         let config =
@@ -817,6 +834,8 @@ mod tests {
 
     #[test]
     fn test_status_indicator_with_error_symbol() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let status_config = StatusConfig {
             symbol: StatusSymbol {
                 success: "".to_string(),
@@ -858,6 +877,8 @@ mod tests {
 
     #[test]
     fn test_status_indicator_with_empty_symbols() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         // Both symbols empty - equivalent to old mode=None
         let status_config = StatusConfig {
             symbol: StatusSymbol {
@@ -884,6 +905,8 @@ mod tests {
 
     #[test]
     fn test_status_without_placeholder() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         // Test that status config has no effect when {status} placeholder is absent
         let status_config = StatusConfig {
             symbol: StatusSymbol {
@@ -913,6 +936,8 @@ mod tests {
 
     #[test]
     fn test_status_override_prompt_color() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let status_config = StatusConfig {
             symbol: StatusSymbol {
                 success: "".to_string(),
@@ -955,6 +980,8 @@ mod tests {
 
     #[test]
     fn test_spinner_not_started_in_shell_mode() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         let mut config = create_test_config(false, false);
         config.set_shell(true);
         // In shell mode, start_spinner should be a no-op (no panic, etc.)
@@ -965,6 +992,8 @@ mod tests {
 
     #[test]
     fn test_spinner_not_started_with_empty_frames() {
+        // create_test_config reads SHELL through PromptFormatter::new.
+        let _guard = crate::test_utils::lock_env();
         // Create config with empty spinner frames (disabled by default)
         let config = create_test_config(false, false);
         // Should not panic when spinner is disabled
@@ -1010,6 +1039,8 @@ mod tests {
 
     #[test]
     fn test_duration_placeholder_below_threshold() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let mut config =
             PromptRuntimeConfig::builder(PromptFormatter::default(), "{duration}r> ", "+  ", "$ ")
                 .mode_indicator_position(ModeIndicatorPosition::None)
@@ -1024,6 +1055,8 @@ mod tests {
 
     #[test]
     fn test_duration_placeholder_above_threshold() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let mut config =
             PromptRuntimeConfig::builder(PromptFormatter::default(), "{duration}r> ", "+  ", "$ ")
                 .mode_indicator_position(ModeIndicatorPosition::None)
@@ -1047,6 +1080,8 @@ mod tests {
 
     #[test]
     fn test_duration_placeholder_no_data() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let config =
             PromptRuntimeConfig::builder(PromptFormatter::default(), "{duration}r> ", "+  ", "$ ")
                 .mode_indicator_position(ModeIndicatorPosition::None)
@@ -1059,6 +1094,8 @@ mod tests {
 
     #[test]
     fn test_clear_command_duration() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let mut config =
             PromptRuntimeConfig::builder(PromptFormatter::default(), "{duration}r> ", "+  ", "$ ")
                 .mode_indicator_position(ModeIndicatorPosition::None)
@@ -1082,6 +1119,8 @@ mod tests {
 
     #[test]
     fn test_duration_placeholder_not_present() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let mut config =
             PromptRuntimeConfig::builder(PromptFormatter::default(), "r> ", "+  ", "$ ")
                 .mode_indicator_position(ModeIndicatorPosition::None)
@@ -1095,6 +1134,8 @@ mod tests {
 
     #[test]
     fn test_duration_custom_threshold() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let duration_config = PromptDurationConfig {
             threshold_ms: 500,
             ..PromptDurationConfig::default()
@@ -1118,6 +1159,8 @@ mod tests {
 
     #[test]
     fn test_duration_custom_format() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let duration_config = PromptDurationConfig {
             format: "took {value} ".to_string(),
             threshold_ms: 2000,
@@ -1146,6 +1189,8 @@ mod tests {
 
     #[test]
     fn test_duration_format_with_brackets() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let duration_config = PromptDurationConfig {
             format: "({value}) ".to_string(),
             threshold_ms: 2000,
@@ -1169,6 +1214,8 @@ mod tests {
 
     #[test]
     fn test_duration_format_without_value_placeholder() {
+        // PromptFormatter::new reads SHELL while this test builds the formatter.
+        let _guard = crate::test_utils::lock_env();
         let duration_config = PromptDurationConfig {
             format: "slow! ".to_string(),
             threshold_ms: 2000,

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -3,6 +3,7 @@
 //! This module provides helpers for tests that need to coordinate
 //! access to process-global state like `current_dir`.
 
+use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
@@ -16,6 +17,20 @@ static CWD_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Process-global mutex for tests that modify environment variables.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Acquire the environment-variable lock for a group of mutations.
+///
+/// A single guard is useful because `lock_env_var` is not re-entrant:
+/// acquiring two `lock_env_var` guards in one test deadlocks on the
+/// process-global mutex. Use one `EnvGuard` and mutate all required
+/// variables through it instead.
+pub fn lock_env() -> EnvGuard {
+    let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    EnvGuard {
+        _lock: lock,
+        originals: BTreeMap::new(),
+    }
+}
 
 /// Acquire the cwd lock and save the current directory.
 ///
@@ -76,6 +91,53 @@ pub fn lock_env_var(name: &'static str, value: impl AsRef<OsStr>) -> EnvVarGuard
     }
 }
 
+/// RAII guard that holds the environment-variable mutex and restores every
+/// variable changed through this guard when it is dropped.
+pub struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    originals: BTreeMap<OsString, Option<OsString>>,
+}
+
+impl EnvGuard {
+    /// Set an environment variable, saving its original value if this is the
+    /// first mutation of the variable through this guard.
+    pub fn set(&mut self, name: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+        let name = name.as_ref().to_os_string();
+        self.originals
+            .entry(name.clone())
+            .or_insert_with(|| std::env::var_os(&name));
+        // SAFETY: Tests serialize access to these process-global variables.
+        unsafe { std::env::set_var(&name, value) };
+    }
+
+    /// Remove an environment variable, saving its original value if this is
+    /// the first mutation of the variable through this guard.
+    pub fn unset(&mut self, name: impl AsRef<OsStr>) {
+        let name = name.as_ref().to_os_string();
+        self.originals
+            .entry(name.clone())
+            .or_insert_with(|| std::env::var_os(&name));
+        // SAFETY: Tests serialize access to these process-global variables.
+        unsafe { std::env::remove_var(&name) };
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // BTreeMap keeps restoration order deterministic.
+        // SAFETY: Tests serialize access to these process-global variables.
+        unsafe {
+            for (name, original) in &self.originals {
+                if let Some(value) = original {
+                    std::env::set_var(name, value);
+                } else {
+                    std::env::remove_var(name);
+                }
+            }
+        }
+    }
+}
+
 /// RAII guard that holds the environment-variable mutex and restores the
 /// original value on drop.
 pub struct EnvVarGuard {
@@ -94,5 +156,105 @@ impl Drop for EnvVarGuard {
                 std::env::remove_var(self.name);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_env_restores_multiple_variables() {
+        let first = "ARF_TEST_UTILS_MULTIPLE_FIRST";
+        let second = "ARF_TEST_UTILS_MULTIPLE_SECOND";
+        let original_first = std::env::var_os(first);
+        let original_second = std::env::var_os(second);
+
+        {
+            let mut guard = lock_env();
+            guard.set(first, "changed-first");
+            guard.set(second, "changed-second");
+            assert_eq!(
+                std::env::var_os(first),
+                Some(OsString::from("changed-first"))
+            );
+            assert_eq!(
+                std::env::var_os(second),
+                Some(OsString::from("changed-second"))
+            );
+        }
+
+        assert_eq!(std::env::var_os(first), original_first);
+        assert_eq!(std::env::var_os(second), original_second);
+    }
+
+    #[test]
+    fn lock_env_restores_first_original_value_after_repeated_mutations() {
+        let name = "ARF_TEST_UTILS_REPEATED";
+        let original = std::env::var_os(name);
+
+        {
+            let mut guard = lock_env();
+            guard.set(name, "first-change");
+            guard.unset(name);
+            guard.set(name, "second-change");
+        }
+
+        assert_eq!(std::env::var_os(name), original);
+    }
+
+    #[test]
+    fn lock_env_supports_mixed_set_and_unset_mutations() {
+        let set_name = "ARF_TEST_UTILS_MIXED_SET";
+        let unset_name = "ARF_TEST_UTILS_MIXED_UNSET";
+        let original_set = std::env::var_os(set_name);
+        let original_unset = std::env::var_os(unset_name);
+
+        {
+            let mut guard = lock_env();
+            guard.set(set_name, "set-value");
+            guard.unset(unset_name);
+            assert_eq!(
+                std::env::var_os(set_name),
+                Some(OsString::from("set-value"))
+            );
+            assert_eq!(std::env::var_os(unset_name), None);
+        }
+
+        assert_eq!(std::env::var_os(set_name), original_set);
+        assert_eq!(std::env::var_os(unset_name), original_unset);
+    }
+
+    #[test]
+    fn lock_env_restores_a_variable_that_was_originally_unset() {
+        // This name is used by no other test and by no production code, so it
+        // is guaranteed to start out unset. Asserting that while holding the
+        // guard avoids the race a lock-then-unlock preamble would introduce.
+        let name = "ARF_TEST_UTILS_ORIGINALLY_UNSET";
+
+        {
+            let mut guard = lock_env();
+            assert_eq!(std::env::var_os(name), None);
+            guard.set(name, "temporary-value");
+        }
+
+        assert_eq!(std::env::var_os(name), None);
+    }
+
+    #[test]
+    fn lock_env_allows_mutating_two_variables_without_deadlocking() {
+        let first = "ARF_TEST_UTILS_NO_DEADLOCK_FIRST";
+        let second = "ARF_TEST_UTILS_NO_DEADLOCK_SECOND";
+        let original_first = std::env::var_os(first);
+        let original_second = std::env::var_os(second);
+
+        {
+            let mut guard = lock_env();
+            guard.set(first, "first-value");
+            guard.set(second, "second-value");
+        }
+
+        assert_eq!(std::env::var_os(first), original_first);
+        assert_eq!(std::env::var_os(second), original_second);
     }
 }

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -2,9 +2,17 @@
 //!
 //! This module provides helpers for tests that need to coordinate
 //! access to process-global state like `current_dir`.
+//!
+//! When a test needs both process-global locks, it must acquire the
+//! environment lock first and the cwd lock second. Two mutexes acquired in
+//! two different orders can deadlock: one test can hold the first mutex while
+//! waiting for the second, while another holds the second while waiting for
+//! the first. Use `lock_env_and_cwd()` to enforce this order structurally, and
+//! never acquire either lock separately while already holding the other.
 
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
@@ -21,7 +29,10 @@ static ENV_MUTEX: Mutex<()> = Mutex::new(());
 /// Acquire the environment-variable lock.
 ///
 /// Hold one `EnvGuard` for the duration of a test and mutate all required
-/// variables through it.
+/// variables through it. If the test also needs the cwd lock, use
+/// `lock_env_and_cwd()` instead. A test must never call `lock_cwd()` while it
+/// already holds an `EnvGuard`; the combined helper enforces the required
+/// environment-then-cwd order.
 pub fn lock_env() -> EnvGuard {
     let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     EnvGuard {
@@ -30,11 +41,35 @@ pub fn lock_env() -> EnvGuard {
     }
 }
 
+/// Acquire the environment and cwd locks in the required order.
+///
+/// The returned guard exposes the environment side through [`Self::env`].
+/// The cwd side is restored automatically when the combined guard is dropped.
+/// Use this helper whenever a test needs both locks so that their acquisition
+/// order cannot be reversed accidentally.
+/// This helper is currently unused, but exists to enforce the ordering policy
+/// structurally.
+#[allow(dead_code)]
+pub fn lock_env_and_cwd() -> EnvCwdGuard {
+    // Keep the acquisition order explicit: environment first, then cwd.
+    let env = lock_env();
+    let cwd = lock_cwd();
+    EnvCwdGuard {
+        env: Some(env),
+        cwd: Some(cwd),
+    }
+}
+
 /// Acquire the cwd lock and save the current directory.
 ///
 /// Returns a guard that restores the original directory on drop.
 /// Tests that call `set_current_dir` should use this instead of
 /// manually saving/restoring:
+///
+/// If the test also needs the environment lock, use `lock_env_and_cwd()`
+/// instead. A test must never call `lock_env()` while it already holds a
+/// `CwdGuard`; the combined helper enforces the required environment-then-cwd
+/// order.
 ///
 /// ```ignore
 /// let _guard = test_utils::lock_cwd();
@@ -55,6 +90,41 @@ pub fn lock_cwd() -> CwdGuard {
 pub struct CwdGuard {
     _lock: MutexGuard<'static, ()>,
     original: PathBuf,
+}
+
+/// RAII guard that holds both process-global test locks.
+pub struct EnvCwdGuard {
+    env: Option<EnvGuard>,
+    cwd: Option<CwdGuard>,
+}
+
+impl EnvCwdGuard {
+    /// Access the environment guard while the combined locks are held.
+    pub fn env(&mut self) -> &mut EnvGuard {
+        self.env
+            .as_mut()
+            .expect("combined test guard environment guard was already dropped")
+    }
+}
+
+impl Drop for EnvCwdGuard {
+    fn drop(&mut self) {
+        // Release in reverse acquisition order. Dropping CwdGuard first
+        // restores the directory while both locks are still held; dropping
+        // EnvGuard second then restores variables and releases ENV_MUTEX.
+        // Preserve a CwdGuard restoration panic until after EnvGuard has
+        // released ENV_MUTEX, so a failed restoration cannot strand that lock.
+        let cwd_panic = self
+            .cwd
+            .take()
+            .and_then(|cwd| catch_unwind(AssertUnwindSafe(|| drop(cwd))).err());
+        if let Some(env) = self.env.take() {
+            drop(env);
+        }
+        if let Some(payload) = cwd_panic {
+            resume_unwind(payload);
+        }
+    }
 }
 
 impl Drop for CwdGuard {
@@ -223,5 +293,35 @@ mod tests {
 
         assert_eq!(std::env::var_os(first), original_first);
         assert_eq!(std::env::var_os(second), original_second);
+    }
+
+    #[test]
+    fn lock_env_and_cwd_restores_both_after_combined_use() {
+        let name = "ARF_TEST_UTILS_COMBINED";
+        let original_value = std::env::var_os(name);
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let original_cwd = {
+            let mut guard = lock_env_and_cwd();
+            let original_cwd = std::env::current_dir().unwrap();
+
+            guard.env().set(name, "combined-value");
+            std::env::set_current_dir(temp_dir.path()).unwrap();
+
+            assert_eq!(
+                std::env::var_os(name),
+                Some(OsString::from("combined-value"))
+            );
+            // macOS resolves symlinks in getcwd, so canonicalize both sides.
+            assert_eq!(
+                std::env::current_dir().unwrap().canonicalize().ok(),
+                temp_dir.path().canonicalize().ok()
+            );
+
+            original_cwd
+        };
+
+        assert_eq!(std::env::var_os(name), original_value);
+        assert_eq!(std::env::current_dir().unwrap(), original_cwd);
     }
 }

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -53,7 +53,7 @@ pub fn lock_env() -> EnvGuard {
 
 /// Acquire the environment and cwd locks in the required order.
 ///
-/// The returned guard exposes the environment side through [`Self::env`].
+/// The returned guard exposes the environment side through [`EnvCwdGuard::env`].
 /// The cwd side is restored automatically when the combined guard is dropped.
 /// Use this helper whenever a test needs both locks so that their acquisition
 /// order cannot be reversed accidentally.

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -47,9 +47,6 @@ pub fn lock_env() -> EnvGuard {
 /// The cwd side is restored automatically when the combined guard is dropped.
 /// Use this helper whenever a test needs both locks so that their acquisition
 /// order cannot be reversed accidentally.
-/// This helper is currently unused, but exists to enforce the ordering policy
-/// structurally.
-#[allow(dead_code)]
 pub fn lock_env_and_cwd() -> EnvCwdGuard {
     // Keep the acquisition order explicit: environment first, then cwd.
     let env = lock_env();
@@ -204,8 +201,10 @@ mod tests {
     fn lock_env_restores_multiple_variables() {
         let first = "ARF_TEST_UTILS_MULTIPLE_FIRST";
         let second = "ARF_TEST_UTILS_MULTIPLE_SECOND";
-        let original_first = std::env::var_os(first);
-        let original_second = std::env::var_os(second);
+        let (original_first, original_second) = {
+            let _guard = lock_env();
+            (std::env::var_os(first), std::env::var_os(second))
+        };
 
         {
             let mut guard = lock_env();
@@ -221,6 +220,7 @@ mod tests {
             );
         }
 
+        let _guard = lock_env();
         assert_eq!(std::env::var_os(first), original_first);
         assert_eq!(std::env::var_os(second), original_second);
     }
@@ -228,8 +228,10 @@ mod tests {
     #[test]
     fn lock_env_restores_first_original_value_after_repeated_mutations() {
         let name = "ARF_TEST_UTILS_REPEATED";
-        let original = std::env::var_os(name);
-
+        let original = {
+            let _guard = lock_env();
+            std::env::var_os(name)
+        };
         {
             let mut guard = lock_env();
             guard.set(name, "first-change");
@@ -237,6 +239,7 @@ mod tests {
             guard.set(name, "second-change");
         }
 
+        let _guard = lock_env();
         assert_eq!(std::env::var_os(name), original);
     }
 
@@ -244,9 +247,10 @@ mod tests {
     fn lock_env_supports_mixed_set_and_unset_mutations() {
         let set_name = "ARF_TEST_UTILS_MIXED_SET";
         let unset_name = "ARF_TEST_UTILS_MIXED_UNSET";
-        let original_set = std::env::var_os(set_name);
-        let original_unset = std::env::var_os(unset_name);
-
+        let (original_set, original_unset) = {
+            let _guard = lock_env();
+            (std::env::var_os(set_name), std::env::var_os(unset_name))
+        };
         {
             let mut guard = lock_env();
             guard.set(set_name, "set-value");
@@ -258,6 +262,7 @@ mod tests {
             assert_eq!(std::env::var_os(unset_name), None);
         }
 
+        let _guard = lock_env();
         assert_eq!(std::env::var_os(set_name), original_set);
         assert_eq!(std::env::var_os(unset_name), original_unset);
     }
@@ -275,6 +280,7 @@ mod tests {
             guard.set(name, "temporary-value");
         }
 
+        let _guard = lock_env();
         assert_eq!(std::env::var_os(name), None);
     }
 
@@ -282,15 +288,17 @@ mod tests {
     fn lock_env_allows_mutating_two_variables_without_deadlocking() {
         let first = "ARF_TEST_UTILS_NO_DEADLOCK_FIRST";
         let second = "ARF_TEST_UTILS_NO_DEADLOCK_SECOND";
-        let original_first = std::env::var_os(first);
-        let original_second = std::env::var_os(second);
-
+        let (original_first, original_second) = {
+            let _guard = lock_env();
+            (std::env::var_os(first), std::env::var_os(second))
+        };
         {
             let mut guard = lock_env();
             guard.set(first, "first-value");
             guard.set(second, "second-value");
         }
 
+        let _guard = lock_env();
         assert_eq!(std::env::var_os(first), original_first);
         assert_eq!(std::env::var_os(second), original_second);
     }
@@ -298,13 +306,15 @@ mod tests {
     #[test]
     fn lock_env_and_cwd_restores_both_after_combined_use() {
         let name = "ARF_TEST_UTILS_COMBINED";
-        let original_value = std::env::var_os(name);
         let temp_dir = tempfile::tempdir().unwrap();
 
-        let original_cwd = {
-            let mut guard = lock_env_and_cwd();
-            let original_cwd = std::env::current_dir().unwrap();
+        let (original_value, original_cwd) = {
+            let _guard = lock_env_and_cwd();
+            (std::env::var_os(name), std::env::current_dir().unwrap())
+        };
 
+        {
+            let mut guard = lock_env_and_cwd();
             guard.env().set(name, "combined-value");
             std::env::set_current_dir(temp_dir.path()).unwrap();
 
@@ -317,10 +327,9 @@ mod tests {
                 std::env::current_dir().unwrap().canonicalize().ok(),
                 temp_dir.path().canonicalize().ok()
             );
+        }
 
-            original_cwd
-        };
-
+        let _guard = lock_env_and_cwd();
         assert_eq!(std::env::var_os(name), original_value);
         assert_eq!(std::env::current_dir().unwrap(), original_cwd);
     }

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -9,6 +9,16 @@
 //! waiting for the second, while another holds the second while waiting for
 //! the first. Use `lock_env_and_cwd()` to enforce this order structurally, and
 //! never acquire either lock separately while already holding the other.
+//!
+//! Known limitation: these locks cover the environment access a test performs
+//! itself, not every read that happens underneath it. `tempfile::tempdir()`,
+//! for instance, reaches `std::env::temp_dir()`, which reads `TMPDIR` on Unix,
+//! and that read is not serialized against a concurrent `set_var` elsewhere.
+//! Closing that hole would mean holding the environment lock across every
+//! temporary-directory creation in the suite, which would serialize almost all
+//! of it. The remaining risk is left uncovered deliberately; a test runner that
+//! gives each test its own process removes it outright, which is the direction
+//! being pursued separately.
 
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -279,10 +279,11 @@ mod tests {
 
     #[test]
     fn lock_env_restores_a_variable_that_was_originally_unset() {
-        // This name is used by no other test and by no production code, so it
-        // is guaranteed to start out unset. Asserting that while holding the
-        // guard avoids the race a lock-then-unlock preamble would introduce.
-        let name = "ARF_TEST_UTILS_ORIGINALLY_UNSET";
+        // Build the name at run time so it cannot have been inherited from the
+        // environment that started the test binary; the test would otherwise
+        // fail whenever someone happened to have that variable set.
+        let name = format!("ARF_TEST_UTILS_ORIGINALLY_UNSET_{}", std::process::id());
+        let name = name.as_str();
 
         {
             let mut guard = lock_env();

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -79,6 +79,11 @@ impl Drop for CwdGuard {
 
 /// Set an environment variable while holding a lock and restore its original
 /// value when the returned guard is dropped.
+///
+/// Superseded by [`lock_env`], which a test can hold once for any number of
+/// variables. Kept only until the remaining environment-dependent tests have
+/// been audited, then removed.
+#[allow(dead_code)]
 pub fn lock_env_var(name: &'static str, value: impl AsRef<OsStr>) -> EnvVarGuard {
     let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     let original = std::env::var_os(name);
@@ -93,6 +98,10 @@ pub fn lock_env_var(name: &'static str, value: impl AsRef<OsStr>) -> EnvVarGuard
 
 /// RAII guard that holds the environment-variable mutex and restores every
 /// variable changed through this guard when it is dropped.
+///
+/// Variable names are compared byte for byte, so on Windows `PATH` and `Path`
+/// are tracked as two separate variables even though the OS treats them as
+/// one. Use a single spelling per variable within one test.
 pub struct EnvGuard {
     _lock: MutexGuard<'static, ()>,
     originals: BTreeMap<OsString, Option<OsString>>,

--- a/crates/arf-console/src/test_utils.rs
+++ b/crates/arf-console/src/test_utils.rs
@@ -18,12 +18,10 @@ static CWD_MUTEX: Mutex<()> = Mutex::new(());
 /// Process-global mutex for tests that modify environment variables.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
-/// Acquire the environment-variable lock for a group of mutations.
+/// Acquire the environment-variable lock.
 ///
-/// A single guard is useful because `lock_env_var` is not re-entrant:
-/// acquiring two `lock_env_var` guards in one test deadlocks on the
-/// process-global mutex. Use one `EnvGuard` and mutate all required
-/// variables through it instead.
+/// Hold one `EnvGuard` for the duration of a test and mutate all required
+/// variables through it.
 pub fn lock_env() -> EnvGuard {
     let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     EnvGuard {
@@ -77,25 +75,6 @@ impl Drop for CwdGuard {
     }
 }
 
-/// Set an environment variable while holding a lock and restore its original
-/// value when the returned guard is dropped.
-///
-/// Superseded by [`lock_env`], which a test can hold once for any number of
-/// variables. Kept only until the remaining environment-dependent tests have
-/// been audited, then removed.
-#[allow(dead_code)]
-pub fn lock_env_var(name: &'static str, value: impl AsRef<OsStr>) -> EnvVarGuard {
-    let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-    let original = std::env::var_os(name);
-    // SAFETY: Tests serialize access to these process-global variables.
-    unsafe { std::env::set_var(name, value) };
-    EnvVarGuard {
-        _lock: lock,
-        name,
-        original,
-    }
-}
-
 /// RAII guard that holds the environment-variable mutex and restores every
 /// variable changed through this guard when it is dropped.
 ///
@@ -142,27 +121,6 @@ impl Drop for EnvGuard {
                 } else {
                     std::env::remove_var(name);
                 }
-            }
-        }
-    }
-}
-
-/// RAII guard that holds the environment-variable mutex and restores the
-/// original value on drop.
-pub struct EnvVarGuard {
-    _lock: MutexGuard<'static, ()>,
-    name: &'static str,
-    original: Option<OsString>,
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // SAFETY: Tests serialize access to these process-global variables.
-        unsafe {
-            if let Some(value) = &self.original {
-                std::env::set_var(self.name, value);
-            } else {
-                std::env::remove_var(self.name);
             }
         }
     }

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -41,6 +41,8 @@ use discovery::{parse_var_from_wrapper_script, set_r_path_vars_from_wrapper};
 use output::{format_error_output, strip_ansi_escapes, strip_cr};
 #[cfg(test)]
 use spinner::SPINNER_THREAD;
+#[cfg(test)]
+mod test_utils;
 
 use std::os::raw::{c_char, c_int};
 

--- a/crates/arf-libr/src/sys/test_utils.rs
+++ b/crates/arf-libr/src/sys/test_utils.rs
@@ -1,0 +1,46 @@
+use std::ffi::OsString;
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Holds the process-global environment lock and restores `R_DOC_DIR` on drop.
+///
+/// This guard is intentionally duplicated locally instead of being extracted
+/// into a shared crate: Rust builds each crate's tests into a separate binary,
+/// so a static mutex in a shared crate would not become one lock across crates.
+/// Every test binary links its own copy, so sharing would provide code reuse
+/// only and no additional safety. With one protected test in arf-libr, a new
+/// workspace member is not worth the manifest, ownership, and maintenance
+/// overhead. Revisit extraction once a third crate needs these guards, or once
+/// arf-libr grows several tests needing multi-variable or CWD handling.
+pub(crate) struct RDocDirGuard {
+    _lock: MutexGuard<'static, ()>,
+    original: Option<OsString>,
+}
+
+impl RDocDirGuard {
+    pub(crate) fn new(value: &str) -> Self {
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let original = std::env::var_os("R_DOC_DIR");
+
+        // SAFETY: Tests hold ENV_MUTEX while mutating this process-global variable.
+        unsafe { std::env::set_var("R_DOC_DIR", value) };
+
+        Self {
+            _lock: lock,
+            original,
+        }
+    }
+}
+
+impl Drop for RDocDirGuard {
+    fn drop(&mut self) {
+        // SAFETY: Tests hold ENV_MUTEX while restoring this process-global variable.
+        unsafe {
+            match &self.original {
+                Some(value) => std::env::set_var("R_DOC_DIR", value),
+                None => std::env::remove_var("R_DOC_DIR"),
+            }
+        }
+    }
+}

--- a/crates/arf-libr/src/sys/tests.rs
+++ b/crates/arf-libr/src/sys/tests.rs
@@ -313,12 +313,7 @@ fn test_parse_var_from_wrapper_script_no_partial_prefix_match() {
 
 #[test]
 fn test_set_r_path_vars_from_wrapper_skips_existing_env() {
-    // NOTE: This test mutates process-global env vars. It saves/restores
-    // R_DOC_DIR to minimise interference with parallel tests.
-    let original = std::env::var("R_DOC_DIR").ok();
-
-    // Pre-set R_DOC_DIR in the environment
-    unsafe { std::env::set_var("R_DOC_DIR", "/custom/doc") };
+    let _env_guard = super::test_utils::RDocDirGuard::new("/custom/doc");
 
     // Create a temp dir with a fake wrapper script (auto-cleaned on drop)
     let tmp = tempfile::tempdir().unwrap();
@@ -334,10 +329,4 @@ fn test_set_r_path_vars_from_wrapper_skips_existing_env() {
 
     // R_DOC_DIR should NOT be overwritten
     assert_eq!(std::env::var("R_DOC_DIR").unwrap(), "/custom/doc");
-
-    // Restore original value
-    match original {
-        Some(val) => unsafe { std::env::set_var("R_DOC_DIR", val) },
-        None => unsafe { std::env::remove_var("R_DOC_DIR") },
-    }
 }


### PR DESCRIPTION
Tests that touch process-global state were guarded three different ways: a mutex-backed guard in `test_utils`, a lockless `EnvVarGuard` duplicated in the CLI test module, and ad hoc `#[serial]`. The `test_utils` guard held its mutex for the lifetime of one variable's guard, so a test needing two variables deadlocked on the second acquisition — the reason the CLI module grew its own copy.

`test_utils` is now the only place environment mutation happens. `lock_env()` takes the lock once and returns a single `EnvGuard`; `set` and `unset` mutate any number of variables through it, each restored on drop to the value it had before that guard first touched it.

Read-only tests are guarded too: on Unix a concurrent `getenv` and `setenv` is undefined behavior even across different variables, so reads must be serialized along with writes. This includes tests that reach the environment through production code — `generate_info_lines` (`R_HOME`), `get_shell_name` (`SHELL`), and the history/masking helpers (`HOME`, `R_HISTFILE`, XDG variables).

Environment and cwd locks now have a fixed order — environment first — enforced by `lock_env_and_cwd()`, so a test needing both can't reverse it.

`arf-libr` gets its own guard instead of sharing one: each crate's tests build into a separate binary, so a static mutex in a shared crate wouldn't unify locking across crates — every binary links its own copy. One protected test doesn't justify a new workspace member; the guard's comment records that reasoning.

`#[serial]` drops from 25 to 8. The remaining eight protect state no guard covers — the `IN_ALTERNATE_MODE` and `R_IS_AT_PROMPT` atomics, the `PENDING_IPC_OPERATION` static, and the `SESSION_META` cache — each annotated with which, so the next reader doesn't have to guess if it's load-bearing.

One gap is left open, and documented: `tempfile::tempdir()` reaches `std::env::temp_dir()`, which reads `TMPDIR`. Closing it would mean holding the environment lock across every temporary-directory creation in the suite, serializing nearly all of it. A test runner that gives each test its own process would remove it outright; that's tracked separately.

No production code changes.

## Test plan

- [x] `cargo test --workspace` — 1223 passed, 0 failed
- [x] `cargo clippy --all-targets --workspace` — no warnings
- [x] `cargo fmt --check`
- [x] Suite run three times after removing `#[serial]` to check for order-dependent flakiness — identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
