### PR TITLE
chore: upgrade reedline to 0.50

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -662,7 +662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1006,18 +1006,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1261,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1589,7 +1589,7 @@ dependencies = [
  "lru",
  "palette",
  "serde",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1622,7 +1622,7 @@ dependencies = [
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum 0.28.0",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1715,20 +1715,20 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826c1fc22a2b1f14c3f6a80fc3d56adfbfb913d07f170bce4246700de7adfd50"
+checksum = "753088c970c4e63f91114d0dbef96c84fbaf3fde8943877f4254d33e97ce2193"
 dependencies = [
  "chrono",
  "crossterm",
  "fd-lock",
- "itertools 0.13.0",
+ "itertools 0.15.0",
  "nu-ansi-term",
  "rusqlite",
  "serde",
  "serde_json",
  "strip-ansi-escapes",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.19",
  "unicase",
  "unicode-segmentation",
@@ -1849,7 +1849,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1912,9 +1912,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1922,22 +1922,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2174,32 +2174,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2256,7 +2235,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm"]
 # NOTE: reedline and rusqlite share the `links = "sqlite3"` native library (via
 # libsqlite3-sys) and must be upgraded together in lockstep, or Cargo's
 # dependency resolution fails.
-reedline = { version = "0.49", features = ["sqlite", "idle_callback"] }
+reedline = { version = "0.50", features = ["sqlite", "idle_callback"] }
 
 # Configuration
 dirs = "6.0"

--- a/crates/arf-console/src/completion/completer.rs
+++ b/crates/arf-console/src/completion/completer.rs
@@ -4,7 +4,7 @@
 //! [`CombinedCompleter`] which dispatches to the appropriate sub-completer.
 
 use super::r_completer::RCompleter;
-use reedline::{Completer, Suggestion};
+use reedline::{Completer, CompletionResult};
 
 // Re-export so external code can keep using `crate::completion::completer::MetaCommandCompleter`.
 pub use super::meta::MetaCommandCompleter;
@@ -82,7 +82,9 @@ impl Default for CombinedCompleter {
 }
 
 impl Completer for CombinedCompleter {
-    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+    fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        // Both sub-completers are synchronous, so their result can be handed
+        // straight through; rebuilding it would only copy the shared list.
         if line.trim_start().starts_with(':') {
             self.meta_completer.complete(line, pos)
         } else {
@@ -99,6 +101,7 @@ mod tests {
     fn test_combined_completer_delegates_to_meta() {
         let mut completer = CombinedCompleter::new();
         let suggestions = completer.complete(":rep", 4);
+        let suggestions = suggestions.suggestions();
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].value, "reprex");
     }
@@ -107,6 +110,7 @@ mod tests {
     fn test_combined_completer_with_leading_whitespace() {
         let mut completer = CombinedCompleter::new();
         let suggestions = completer.complete("  :rep", 6);
+        let suggestions = suggestions.suggestions();
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].value, "reprex");
     }
@@ -116,6 +120,7 @@ mod tests {
         // CombinedCompleter is used in R mode, so `:r` should be excluded
         let mut completer = CombinedCompleter::new();
         let suggestions = completer.complete(":", 1);
+        let suggestions = suggestions.suggestions();
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(
             !values.contains(&"r"),

--- a/crates/arf-console/src/completion/menu.rs
+++ b/crates/arf-console/src/completion/menu.rs
@@ -75,6 +75,22 @@ impl Menu for FunctionAwareMenu {
         self.inner.is_active()
     }
 
+    fn set_active(&mut self, active: bool) {
+        self.inner.set_active(active);
+    }
+
+    fn clear_input(&mut self) {
+        self.inner.clear_input();
+    }
+
+    fn on_activate(&mut self) {
+        self.inner.on_activate();
+    }
+
+    fn handle_menu_event(&mut self, event: &MenuEvent) {
+        self.inner.handle_menu_event(event);
+    }
+
     fn menu_event(&mut self, event: MenuEvent) {
         self.inner.menu_event(event);
     }
@@ -153,6 +169,18 @@ impl Menu for FunctionAwareMenu {
         self.inner.get_values()
     }
 
+    fn reset_position(&mut self) {
+        self.inner.reset_position();
+    }
+
+    fn results_are_provisional(&self) -> bool {
+        self.inner.results_are_provisional()
+    }
+
+    fn is_awaiting_first_answer(&self) -> bool {
+        self.inner.is_awaiting_first_answer()
+    }
+
     fn menu_required_lines(&self, terminal_columns: u16) -> u16 {
         self.inner.menu_required_lines(terminal_columns)
     }
@@ -222,6 +250,18 @@ impl Menu for StateSyncHistoryMenu {
         self.inner.is_active()
     }
 
+    fn set_active(&mut self, active: bool) {
+        self.inner.set_active(active);
+    }
+
+    fn clear_input(&mut self) {
+        self.inner.clear_input();
+    }
+
+    fn handle_menu_event(&mut self, event: &MenuEvent) {
+        self.inner.handle_menu_event(event);
+    }
+
     fn menu_event(&mut self, event: MenuEvent) {
         self.inner.menu_event(event);
     }
@@ -283,6 +323,10 @@ impl Menu for StateSyncHistoryMenu {
 
     fn get_values(&self) -> &[Suggestion] {
         self.inner.get_values()
+    }
+
+    fn reset_position(&mut self) {
+        self.inner.reset_position();
     }
 
     fn menu_required_lines(&self, terminal_columns: u16) -> u16 {

--- a/crates/arf-console/src/completion/meta.rs
+++ b/crates/arf-console/src/completion/meta.rs
@@ -4,7 +4,7 @@ use super::path::PathCompletionOptions;
 use super::string_context::path_to_suggestions;
 use crate::external::rig;
 use crate::fuzzy::fuzzy_match;
-use reedline::{Completer, Span, Suggestion};
+use reedline::{Completer, CompletionResult, Span, Suggestion};
 
 /// Definition of a meta command for completion.
 struct MetaCommandDef {
@@ -552,8 +552,8 @@ impl Default for MetaCommandCompleter {
 }
 
 impl Completer for MetaCommandCompleter {
-    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        self.complete_commands(line, pos)
+    fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        CompletionResult::fresh(self.complete_commands(line, pos))
     }
 }
 
@@ -561,10 +561,18 @@ impl Completer for MetaCommandCompleter {
 mod tests {
     use super::*;
 
+    fn completion_suggestions(
+        completer: &mut MetaCommandCompleter,
+        line: &str,
+        pos: usize,
+    ) -> Vec<Suggestion> {
+        completer.complete(line, pos).suggestions().to_vec()
+    }
+
     #[test]
     fn test_meta_command_completer_empty_colon() {
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
         assert!(!suggestions.is_empty());
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(values.contains(&"shell"));
@@ -584,7 +592,7 @@ mod tests {
     #[test]
     fn test_meta_command_completer_partial_command() {
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":rep", 4);
+        let suggestions = completion_suggestions(&mut completer, ":rep", 4);
         assert_eq!(suggestions.len(), 1);
         assert_eq!(suggestions[0].value, "reprex");
     }
@@ -593,23 +601,23 @@ mod tests {
     fn test_meta_command_completer_no_subcommands() {
         let mut completer = MetaCommandCompleter::new();
         // All commands have no subcommands
-        let suggestions = completer.complete(":reprex ", 8);
+        let suggestions = completion_suggestions(&mut completer, ":reprex ", 8);
         assert!(suggestions.is_empty());
-        let suggestions = completer.complete(":commands ", 10);
+        let suggestions = completion_suggestions(&mut completer, ":commands ", 10);
         assert!(suggestions.is_empty());
     }
 
     #[test]
     fn test_meta_command_completer_not_meta_command() {
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete("print(x)", 8);
+        let suggestions = completion_suggestions(&mut completer, "print(x)", 8);
         assert!(suggestions.is_empty());
     }
 
     #[test]
     fn test_meta_command_completer_has_descriptions() {
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
         let reprex = suggestions.iter().find(|s| s.value == "reprex").unwrap();
         assert!(reprex.description.is_some());
         assert!(reprex.description.as_ref().unwrap().contains("reprex"));
@@ -619,7 +627,7 @@ mod tests {
     fn test_meta_command_completer_excludes_r_command() {
         // In R mode, `:r` should be excluded from completion
         let mut completer = MetaCommandCompleter::with_exclusions(vec!["r"]);
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(!values.contains(&"r"), "`:r` should be excluded in R mode");
         assert!(
@@ -633,7 +641,7 @@ mod tests {
         // In Shell mode, R-specific commands should be excluded from completion
         let mut completer =
             MetaCommandCompleter::with_exclusions(MetaCommandCompleter::shell_mode_exclusions());
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
 
         // These should be excluded in Shell mode
@@ -668,7 +676,7 @@ mod tests {
         // Even with partial match, excluded commands should not appear
         let mut completer = MetaCommandCompleter::with_exclusions(vec!["r"]);
         // Typing ":r" should not match excluded "r" command
-        let suggestions = completer.complete(":r", 2);
+        let suggestions = completion_suggestions(&mut completer, ":r", 2);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(
             !values.contains(&"r"),
@@ -685,7 +693,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // :switch takes an argument (R version)
-        let suggestions = completer.complete(":sw", 3);
+        let suggestions = completion_suggestions(&mut completer, ":sw", 3);
         let switch = suggestions.iter().find(|s| s.value == "switch").unwrap();
         assert!(
             switch.append_whitespace,
@@ -693,7 +701,7 @@ mod tests {
         );
 
         // :system takes an argument (shell command)
-        let suggestions = completer.complete(":sys", 4);
+        let suggestions = completion_suggestions(&mut completer, ":sys", 4);
         let system = suggestions.iter().find(|s| s.value == "system").unwrap();
         assert!(
             system.append_whitespace,
@@ -706,7 +714,7 @@ mod tests {
         // Commands that don't take arguments should have append_whitespace: false
         let mut completer = MetaCommandCompleter::new();
 
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
 
         // Commands without arguments
         for cmd_name in &[
@@ -737,7 +745,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // Typing ":rep" should match "reprex" and highlight positions 0,1,2
-        let suggestions = completer.complete(":rep", 4);
+        let suggestions = completion_suggestions(&mut completer, ":rep", 4);
         assert_eq!(suggestions.len(), 1);
         let reprex = &suggestions[0];
         assert_eq!(reprex.value, "reprex");
@@ -749,7 +757,7 @@ mod tests {
         // When just ":" is typed, no prefix to highlight
         let mut completer = MetaCommandCompleter::new();
 
-        let suggestions = completer.complete(":", 1);
+        let suggestions = completion_suggestions(&mut completer, ":", 1);
         assert!(!suggestions.is_empty());
         for suggestion in &suggestions {
             assert_eq!(
@@ -764,7 +772,7 @@ mod tests {
         // Single character fuzzy match - 'r' matches at different positions in different commands
         let mut completer = MetaCommandCompleter::new();
 
-        let suggestions = completer.complete(":r", 2);
+        let suggestions = completion_suggestions(&mut completer, ":r", 2);
         // With fuzzy matching, `:r` matches any command containing 'r':
         // - "r" at position 0
         // - "reprex" at position 0
@@ -801,7 +809,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // ":rst" should fuzzy match "restart"
-        let suggestions = completer.complete(":rst", 4);
+        let suggestions = completion_suggestions(&mut completer, ":rst", 4);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(
             values.contains(&"restart"),
@@ -823,7 +831,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // ":af" should fuzzy match "autoformat"
-        let suggestions = completer.complete(":af", 3);
+        let suggestions = completion_suggestions(&mut completer, ":af", 3);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(
             values.contains(&"autoformat"),
@@ -848,7 +856,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // ":cms" should match "cmds" - c=0, m=1, d=2, s=3
-        let suggestions = completer.complete(":cms", 4);
+        let suggestions = completion_suggestions(&mut completer, ":cms", 4);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(values.contains(&"cmds"), "`:cms` should fuzzy match `cmds`");
 
@@ -865,7 +873,7 @@ mod tests {
         let mut completer = MetaCommandCompleter::new();
 
         // ":xyz" should not match any command
-        let suggestions = completer.complete(":xyz", 4);
+        let suggestions = completion_suggestions(&mut completer, ":xyz", 4);
         assert!(
             suggestions.is_empty(),
             "`:xyz` should not match any command"
@@ -878,14 +886,14 @@ mod tests {
         // because they open an interactive help browser (no argument needed)
         let mut completer = MetaCommandCompleter::new();
 
-        let suggestions = completer.complete(":hel", 4);
+        let suggestions = completion_suggestions(&mut completer, ":hel", 4);
         let help = suggestions.iter().find(|s| s.value == "help").unwrap();
         assert!(
             !help.append_whitespace,
             "`:help` should NOT append whitespace"
         );
 
-        let suggestions = completer.complete(":h", 2);
+        let suggestions = completion_suggestions(&mut completer, ":h", 2);
         let h = suggestions.iter().find(|s| s.value == "h").unwrap();
         assert!(!h.append_whitespace, "`:h` should NOT append whitespace");
     }
@@ -901,7 +909,7 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":cd ", 4);
+        let suggestions = completion_suggestions(&mut completer, ":cd ", 4);
 
         // Should only contain directories (directories_only: true)
         assert!(!suggestions.is_empty(), "Should have directory completions");
@@ -930,7 +938,7 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":cd su", 6);
+        let suggestions = completion_suggestions(&mut completer, ":cd su", 6);
 
         assert!(
             suggestions.iter().any(|s| s.value == "subdir/"),
@@ -947,7 +955,7 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":pushd ", 7);
+        let suggestions = completion_suggestions(&mut completer, ":pushd ", 7);
 
         assert!(
             suggestions.iter().any(|s| s.value == "mydir/"),
@@ -959,7 +967,7 @@ mod tests {
     fn test_meta_popd_no_completion() {
         // ":popd " should NOT show path completions (takes no argument)
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":popd ", 6);
+        let suggestions = completion_suggestions(&mut completer, ":popd ", 6);
         assert!(
             suggestions.is_empty(),
             "popd should not have completions, got: {:?}",
@@ -977,7 +985,7 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":cd src/", 8);
+        let suggestions = completion_suggestions(&mut completer, ":cd src/", 8);
 
         assert!(
             suggestions.iter().any(|s| s.value == "src/inner/"),
@@ -992,7 +1000,7 @@ mod tests {
     fn test_meta_command_switch_bang_appears_in_completions() {
         let mut completer = MetaCommandCompleter::new();
         // ":sw" should fuzzy match both "switch" and "switch!"
-        let suggestions = completer.complete(":sw", 3);
+        let suggestions = completion_suggestions(&mut completer, ":sw", 3);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(values.contains(&"switch"), "should match :switch");
         assert!(values.contains(&"switch!"), "should match :switch!");
@@ -1009,7 +1017,7 @@ mod tests {
     fn test_meta_command_restart_bang_appears_in_completions() {
         let mut completer = MetaCommandCompleter::new();
         // ":restart" should fuzzy match both "restart" and "restart!"
-        let suggestions = completer.complete(":restart", 8);
+        let suggestions = completion_suggestions(&mut completer, ":restart", 8);
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(values.contains(&"restart"), "should match :restart");
         assert!(values.contains(&"restart!"), "should match :restart!");
@@ -1028,8 +1036,8 @@ mod tests {
         // Without rig installed, both return empty, but the key thing is they take
         // the same code path (not falling through to the default empty vec).
         let mut completer = MetaCommandCompleter::new();
-        let switch_suggestions = completer.complete(":switch ", 8);
-        let switch_bang_suggestions = completer.complete(":switch! ", 9);
+        let switch_suggestions = completion_suggestions(&mut completer, ":switch ", 8);
+        let switch_bang_suggestions = completion_suggestions(&mut completer, ":switch! ", 9);
         assert_eq!(
             switch_suggestions.len(),
             switch_bang_suggestions.len(),
@@ -1037,8 +1045,8 @@ mod tests {
         );
 
         // Partial version input should also work
-        let switch_partial = completer.complete(":switch 4", 9);
-        let switch_bang_partial = completer.complete(":switch! 4", 10);
+        let switch_partial = completion_suggestions(&mut completer, ":switch 4", 9);
+        let switch_bang_partial = completion_suggestions(&mut completer, ":switch! 4", 10);
         assert_eq!(
             switch_partial.len(),
             switch_bang_partial.len(),
@@ -1050,7 +1058,7 @@ mod tests {
     fn test_meta_command_switch_bang_no_subcommands_for_reprex() {
         // ":reprex " should have no subcommands (no false match from strip_suffix)
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":reprex ", 8);
+        let suggestions = completion_suggestions(&mut completer, ":reprex ", 8);
         assert!(suggestions.is_empty(), ":reprex should have no subcommands");
     }
 
@@ -1058,7 +1066,7 @@ mod tests {
     fn test_meta_command_history_bang_no_subcommands() {
         // ":history! " should NOT offer history subcommands (history! is not a valid command)
         let mut completer = MetaCommandCompleter::new();
-        let suggestions = completer.complete(":history! ", 10);
+        let suggestions = completion_suggestions(&mut completer, ":history! ", 10);
         assert!(
             suggestions.is_empty(),
             ":history! should not offer subcommands, got: {:?}",

--- a/crates/arf-console/src/completion/r_completer.rs
+++ b/crates/arf-console/src/completion/r_completer.rs
@@ -2,7 +2,7 @@
 
 use super::string_context::{complete_path_in_string, detect_string_context};
 use crate::fuzzy::fuzzy_match;
-use reedline::{Completer, Span, Suggestion};
+use reedline::{Completer, CompletionResult, Span, Suggestion};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
@@ -423,7 +423,13 @@ impl Default for RCompleter {
 }
 
 impl Completer for RCompleter {
-    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+    fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        CompletionResult::fresh(self.complete_impl(line, pos))
+    }
+}
+
+impl RCompleter {
+    fn complete_impl(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         // Check if we're inside a string - use Rust path completion with fuzzy matching
         // This provides better UX than R's built-in completion:
         // - Fuzzy matching: "rdm" matches "README.md"

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -6,7 +6,7 @@
 use super::meta::MetaCommandCompleter;
 use super::path::PathCompletionOptions;
 use super::string_context::path_to_suggestions;
-use reedline::{Completer, Span, Suggestion};
+use reedline::{Completer, CompletionResult, Span, Suggestion};
 
 /// Shell separators that start a new token.
 const TOKEN_SEPARATORS: &[char] = &['|', ';', '&', '<', '>'];
@@ -135,7 +135,13 @@ impl ShellCompleter {
 }
 
 impl Completer for ShellCompleter {
-    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+    fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        CompletionResult::fresh(self.complete_impl(line, pos))
+    }
+}
+
+impl ShellCompleter {
+    fn complete_impl(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let pos = pos.min(line.len());
         if !line.is_char_boundary(pos) {
             return vec![];
@@ -144,7 +150,11 @@ impl Completer for ShellCompleter {
 
         // Delegate meta commands to MetaCommandCompleter
         if trimmed.starts_with(':') {
-            return self.meta_completer.complete(line, pos);
+            return self
+                .meta_completer
+                .complete(line, pos)
+                .suggestions()
+                .to_vec();
         }
 
         // Find the current token start and extract the partial text
@@ -277,6 +287,7 @@ mod tests {
         let mut completer = ShellCompleter::new(false);
         // :cd is available in shell mode (not excluded)
         let suggestions = completer.complete(":c", 2);
+        let suggestions = suggestions.suggestions();
         assert!(
             suggestions.iter().any(|s| s.value == "cd"),
             "should suggest :cd for :c"
@@ -287,6 +298,7 @@ mod tests {
     fn test_shell_completer_excludes_shell_mode_meta_commands() {
         let mut completer = ShellCompleter::new(false);
         let suggestions = completer.complete(":", 1);
+        let suggestions = suggestions.suggestions();
         let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
         assert!(
             !values.contains(&"shell"),
@@ -302,6 +314,7 @@ mod tests {
     fn test_shell_completer_no_command_names_when_disabled() {
         let mut completer = ShellCompleter::new(false);
         let suggestions = completer.complete("", 0);
+        let suggestions = suggestions.suggestions();
         assert!(
             suggestions
                 .iter()
@@ -316,7 +329,8 @@ mod tests {
         let mut completer = ShellCompleter::new(false);
         // Completing after "cat " - any path suggestions should have span starting at 4
         let suggestions = completer.complete("cat /", 5);
-        for s in &suggestions {
+        let suggestions = suggestions.suggestions();
+        for s in suggestions {
             assert_eq!(s.span.start, 4, "span should start at the token start (4)");
         }
     }
@@ -395,6 +409,7 @@ mod tests {
         completer.command_cache = Some(collect_executables_from_path_str(&path_str));
 
         let suggestions = completer.complete("my", 2);
+        let suggestions = suggestions.suggestions();
         let cmd_values: Vec<&str> = suggestions
             .iter()
             .filter(|s| s.description.as_deref() == Some("command"))
@@ -420,6 +435,7 @@ mod tests {
 
         // "ls my" — cursor is in argument position, not command position
         let suggestions = completer.complete("ls my", 5);
+        let suggestions = suggestions.suggestions();
         let has_cmd = suggestions
             .iter()
             .any(|s| s.description.as_deref() == Some("command") && s.value == "mybin");


### PR DESCRIPTION
Upgrades reedline from 0.49 to 0.50 and absorbs the two breaking changes in that range. No user-visible behavior change, so there is no CHANGELOG entry. `rusqlite` is unaffected — reedline 0.50 still depends on 0.40.1, so the lockstep noted in `Cargo.toml` does not come into play.

## `Completer::complete` now returns `CompletionResult`

The return type changed from `Vec<Suggestion>` to an enum that can also express stale and pending results, holding the suggestions in a shared `Arc<[Suggestion]>`.

arf's completers are all synchronous, so each returns `CompletionResult::fresh` and keeps the default `poll_completion`, which reports `Idle`. Internals keep passing `Vec<Suggestion>` around and convert only at the trait boundary, which keeps the change small and leaves the existing tests meaningful. `CombinedCompleter` hands its sub-completer's result straight through rather than rebuilding it.

## `Menu` gained three required methods

`set_active`, `clear_input` and `reset_position` are now required, and both wrapper menus forward them.

The wrappers also forward some methods that come with a default, because a default on a wrapper answers about the wrapper rather than the menu it wraps. `FunctionAwareMenu` forwards `on_activate`, `handle_menu_event`, `results_are_provisional` and `is_awaiting_first_answer`, since `IdeMenu` overrides all four. `StateSyncHistoryMenu` forwards only `handle_menu_event`, since `ListMenu` overrides none of the others.

`Menu::settings` is left unforwarded because `MenuSettings` is not re-exported, so an external crate cannot name the return type. That looks like an upstream regression rather than a deliberate restriction.
It is exported in 0.48 and missing from 0.49 onward. The same gap makes `MenuBuilder` unimplementable outside the crate, since `settings_mut` names the type too.
Reporting it upstream is tracked separately.

Nothing breaks here in the meantime: reedline never calls `settings` on these menus, and its default body is reached only through `name` and `indicator`, which both wrappers already override.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 22 suites passing, no assertion semantics changed (the test edits are accessor plumbing only)
