### PR TITLE
fix: drop the xz codec so binaries stop linking system liblzma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Experimental/Breaking:** `arf ipc eval` now refuses R code unless every function it calls is allowlisted, so a program with access to the socket can no longer run arbitrary code in the session; literals and object references still evaluate without configuration. Allow calls with `[ipc.eval].allowed_functions` or `--ipc-eval-allow-function`, or opt out for a session with `--ipc-eval-unrestricted` at startup. The check is syntactic, not an R sandbox.
 - **Experimental/Breaking:** `arf ipc send` and `arf ipc eval --visible` now show the code and ask for confirmation before running it in an interactive REPL; `:ipc send-policy allow` suspends the prompt until arf restarts. Headless sessions run immediately, and the eval allowlist does not apply to either path.
 
+### Fixed
+
+- macOS binaries no longer fail to start with a missing `liblzma` library error.
+
 ## [0.4.5] - 2026-08-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,17 +1174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "rd-ast"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd34b9f48d1d7e4b54fcb38e191460edaac7bcef76685235394649868e7c728"
+checksum = "1271da631b9dbdeac3d23e1666c066164ec8eb620cb8504310a0bcd9948b4c0b"
 dependencies = [
  "rd-rds",
  "serde",
@@ -1651,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rd-helpdb"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306a2d0a2548c9a4eda615817d2f7d3ac74b886a632d178f5d973fe95572e0a1"
+checksum = "6116acd31bf38ad02d774c6f530336b1e3baba51b3f1b7e0d99339e22543479d"
 dependencies = [
  "flate2",
  "rd-rds",
@@ -1662,31 +1651,30 @@ dependencies = [
 
 [[package]]
 name = "rd-rds"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9007f260e5d0ff385c164391fe76162d0525ed7bc37650ff2066bc64ef4441a2"
+checksum = "17ee44999c4d2eee2b81696a21b12f1c47d7e13d3d709222f5e90ad51ca61200"
 dependencies = [
  "bzip2",
  "flate2",
  "ruzstd",
  "thiserror 2.0.19",
- "xz2",
 ]
 
 [[package]]
 name = "rd-source"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498b9c8e7c53b728a85178ca0dcf37c432c108f104bf236d743cd0a33be3a85f"
+checksum = "7820ec265c6daf795863a24a14f648b40f2f70327e641f404b3927047693dc13"
 dependencies = [
  "rd-ast",
 ]
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4cde9afc9d1458c1c5c54f2a29a8e8acae078b6fe9650be824236e7c4ddcc"
+checksum = "5b790fa2a3ec7463dc76158ed4dd6cf94b92e878046c3b30203b049d5ceda4e6"
 dependencies = [
  "rd-ast",
  "rd2qmd-mdast",
@@ -1698,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3069aab7f4fe35981f750c2145f367c35427559bcb03cd65b665f6b9a8954005"
+checksum = "55f11232a7184262dec723f0bc5a883689d3801107779fdce6dea84da9e07999"
 dependencies = [
  "serde",
 ]
@@ -1872,9 +1860,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -2978,15 +2966,6 @@ checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
  "markup5ever",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,15 @@ tree-sitter = "0.24"
 tree-sitter-r = "1.3"
 
 # Rd to Markdown conversion
-rd2qmd-core = "0.5.1"
-rd-source = "0.1"
-rd-helpdb = "0.1"
-rd-rds = "0.1"
-rd-ast = { version = "0.1", features = ["serde"] }
+rd2qmd-core = "0.5.2"
+rd-source = "0.3.1"
+# These three name their codecs because Cargo unions features: leaving any one
+# edge at its defaults re-enables every codec for the whole graph. xz is left
+# out because it links the system liblzma, which breaks the released macOS
+# binaries; reconsider once upstream ships a pure-Rust xz decoder.
+rd-helpdb = { version = "0.3.1", default-features = false, features = ["gzip", "bzip2", "zstd"] }
+rd-rds = { version = "0.3.1", default-features = false, features = ["gzip", "bzip2", "zstd"] }
+rd-ast = { version = "0.3.1", default-features = false, features = ["serde", "gzip", "bzip2", "zstd"] }
 
 # Markdown parsing
 pulldown-cmark = "0.13"


### PR DESCRIPTION
Released macOS binaries aborted at startup:

```
dyld: Library not loaded: /opt/homebrew/opt/xz/lib/liblzma.5.dylib
  Referenced from: ~/.cargo/bin/arf
```

`rd-rds` enables `gzip`, `xz`, `bzip2` and `zstd` by default, and its `xz` feature pulls in `xz2` and `lzma-sys`. That build script links the system liblzma dynamically whenever `pkg-config` finds one and neither its `static` feature nor `LZMA_API_STATIC` is set. The release builder had Homebrew's xz installed, so the published binary referenced a library most users do not have. Building from source worked only because the same library happened to be present locally.

The obvious fix was unavailable until now. `rd-helpdb` and `rd-ast` took `rd-rds` with default features enabled, and Cargo unions features across the graph, so disabling them on our own `rd-rds` edge did nothing. `rd2qmd-core` re-enabled them through `rd-ast` as well.

## What changed

Update to `r-documentation-rs` 0.3.1, which forwards the codec selection through `rd-helpdb` and `rd-ast` rather than enabling `rd-rds`'s defaults, and to `rd2qmd-core` 0.5.2, which disables `rd-ast`'s default features. Every edge into the codec set is now under this crate's control.

The codecs are then named explicitly on the `rd-rds`, `rd-helpdb` and `rd-ast` edges. All three are required: if any one of them keeps its defaults, every codec comes back for the whole graph.

`xz` is the only codec left out, because it is the only one that links a C library. `flate2` defaults to `miniz_oxide`, `bzip2` 0.6 defaults to `libbz2-rs-sys`, and `ruzstd` is pure Rust, so the other three cost nothing to keep. Upstream already has a pure-Rust xz decoder on main, though not in 0.3.1, so `xz` can come back once that ships.

## Why dropping xz is safe

The codec features have no effect on help text itself. That content lives in `<pkg>.rdb`, whose records are a raw zlib stream that `rd-helpdb` always decompresses through its own unconditional `flate2` dependency.

What the features do select is the set of compression envelopes accepted for standalone `.rds` files. Those are `help/<pkg>.rdx`, `help/aliases.rds`, and the `Meta/*.rds` indexes, all of which R's package installation tooling writes itself using gzip. A package author has no way to choose xz for them.

`.rds` files compressed with xz do exist, since `saveRDS()` accepts `compress = "xz"`, but they are data files rather than anything read here. This decision is worth revisiting if arf ever starts reading `.rds` files supplied by users.

## Notes

`ruzstd` moves from 0.8.3 to 0.9.0 because `rd-rds` 0.3.1 requires it. No source changes were necessary: upstream reports no breaking public API changes between 0.1.0 and 0.3.1 for the crates used here.

Fixes #302

## Test plan

- [x] `cargo tree -i lzma-sys` and `cargo tree -i xz2` both report no matching package, and neither remains in `Cargo.lock`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all suites pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Confirm a release binary starts on a macOS machine without Homebrew's xz installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
