### PR TITLE
fix!: persistent and volatile history storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- History storage now has explicit persistent and volatile modes. `--no-history` selects volatile in-memory history (including IPC and session recall) without loading or writing a database; persistent open failures degrade to a volatile fallback.
+- Legacy `history.disabled` is accepted with a migration warning: `true` maps to volatile, `false` maps to persistent, and an explicit `history.mode` takes priority when both are present.
+
 - Command history now records whether each entry was a meta command (`:cd`, `:help`, ...) as determined by the REPL itself, laying groundwork for excluding them from history search (#312).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - History storage now has explicit persistent and volatile modes. `--no-history` selects volatile in-memory history (including IPC and session recall) without loading or writing a database; persistent open failures degrade to a volatile fallback.
 - Legacy `history.disabled` is accepted with a migration warning: `true` maps to volatile, `false` maps to persistent, and an explicit `history.mode` takes priority when both are present.
+- Persistent history directories can be configured with `history.mode = { dir = "..." }`; the deprecated top-level `history.dir` is accepted only for migration with a warning.
 
 - Command history now records whether each entry was a meta command (`:cd`, `:help`, ...) as determined by the REPL itself, laying groundwork for excluding them from history search (#312).
 
@@ -244,7 +245,7 @@
 - Matching bracket highlighting: when cursor is on or after a bracket (`()`, `[]`, `{}`), both brackets are highlighted with a background color. Syntax-aware via tree-sitter (skips brackets in strings/comments). Configurable via `[editor] highlight_matching_bracket` (default: `false`) and `[colors.r] matching_bracket` (default: `"LightYellow"`) (#106)
 - R's `options(width)` is now synced with the terminal width at startup and dynamically on resize, configurable via `[r] auto_width` (default: `true`) (#104)
 - `:changelog` meta command to view the arf changelog in the built-in Markdown pager
-- `ARF_HISTORY_DIR` environment variable to override the history directory (priority: CLI `--history-dir` > `ARF_HISTORY_DIR` > TOML `[history] dir` > XDG default)
+- `ARF_HISTORY_DIR` environment variable to override the history directory (priority: CLI `--history-dir` > `ARF_HISTORY_DIR` > TOML `history.mode = { dir = "..." }` > XDG default)
 - Experimental fuzzy matching for `pkg::func` namespace patterns and `library()`/`require()` package name completions (`experimental.r_completion.fuzzy`)
 - Configurable `package_functions` for custom function names that trigger package completion (e.g., `box::use`)
 - `:restart!` and `:switch!` commands to skip confirmation prompt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Changed
 
 - History storage now has explicit persistent and volatile modes. `--no-history` selects volatile in-memory history (including IPC and session recall) without loading or writing a database; persistent open failures degrade to a volatile fallback.
-- Legacy `history.disabled` is accepted with a migration warning: `true` maps to volatile, `false` maps to persistent, and an explicit `history.mode` takes priority when both are present.
-- Persistent history directories can be configured with `history.mode = { dir = "..." }`; the deprecated top-level `history.dir` is accepted only for migration with a warning.
+- Legacy `history.disabled` and top-level `history.dir` are accepted with a migration warning when `history.mode` is omitted: `disabled = false` with `dir` preserves the custom persistent directory, while `disabled = true` selects volatile even when `dir` is present. With an explicit `mode`, legacy `disabled` is ignored in favor of that mode, but top-level `dir` is a parse error. Migrate to a string mode or `history.mode = { dir = "..." }`.
 
 - Command history now records whether each entry was a meta command (`:cd`, `:help`, ...) as determined by the REPL itself, laying groundwork for excluding them from history search (#312).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- History storage now has explicit persistent and volatile modes. `--no-history` selects volatile in-memory history (including IPC and session recall) without loading or writing a database; persistent open failures degrade to a volatile fallback.
+- History storage now has explicit persistent and volatile modes. `--no-history` selects volatile in-memory history (including IPC and session recall) without loading or writing a database; persistent open failures degrade to a volatile fallback. Fallback and unavailable runtimes retain and report their concrete initialization cause, including it as `history_runtime.detail` in headless JSON.
 - Legacy `history.disabled` and top-level `history.dir` are accepted with a migration warning when `history.mode` is omitted: `disabled = false` with `dir` preserves the custom persistent directory, while `disabled = true` selects volatile even when `dir` is present. With an explicit `mode`, legacy `disabled` is ignored in favor of that mode, but top-level `dir` is a parse error. Migrate to a string mode or `history.mode = { dir = "..." }`.
 
 - Command history now records whether each entry was a meta command (`:cd`, `:help`, ...) as determined by the REPL itself, laying groundwork for excluding them from history search (#312).

--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -97,7 +97,6 @@
     "history": {
       "$ref": "#/$defs/HistoryConfig",
       "default": {
-        "dir": null,
         "menu_max_height": 15,
         "mode": "persistent"
       }
@@ -1650,47 +1649,38 @@
       "type": "object",
       "properties": {
         "menu_max_height": {
-          "description": "Maximum height (rows) for the history search menu (Ctrl+R).\nThe actual height is the minimum of this value and the terminal height minus overhead.",
+          "description": "Maximum height (rows) for the history search menu (Ctrl+R).",
           "type": "integer",
           "format": "uint16",
           "default": 15,
           "maximum": 65535,
           "minimum": 0
-        }
-      },
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "dir": {
-              "type": [
-                "string",
-                "null"
-              ],
-              "default": null
-            },
-            "mode": {
-              "type": "string",
-              "const": "persistent"
-            }
-          },
-          "required": [
-            "mode"
-          ]
         },
-        {
-          "type": "object",
-          "properties": {
-            "mode": {
+        "mode": {
+          "default": "persistent",
+          "oneOf": [
+            {
               "type": "string",
-              "const": "volatile"
+              "enum": [
+                "persistent",
+                "volatile"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "dir": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "dir"
+              ]
             }
-          },
-          "required": [
-            "mode"
           ]
         }
-      ]
+      }
     },
     "HistoryForgetConfig": {
       "description": "Configuration for automatic removal of failed commands from history.",

--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -98,8 +98,8 @@
       "$ref": "#/$defs/HistoryConfig",
       "default": {
         "dir": null,
-        "disabled": false,
-        "menu_max_height": 15
+        "menu_max_height": 15,
+        "mode": "persistent"
       }
     },
     "ipc": {
@@ -1649,19 +1649,6 @@
       "description": "History configuration.",
       "type": "object",
       "properties": {
-        "dir": {
-          "description": "Custom history directory (overrides default XDG location).\nR history will be stored at `{dir}/r.db`, Shell at `{dir}/shell.db`.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null
-        },
-        "disabled": {
-          "description": "Disable history entirely.",
-          "type": "boolean",
-          "default": false
-        },
         "menu_max_height": {
           "description": "Maximum height (rows) for the history search menu (Ctrl+R).\nThe actual height is the minimum of this value and the terminal height minus overhead.",
           "type": "integer",
@@ -1670,7 +1657,40 @@
           "maximum": 65535,
           "minimum": 0
         }
-      }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "dir": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "mode": {
+              "type": "string",
+              "const": "persistent"
+            }
+          },
+          "required": [
+            "mode"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "volatile"
+            }
+          },
+          "required": [
+            "mode"
+          ]
+        }
+      ]
     },
     "HistoryForgetConfig": {
       "description": "Configuration for automatic removal of failed commands from history.",

--- a/crates/arf-console/src/app/commands.rs
+++ b/crates/arf-console/src/app/commands.rs
@@ -150,8 +150,7 @@ fn handle_history_import(
     // Required for actual imports and for dry-run with dedup (needs DB access)
     let history_dir = cli_history_dir
         .cloned()
-        .or(config.history.dir.clone())
-        .or_else(config::history_dir);
+        .or_else(|| config::history_dir_for_mode(&config.history.mode));
 
     // Determine source file path
     // Note: --from arf requires --file to avoid self-import (source = target)
@@ -382,8 +381,7 @@ fn handle_history_export(
     // Resolve effective history directory
     let history_dir = cli_history_dir
         .cloned()
-        .or(config.history.dir.clone())
-        .or_else(config::history_dir)
+        .or_else(|| config::history_dir_for_mode(&config.history.mode))
         .ok_or_else(|| anyhow::anyhow!("Could not determine history directory"))?;
 
     let r_path = history_dir.join("r.db");

--- a/crates/arf-console/src/app/config_load.rs
+++ b/crates/arf-console/src/app/config_load.rs
@@ -6,6 +6,11 @@ use crate::config::{
     load_config_from_path, load_config_from_path_with_provenance, mask_home_path,
 };
 
+fn report_history_migration_warning(warning: &str) {
+    eprintln!("Warning: {warning}");
+    log::warn!("{warning}");
+}
+
 /// A config load warning with stable machine-readable classification.
 #[derive(Debug)]
 pub(crate) struct ConfigLoadWarning {
@@ -29,7 +34,12 @@ pub(crate) fn load_config_with_fallback(
     };
 
     match result {
-        Ok(config) => (config, config_path, ConfigStatus::Ok),
+        Ok(mut config) => {
+            if let Some(warning) = config.history_migration_warning.take() {
+                report_history_migration_warning(&warning);
+            }
+            (config, config_path, ConfigStatus::Ok)
+        }
         Err(e) => {
             let (raw_path, masked_path, source_msg, status) = match &e {
                 ConfigLoadError::Read { path, source } => (
@@ -70,7 +80,12 @@ pub(crate) fn load_config_or_warn(config_path: Option<&std::path::PathBuf>) -> C
         load_config()
     };
     match result {
-        Ok(config) => config,
+        Ok(mut config) => {
+            if let Some(warning) = config.history_migration_warning.take() {
+                report_history_migration_warning(&warning);
+            }
+            config
+        }
         Err(e) => {
             let (path_display, source_msg) = match &e {
                 ConfigLoadError::Read { path, source } => {
@@ -104,7 +119,13 @@ pub(crate) fn load_config_collecting_warnings(
         load_config()
     };
     match result {
-        Ok(config) => config,
+        Ok(mut config) => {
+            if let Some(warning) = config.history_migration_warning.take() {
+                log::warn!("{warning}");
+                warnings.push(warning);
+            }
+            config
+        }
         Err(e) => {
             let (path_display, source_msg) = match &e {
                 ConfigLoadError::Read { path, source } => {
@@ -136,7 +157,22 @@ pub(crate) fn load_config_collecting_diagnostics(
     };
 
     match result {
-        Ok((config, provenance)) => (config, provenance),
+        Ok((mut config, provenance)) => {
+            let warning = config.history_migration_warning.take();
+            if let (Some(warning), Some(provenance)) = (&warning, provenance.as_ref()) {
+                log::warn!("{warning}");
+                warnings.push(ConfigLoadWarning {
+                    code: "config.history_disabled_deprecated",
+                    message: warning.clone(),
+                    path: provenance.path.clone(),
+                });
+            }
+            let provenance = provenance.map(|mut provenance| {
+                provenance.history_migration_warning = warning;
+                provenance
+            });
+            (config, provenance)
+        }
         Err(error) => {
             let (code, path, message) = match error {
                 ConfigLoadError::Read { path, source } => {
@@ -157,5 +193,45 @@ pub(crate) fn load_config_collecting_diagnostics(
             });
             (Config::default(), None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deprecated_history_disabled_is_collected_for_headless_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        std::fs::write(&path, "[history]\ndisabled = true\n").unwrap();
+        let mut warnings = Vec::new();
+        let config = load_config_collecting_warnings(Some(&path), &mut warnings);
+
+        assert!(matches!(
+            config.history.mode,
+            crate::config::HistoryMode::Volatile
+        ));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("history.mode = \"volatile\""));
+    }
+
+    #[test]
+    fn deprecated_history_disabled_has_a_stable_diagnostic_code() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        std::fs::write(&path, "[history]\ndisabled = false\n").unwrap();
+        let mut warnings = Vec::new();
+        let (_, provenance) = load_config_collecting_diagnostics(Some(&path), &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "config.history_disabled_deprecated");
+        assert!(
+            provenance
+                .unwrap()
+                .history_migration_warning
+                .unwrap()
+                .contains("persistent")
+        );
     }
 }

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -7,6 +7,7 @@ use crate::app::session_id::create_session_id;
 use crate::app::setup::{RSourceOverrideState, RSourceResolutionReport, setup_r};
 use crate::cli::RArgsBuilder;
 use crate::config;
+use crate::history::HistoryRuntime;
 use crate::ipc;
 use crate::ipc::session::{SessionInfo, SessionType};
 use crate::output::write_json;
@@ -32,8 +33,28 @@ struct HeadlessInfo {
     started_at: String,
     log_file: Option<String>,
     history_session_id: Option<i64>,
+    history_runtime: HeadlessHistoryRuntime,
     r_source_override: HeadlessRSourceOverride,
     warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HeadlessHistoryRuntime {
+    state: String,
+    path: Option<String>,
+    reason: Option<String>,
+}
+
+impl HeadlessHistoryRuntime {
+    fn from_runtime(runtime: &HistoryRuntime) -> Self {
+        Self {
+            state: runtime.state_name().to_string(),
+            path: runtime
+                .requested_path()
+                .map(|path| path.display().to_string()),
+            reason: runtime.reason_name().map(str::to_string),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -65,6 +86,7 @@ impl HeadlessRSourceOverride {
 impl HeadlessInfo {
     fn from_session(
         session: &SessionInfo,
+        history_runtime: &HistoryRuntime,
         warnings: Vec<String>,
         resolution: &RSourceResolutionReport,
     ) -> Self {
@@ -84,6 +106,7 @@ impl HeadlessInfo {
             started_at: session.started_at.clone(),
             log_file: session.log_file.clone(),
             history_session_id: session.history_session_id,
+            history_runtime: HeadlessHistoryRuntime::from_runtime(history_runtime),
             r_source_override: HeadlessRSourceOverride::from_report(resolution),
             warnings,
         }
@@ -204,49 +227,40 @@ pub(crate) fn run_headless(
     // Initialize the single history owner for headless mode. Volatile history
     // is still queryable through IPC during this process but never touches disk.
     let session_id = create_session_id(&config);
-    let mut session_id_raw = None;
-    if let Some(sid) = session_id {
-        let history_path = {
-            let dir = config::history_dir_for_mode(&config.history.mode);
-            dir.map(|d| d.join("r.db"))
-        };
-        let opened = if matches!(config.history.mode, crate::config::HistoryMode::Volatile) {
-            crate::history::HistoryStore::in_memory(Some(sid), Some(chrono::Utc::now()))
-        } else if let Some(path) = history_path.clone() {
-            crate::history::HistoryStore::open(path, Some(sid), Some(chrono::Utc::now()))
-        } else {
-            Err(reedline::ReedlineError(
-                reedline::ReedlineErrorVariants::HistoryDatabaseError(
-                    "no history directory available".to_string(),
-                ),
-            ))
-        };
-        match opened {
-            Ok(history) => {
-                ipc::set_headless_history(history);
-                session_id_raw = Some(i64::from(sid));
-                log::info!("Headless history enabled");
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to open history database: {}; using volatile fallback",
-                    e
-                );
-                match crate::history::HistoryStore::in_memory(Some(sid), Some(chrono::Utc::now())) {
-                    Ok(history) => {
-                        ipc::set_headless_history(history);
-                        session_id_raw = Some(i64::from(sid));
-                    }
-                    Err(fallback_error) => {
-                        log::warn!(
-                            "Failed to create volatile history fallback: {}",
-                            fallback_error
-                        );
-                    }
-                }
+    let history_path =
+        config::history_dir_for_mode(&config.history.mode).map(|dir| dir.join("r.db"));
+    let history_runtime = HistoryRuntime::initialize(
+        &config.history.mode,
+        history_path,
+        session_id,
+        Some(chrono::Utc::now()),
+    );
+    if let Some(history) = history_runtime.store() {
+        ipc::set_headless_history(history);
+        log::info!("Headless history runtime: {}", history_runtime.state_name());
+        if let Some(warning) = history_runtime.startup_warning() {
+            log::warn!("Headless history: {warning}");
+            if json {
+                warnings.push(warning);
+            } else {
+                eprintln!("Warning: Headless history: {warning}");
             }
         }
+    } else {
+        let warning = history_runtime
+            .startup_warning()
+            .unwrap_or_else(|| "history unavailable".to_string());
+        log::warn!("Headless history unavailable: {warning}");
+        if json {
+            warnings.push(warning);
+        } else {
+            eprintln!("Warning: Headless history unavailable: {warning}");
+        }
     }
+    let session_id_raw = history_runtime
+        .store()
+        .and_then(|store| store.session())
+        .map(i64::from);
 
     // Start IPC server (with optional custom bind path)
     let log_file_str = log_file.map(|p| {
@@ -303,7 +317,7 @@ pub(crate) fn run_headless(
 
     if json {
         // Output session info as JSON to stdout
-        let output = HeadlessInfo::from_session(&session, warnings, &resolution);
+        let output = HeadlessInfo::from_session(&session, &history_runtime, warnings, &resolution);
         // Use writeln + flush instead of println to ensure the JSON is
         // delivered immediately when stdout is piped (non-TTY). This is the
         // readiness signal for CI scripts waiting on the output.
@@ -475,6 +489,8 @@ mod tests {
 
     #[test]
     fn headless_json_includes_r_home_from_session() {
+        let history_runtime =
+            HistoryRuntime::initialize(&crate::config::HistoryMode::Volatile, None, None, None);
         let mut session = SessionInfo {
             pid: 12345,
             socket_path: "/tmp/arf.sock".to_string(),
@@ -489,20 +505,96 @@ mod tests {
 
         let output = HeadlessInfo::from_session(
             &session,
+            &history_runtime,
             Vec::new(),
             &report(RSourceOverrideState::NotConfigured),
         );
         let json = serde_json::to_value(output).unwrap();
         assert_eq!(json["r_home"], "/opt/R/4.4.1/lib/R");
+        assert_eq!(json["history_runtime"]["state"], "volatile");
+        assert_eq!(json["history_runtime"]["reason"], "configured");
 
         session.r_home = None;
         let output = HeadlessInfo::from_session(
             &session,
+            &history_runtime,
             Vec::new(),
             &report(RSourceOverrideState::NotConfigured),
         );
         let json = serde_json::to_value(output).unwrap();
         assert!(json["r_home"].is_null());
+    }
+
+    #[test]
+    fn headless_history_runtime_uses_stable_reason_and_separate_path() {
+        use crate::history::{
+            HistoryHandle, HistorySaveReceipt, HistoryStore, VolatileHistoryReason,
+        };
+
+        let store = HistoryStore::in_memory(None, None).unwrap();
+        let handle = || HistoryHandle {
+            store: store.clone(),
+            receipt: HistorySaveReceipt::new(),
+        };
+        let configured = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Configured,
+        };
+        let fallback = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Fallback {
+                requested_path: Some("/tmp/history.db".into()),
+            },
+        };
+        let fallback_without_path = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Fallback {
+                requested_path: None,
+            },
+        };
+        let unavailable = HistoryRuntime::Unavailable {
+            requested_path: Some("/tmp/history.db".into()),
+        };
+        let persistent_dir = tempfile::tempdir().unwrap();
+        let persistent_path = persistent_dir.path().join("history.db");
+        let persistent = HistoryRuntime::Persistent(HistoryHandle {
+            store: HistoryStore::open(persistent_path.clone(), None, None).unwrap(),
+            receipt: HistorySaveReceipt::new(),
+        });
+
+        assert!(configured.startup_warning().is_none());
+        assert!(fallback.startup_warning().is_some());
+        assert!(unavailable.startup_warning().is_some());
+        let persistent_json =
+            serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&persistent)).unwrap();
+        assert_eq!(persistent_json["state"], "persistent");
+        assert!(persistent_json["reason"].is_null());
+        assert_eq!(
+            persistent_json["path"],
+            persistent_path.display().to_string()
+        );
+
+        let configured_json =
+            serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&configured)).unwrap();
+        assert_eq!(configured_json["state"], "volatile");
+        assert_eq!(configured_json["reason"], "configured");
+        assert!(configured_json["path"].is_null());
+
+        let fallback_json =
+            serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&fallback)).unwrap();
+        assert_eq!(fallback_json["reason"], "fallback");
+        assert_eq!(fallback_json["path"], "/tmp/history.db");
+        let no_path_json =
+            serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&fallback_without_path))
+                .unwrap();
+        assert_eq!(no_path_json["reason"], "fallback");
+        assert!(no_path_json["path"].is_null());
+
+        let unavailable_json =
+            serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&unavailable)).unwrap();
+        assert_eq!(unavailable_json["state"], "unavailable");
+        assert_eq!(unavailable_json["reason"], "initialization_failed");
+        assert_eq!(unavailable_json["path"], "/tmp/history.db");
     }
 
     #[test]

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -43,6 +43,7 @@ struct HeadlessHistoryRuntime {
     state: String,
     path: Option<String>,
     reason: Option<String>,
+    detail: Option<String>,
 }
 
 impl HeadlessHistoryRuntime {
@@ -53,6 +54,7 @@ impl HeadlessHistoryRuntime {
                 .requested_path()
                 .map(|path| path.display().to_string()),
             reason: runtime.reason_name().map(str::to_string),
+            detail: runtime.diagnostic_detail(),
         }
     }
 }
@@ -528,7 +530,8 @@ mod tests {
     #[test]
     fn headless_history_runtime_uses_stable_reason_and_separate_path() {
         use crate::history::{
-            HistoryHandle, HistorySaveReceipt, HistoryStore, VolatileHistoryReason,
+            HistoryFailureDetail, HistoryHandle, HistorySaveReceipt, HistoryStore,
+            VolatileHistoryReason,
         };
 
         let store = HistoryStore::in_memory(None, None).unwrap();
@@ -543,17 +546,22 @@ mod tests {
         let fallback = HistoryRuntime::Volatile {
             handle: handle(),
             reason: VolatileHistoryReason::Fallback {
-                requested_path: Some("/tmp/history.db".into()),
+                persistent_failure: HistoryFailureDetail::test_persistent_open(
+                    "/tmp/history.db".into(),
+                ),
             },
         };
         let fallback_without_path = HistoryRuntime::Volatile {
             handle: handle(),
             reason: VolatileHistoryReason::Fallback {
-                requested_path: None,
+                persistent_failure: HistoryFailureDetail::test_path_resolution(),
             },
         };
         let unavailable = HistoryRuntime::Unavailable {
-            requested_path: Some("/tmp/history.db".into()),
+            failure: HistoryFailureDetail::test_memory(),
+            previous_failure: Some(HistoryFailureDetail::test_persistent_open(
+                "/tmp/history.db".into(),
+            )),
         };
         let persistent_dir = tempfile::tempdir().unwrap();
         let persistent_path = persistent_dir.path().join("history.db");
@@ -579,11 +587,13 @@ mod tests {
         assert_eq!(configured_json["state"], "volatile");
         assert_eq!(configured_json["reason"], "configured");
         assert!(configured_json["path"].is_null());
+        assert!(configured_json["detail"].is_null());
 
         let fallback_json =
             serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&fallback)).unwrap();
         assert_eq!(fallback_json["reason"], "fallback");
         assert_eq!(fallback_json["path"], "/tmp/history.db");
+        assert!(!fallback_json["detail"].as_str().unwrap().is_empty());
         let no_path_json =
             serde_json::to_value(HeadlessHistoryRuntime::from_runtime(&fallback_without_path))
                 .unwrap();
@@ -595,6 +605,12 @@ mod tests {
         assert_eq!(unavailable_json["state"], "unavailable");
         assert_eq!(unavailable_json["reason"], "initialization_failed");
         assert_eq!(unavailable_json["path"], "/tmp/history.db");
+        assert!(
+            unavailable_json["detail"]
+                .as_str()
+                .unwrap()
+                .contains("memory initialization failure")
+        );
     }
 
     #[test]

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -20,8 +20,8 @@ use serde::Serialize;
 ///
 /// Contains session connection info and any warnings collected during startup.
 /// All keys are always present in the JSON output; `r_version`, `r_home`, `log_file`,
-/// and `history_session_id` may be `null`. `warnings` is an array that may be
-/// empty.
+/// and `history_session_id` may be `null` only when history initialization is
+/// unavailable. `warnings` is an array that may be empty.
 #[derive(Debug, Serialize)]
 struct HeadlessInfo {
     pid: u32,
@@ -190,38 +190,59 @@ pub(crate) fn run_headless(
 
     // Apply CLI history overrides (same logic as the REPL path in main())
     if no_history {
-        config.history.disabled = true;
+        config.history.mode = crate::config::HistoryMode::Volatile;
     } else if let Some(history_dir) = cli_history_dir {
-        config.history.dir = Some(history_dir.to_path_buf());
+        config.history.mode = crate::config::HistoryMode::Persistent {
+            dir: Some(history_dir.to_path_buf()),
+        };
     }
 
     let mut eval_allowlist = config.ipc.eval.allowed_functions.clone();
     eval_allowlist.extend(ipc_eval_allow_function.iter().cloned());
     ipc::policy::set_policy(eval_allowlist, ipc_eval_unrestricted);
 
-    // Initialize history for headless mode (same SQLite database as the REPL).
-    // Only advertise history_session_id to IPC if the backend was actually opened.
+    // Initialize the single history owner for headless mode. Volatile history
+    // is still queryable through IPC during this process but never touches disk.
     let session_id = create_session_id(&config);
     let mut session_id_raw = None;
     if let Some(sid) = session_id {
         let history_path = {
-            let dir = config.history.dir.clone().or_else(config::history_dir);
+            let dir = config::history_dir_for_mode(&config.history.mode);
             dir.map(|d| d.join("r.db"))
         };
-        if let Some(path) = history_path {
-            match crate::history::HistoryStore::open(
-                path.clone(),
-                Some(sid),
-                Some(chrono::Utc::now()),
-            ) {
-                Ok(history) => {
-                    ipc::set_headless_history(history);
-                    ipc::set_history_db_info(path.clone(), Some(sid));
-                    session_id_raw = Some(i64::from(sid));
-                    log::info!("Headless history enabled: {}", path.display());
-                }
-                Err(e) => {
-                    log::warn!("Failed to open history database {}: {}", path.display(), e);
+        let opened = if matches!(config.history.mode, crate::config::HistoryMode::Volatile) {
+            crate::history::HistoryStore::in_memory(Some(sid), Some(chrono::Utc::now()))
+        } else if let Some(path) = history_path.clone() {
+            crate::history::HistoryStore::open(path, Some(sid), Some(chrono::Utc::now()))
+        } else {
+            Err(reedline::ReedlineError(
+                reedline::ReedlineErrorVariants::HistoryDatabaseError(
+                    "no history directory available".to_string(),
+                ),
+            ))
+        };
+        match opened {
+            Ok(history) => {
+                ipc::set_headless_history(history);
+                session_id_raw = Some(i64::from(sid));
+                log::info!("Headless history enabled");
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to open history database: {}; using volatile fallback",
+                    e
+                );
+                match crate::history::HistoryStore::in_memory(Some(sid), Some(chrono::Utc::now())) {
+                    Ok(history) => {
+                        ipc::set_headless_history(history);
+                        session_id_raw = Some(i64::from(sid));
+                    }
+                    Err(fallback_error) => {
+                        log::warn!(
+                            "Failed to create volatile history fallback: {}",
+                            fallback_error
+                        );
+                    }
                 }
             }
         }

--- a/crates/arf-console/src/app/session_id.rs
+++ b/crates/arf-console/src/app/session_id.rs
@@ -1,23 +1,13 @@
 //! Reedline history session ID creation.
 
-use crate::config;
 use crate::config::Config;
 use reedline::Reedline;
 
-/// Generate a history session ID when history is enabled and a history directory
-/// is available, or `None` otherwise.
+/// Generate a session ID for both persistent and volatile history.
 ///
-/// This ensures IPC/session JSON does not misleadingly advertise history isolation
-/// when no history backend is configured.
-pub(crate) fn create_session_id(config: &Config) -> Option<reedline::HistorySessionId> {
-    if config.history.disabled {
-        return None;
-    }
-    // Check that a history directory is actually resolvable, matching the logic
-    // in Repl::r_history_path() / shell_history_path().
-    if config.history.dir.is_none() && config::history_dir().is_none() {
-        return None;
-    }
+/// Volatile history still needs session isolation while the process is alive;
+/// it simply does not use the ID to read or write a file.
+pub(crate) fn create_session_id(_config: &Config) -> Option<reedline::HistorySessionId> {
     Reedline::create_history_session_id()
 }
 
@@ -29,8 +19,9 @@ mod session_id_tests {
     fn test_create_session_id_when_history_enabled() {
         let mut config = Config::default();
         // Ensure a history dir is available by setting it explicitly
-        config.history.dir = Some(std::env::temp_dir());
-        assert!(!config.history.disabled);
+        config.history.mode = crate::config::HistoryMode::Persistent {
+            dir: Some(std::env::temp_dir()),
+        };
         let id = create_session_id(&config);
         assert!(
             id.is_some(),
@@ -39,25 +30,24 @@ mod session_id_tests {
     }
 
     #[test]
-    fn test_create_session_id_when_history_disabled() {
+    fn test_create_session_id_when_history_volatile() {
         let mut config = Config::default();
-        config.history.disabled = true;
+        config.history.mode = crate::config::HistoryMode::Volatile;
         let id = create_session_id(&config);
-        assert!(id.is_none(), "should be None when history is disabled");
+        assert!(id.is_some(), "volatile history still has a session ID");
     }
 
     #[test]
-    fn test_create_session_id_respects_default_history_dir() {
-        // create_session_id reads HOME/XDG variables indirectly through history_dir.
+    fn test_create_session_id_is_independent_of_history_directory() {
         let _guard = crate::test_utils::lock_env();
-        // With default config (history.dir = None), session ID depends on
-        // whether the platform provides a data directory via history_dir().
+        // Session IDs are independent of the persistent directory.
         let config = Config::default();
-        assert!(!config.history.disabled);
-        assert!(config.history.dir.is_none());
+        assert!(matches!(
+            config.history.mode,
+            crate::config::HistoryMode::Persistent { dir: None }
+        ));
         let id = create_session_id(&config);
-        // On most platforms history_dir() returns Some, so session ID is generated.
-        // On exotic platforms where it returns None, session ID should be None.
-        assert_eq!(id.is_some(), config::history_dir().is_some());
+        // Session IDs are generated independently of the configured directory.
+        assert!(id.is_some());
     }
 }

--- a/crates/arf-console/src/cli/history.rs
+++ b/crates/arf-console/src/cli/history.rs
@@ -21,7 +21,7 @@ pub(crate) enum HistoryAction {
         from: ImportSource,
 
         /// Path to the history file/database to import.
-        /// Defaults: radian=~/.radian_history, r=.Rhistory, arf=history.dir/r.db
+        /// Defaults: radian=~/.radian_history, r=.Rhistory, arf=persistent history `dir`/r.db
         #[arg(long, value_hint = ValueHint::FilePath)]
         file: Option<PathBuf>,
 

--- a/crates/arf-console/src/cli/shared.rs
+++ b/crates/arf-console/src/cli/shared.rs
@@ -111,7 +111,7 @@ pub struct HistoryOptions {
     /// R history is stored at `{dir}/r.db`. The interactive console also
     /// stores shell history at `{dir}/shell.db`.
     ///
-    /// Config: history.mode = "persistent" and its `dir` field
+    /// Config: history.mode = { dir = "..." }
     #[arg(
         long = "history-dir",
         value_hint = ValueHint::DirPath,

--- a/crates/arf-console/src/cli/shared.rs
+++ b/crates/arf-console/src/cli/shared.rs
@@ -111,7 +111,7 @@ pub struct HistoryOptions {
     /// R history is stored at `{dir}/r.db`. The interactive console also
     /// stores shell history at `{dir}/shell.db`.
     ///
-    /// Config: history.dir
+    /// Config: history.mode = "persistent" and its `dir` field
     #[arg(
         long = "history-dir",
         value_hint = ValueHint::DirPath,
@@ -121,9 +121,9 @@ pub struct HistoryOptions {
     )]
     pub history_dir: Option<PathBuf>,
 
-    /// Disable history (no history saved or loaded)
+    /// Keep history only in memory for this session (no history loaded or saved)
     ///
-    /// Config: history.disabled
+    /// Overrides config: history.mode = "volatile"
     #[arg(long = "no-history", hide_short_help = true)]
     pub no_history: bool,
 }

--- a/crates/arf-console/src/config/history.rs
+++ b/crates/arf-console/src/config/history.rs
@@ -1,33 +1,93 @@
 //! History configuration.
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 
+/// Where command history is kept for the duration of a process.
+///
+/// `volatile` deliberately keeps history in an arf-owned in-memory SQLite
+/// store. It never reads or writes the configured history directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+pub enum HistoryMode {
+    Persistent {
+        #[serde(default)]
+        dir: Option<PathBuf>,
+    },
+    Volatile,
+}
+
+impl HistoryMode {
+    /// Return the configured directory when persistence is selected.
+    pub fn persistent_dir(&self) -> Option<&PathBuf> {
+        match self {
+            Self::Persistent { dir } => dir.as_ref(),
+            Self::Volatile => None,
+        }
+    }
+}
+
 /// History configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(default)]
 pub struct HistoryConfig {
     /// Maximum height (rows) for the history search menu (Ctrl+R).
     /// The actual height is the minimum of this value and the terminal height minus overhead.
     pub menu_max_height: u16,
 
-    /// Disable history entirely.
-    #[serde(default)]
-    pub disabled: bool,
+    /// Keep history only for the current process; do not load or save a file.
+    #[serde(flatten)]
+    pub mode: HistoryMode,
+}
 
-    /// Custom history directory (overrides default XDG location).
-    /// R history will be stored at `{dir}/r.db`, Shell at `{dir}/shell.db`.
-    #[serde(default)]
-    pub dir: Option<PathBuf>,
+impl<'de> Deserialize<'de> for HistoryConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawHistoryConfig {
+            #[serde(default = "default_menu_max_height")]
+            menu_max_height: u16,
+            mode: Option<String>,
+            #[serde(default)]
+            dir: Option<PathBuf>,
+            #[serde(default)]
+            disabled: Option<bool>,
+        }
+
+        let raw = RawHistoryConfig::deserialize(deserializer)?;
+        let mode = match (raw.mode, raw.disabled) {
+            (Some(mode), _) => match mode.as_str() {
+                "persistent" => HistoryMode::Persistent { dir: raw.dir },
+                "volatile" => HistoryMode::Volatile,
+                _ => {
+                    return Err(serde::de::Error::unknown_variant(
+                        &mode,
+                        &["persistent", "volatile"],
+                    ));
+                }
+            },
+            (None, Some(true)) => HistoryMode::Volatile,
+            (None, Some(false)) | (None, None) => HistoryMode::Persistent { dir: raw.dir },
+        };
+        Ok(Self {
+            menu_max_height: raw.menu_max_height,
+            mode,
+        })
+    }
+}
+
+fn default_menu_max_height() -> u16 {
+    15
 }
 
 impl Default for HistoryConfig {
     fn default() -> Self {
         HistoryConfig {
             menu_max_height: 15,
-            disabled: false,
-            dir: None,
+            mode: HistoryMode::Persistent { dir: None },
         }
     }
 }

--- a/crates/arf-console/src/config/history.rs
+++ b/crates/arf-console/src/config/history.rs
@@ -1,20 +1,16 @@
 //! History configuration.
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 
 /// Where command history is kept for the duration of a process.
 ///
 /// `volatile` deliberately keeps history in an arf-owned in-memory SQLite
 /// store. It never reads or writes the configured history directory.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "mode", rename_all = "lowercase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HistoryMode {
-    Persistent {
-        #[serde(default)]
-        dir: Option<PathBuf>,
-    },
+    Persistent { dir: Option<PathBuf> },
     Volatile,
 }
 
@@ -29,16 +25,45 @@ impl HistoryMode {
 }
 
 /// History configuration.
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(default)]
+#[derive(Debug, Clone)]
 pub struct HistoryConfig {
     /// Maximum height (rows) for the history search menu (Ctrl+R).
     /// The actual height is the minimum of this value and the terminal height minus overhead.
     pub menu_max_height: u16,
 
-    /// Keep history only for the current process; do not load or save a file.
-    #[serde(flatten)]
+    /// Persistent or session-only history behavior.
     pub mode: HistoryMode,
+}
+
+impl Serialize for HistoryConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum WireMode<'a> {
+            Name(&'a str),
+            Persistent { dir: &'a PathBuf },
+        }
+
+        #[derive(Serialize)]
+        struct WireHistory<'a> {
+            menu_max_height: u16,
+            mode: WireMode<'a>,
+        }
+
+        let mode = match &self.mode {
+            HistoryMode::Persistent { dir: Some(dir) } => WireMode::Persistent { dir },
+            HistoryMode::Persistent { dir: None } => WireMode::Name("persistent"),
+            HistoryMode::Volatile => WireMode::Name("volatile"),
+        };
+        WireHistory {
+            menu_max_height: self.menu_max_height,
+            mode,
+        }
+        .serialize(serializer)
+    }
 }
 
 impl<'de> Deserialize<'de> for HistoryConfig {
@@ -47,10 +72,24 @@ impl<'de> Deserialize<'de> for HistoryConfig {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawMode {
+            Name(String),
+            Persistent(RawPersistentMode),
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct RawPersistentMode {
+            dir: PathBuf,
+        }
+
+        #[derive(Deserialize)]
         struct RawHistoryConfig {
             #[serde(default = "default_menu_max_height")]
             menu_max_height: u16,
-            mode: Option<String>,
+            #[serde(default)]
+            mode: Option<RawMode>,
             #[serde(default)]
             dir: Option<PathBuf>,
             #[serde(default)]
@@ -58,23 +97,80 @@ impl<'de> Deserialize<'de> for HistoryConfig {
         }
 
         let raw = RawHistoryConfig::deserialize(deserializer)?;
-        let mode = match (raw.mode, raw.disabled) {
-            (Some(mode), _) => match mode.as_str() {
-                "persistent" => HistoryMode::Persistent { dir: raw.dir },
-                "volatile" => HistoryMode::Volatile,
-                _ => {
-                    return Err(serde::de::Error::unknown_variant(
-                        &mode,
-                        &["persistent", "volatile"],
+        let mode = match raw.mode {
+            Some(RawMode::Name(mode)) => {
+                if raw.dir.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "history.dir cannot be used when history.mode is set",
                     ));
                 }
+                match (mode.as_str(), raw.disabled) {
+                    ("persistent", _) => HistoryMode::Persistent { dir: None },
+                    ("volatile", _) => HistoryMode::Volatile,
+                    _ => {
+                        return Err(serde::de::Error::unknown_variant(
+                            &mode,
+                            &["persistent", "volatile"],
+                        ));
+                    }
+                }
+            }
+            Some(RawMode::Persistent(RawPersistentMode { dir })) => {
+                if raw.dir.is_some() {
+                    return Err(serde::de::Error::custom(
+                        "history.dir cannot be used when history.mode is set",
+                    ));
+                }
+                HistoryMode::Persistent { dir: Some(dir) }
+            }
+            None => match (raw.disabled, raw.dir) {
+                (Some(true), _) => HistoryMode::Volatile,
+                (Some(false), dir) | (None, dir) => HistoryMode::Persistent { dir },
             },
-            (None, Some(true)) => HistoryMode::Volatile,
-            (None, Some(false)) | (None, None) => HistoryMode::Persistent { dir: raw.dir },
         };
         Ok(Self {
             menu_max_height: raw.menu_max_height,
             mode,
+        })
+    }
+}
+
+impl JsonSchema for HistoryConfig {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("HistoryConfig")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "History configuration.",
+            "type": "object",
+            "properties": {
+                "menu_max_height": {
+                    "description": "Maximum height (rows) for the history search menu (Ctrl+R).",
+                    "type": "integer",
+                    "format": "uint16",
+                    "default": 15,
+                    "maximum": 65535,
+                    "minimum": 0
+                },
+                "mode": {
+                    "default": "persistent",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["persistent", "volatile"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "dir": { "type": "string" }
+                            },
+                            "required": ["dir"],
+                            "additionalProperties": false
+                        }
+                    ]
+                }
+            }
         })
     }
 }

--- a/crates/arf-console/src/config/mod.rs
+++ b/crates/arf-console/src/config/mod.rs
@@ -17,7 +17,7 @@ pub use editor::{AutoSuggestions, EditorConfig, EditorMode};
 pub use experimental::{
     ExperimentalConfig, HistoryForgetConfig, PromptDurationConfig, RSourceOverride, SpinnerConfig,
 };
-pub use history::HistoryConfig;
+pub use history::{HistoryConfig, HistoryMode};
 pub use ipc::IpcConfig;
 pub use mode::ModeConfig;
 #[allow(unused_imports)]
@@ -64,6 +64,7 @@ pub enum ConfigLoadError {
 pub(crate) struct ConfigLoadProvenance {
     pub(crate) path: PathBuf,
     pub(crate) startup_r_source_present: bool,
+    pub(crate) history_migration_warning: Option<String>,
 }
 
 impl std::fmt::Display for ConfigLoadError {
@@ -121,6 +122,8 @@ pub struct Config {
     pub colors: ColorsConfig,
     #[serde(default)]
     pub experimental: ExperimentalConfig,
+    #[serde(skip)]
+    pub(crate) history_migration_warning: Option<String>,
 }
 
 /// Get the XDG config directory for this application.
@@ -150,6 +153,18 @@ pub fn config_file_path() -> Option<PathBuf> {
 /// - Shell mode: `history/shell.db`
 pub fn history_dir() -> Option<PathBuf> {
     data_dir().map(|p| p.join("history"))
+}
+
+/// Resolve the on-disk history directory for a configured mode.
+///
+/// Volatile history deliberately has no path: it must not expose, read, or
+/// create the persistent XDG directory. Persistent mode uses its explicit
+/// directory when present and otherwise the XDG default.
+pub fn history_dir_for_mode(mode: &HistoryMode) -> Option<PathBuf> {
+    match mode {
+        HistoryMode::Persistent { .. } => mode.persistent_dir().cloned().or_else(history_dir),
+        HistoryMode::Volatile => None,
+    }
 }
 
 /// Mask home directory in path with `~` for privacy.
@@ -212,18 +227,33 @@ pub(crate) fn load_config_from_path_with_provenance(
         .get("startup")
         .and_then(|startup| startup.get("r_source"))
         .is_some();
-    let config = toml::from_str::<Config>(&content).map_err(|e| ConfigLoadError::Parse {
+    let mut config = toml::from_str::<Config>(&content).map_err(|e| ConfigLoadError::Parse {
         source: e,
         path: path.to_path_buf(),
     })?;
+    config.history_migration_warning = history_migration_warning(&document);
+    let migration_warning = config.history_migration_warning.clone();
 
     Ok((
         config,
         Some(ConfigLoadProvenance {
             path: path.to_path_buf(),
             startup_r_source_present,
+            history_migration_warning: migration_warning,
         }),
     ))
+}
+
+fn history_migration_warning(document: &toml::Value) -> Option<String> {
+    let history = document.get("history")?.as_table()?;
+    let has_mode = history.contains_key("mode");
+    let disabled = history.get("disabled").and_then(toml::Value::as_bool);
+    match (has_mode, disabled) {
+        (true, Some(_)) => Some("Config key history.disabled is deprecated and ignored because history.mode is set; use history.mode only.".to_string()),
+        (false, Some(true)) => Some("Config key history.disabled is deprecated; use history.mode = \"volatile\" instead.".to_string()),
+        (false, Some(false)) => Some("Config key history.disabled is deprecated; use history.mode = \"persistent\" instead.".to_string()),
+        _ => None,
+    }
 }
 
 /// Generate default configuration as a TOML string with comments.
@@ -502,13 +532,94 @@ mode_indicator = "none"
     }
 
     #[test]
-    fn test_parse_history_disabled() {
+    fn test_parse_history_mode_volatile() {
         let toml_str = r#"
 [history]
-disabled = true
+mode = "volatile"
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
-        assert!(config.history.disabled);
+        assert!(matches!(config.history.mode, HistoryMode::Volatile));
+    }
+
+    #[test]
+    fn test_legacy_history_disabled_migrates_with_warning() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        fs::write(&path, "[history]\ndisabled = true\n").unwrap();
+        let (config, provenance) = load_config_from_path_with_provenance(&path).unwrap();
+        assert!(matches!(config.history.mode, HistoryMode::Volatile));
+        assert!(config.history_migration_warning.is_some());
+        assert!(provenance.unwrap().history_migration_warning.is_some());
+    }
+
+    #[test]
+    fn test_legacy_history_disabled_false_preserves_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        fs::write(
+            &path,
+            "[history]\ndisabled = false\ndir = \"/tmp/arf-history\"\n",
+        )
+        .unwrap();
+        let (loaded, provenance) = load_config_from_path_with_provenance(&path).unwrap();
+        assert!(
+            provenance
+                .unwrap()
+                .history_migration_warning
+                .unwrap()
+                .contains("persistent")
+        );
+        assert!(matches!(
+            loaded.history.mode,
+            HistoryMode::Persistent { .. }
+        ));
+
+        let config: Config =
+            toml::from_str("[history]\ndisabled = false\ndir = \"/tmp/arf-history\"\n").unwrap();
+        assert!(matches!(
+            config.history.mode,
+            HistoryMode::Persistent { dir: Some(ref dir) } if dir == std::path::Path::new("/tmp/arf-history")
+        ));
+    }
+
+    #[test]
+    fn test_history_mode_wins_over_legacy_disabled() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        fs::write(&path, "[history]\nmode = \"volatile\"\ndisabled = false\n").unwrap();
+        let (config, provenance) = load_config_from_path_with_provenance(&path).unwrap();
+        assert!(
+            provenance
+                .unwrap()
+                .history_migration_warning
+                .unwrap()
+                .contains("ignored")
+        );
+        assert!(matches!(config.history.mode, HistoryMode::Volatile));
+    }
+
+    #[test]
+    fn test_history_mode_wrong_type_is_parse_error() {
+        let result = toml::from_str::<Config>("[history]\nmode = 1\n");
+        assert!(result.is_err());
+        let result = toml::from_str::<Config>("[history]\ndisabled = \"true\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_history_dir_for_mode_never_exposes_a_volatile_path() {
+        assert_eq!(
+            history_dir_for_mode(&HistoryMode::Volatile),
+            None,
+            "volatile history must not expose the persistent XDG directory"
+        );
+        let explicit = std::path::PathBuf::from("/tmp/arf-history");
+        assert_eq!(
+            history_dir_for_mode(&HistoryMode::Persistent {
+                dir: Some(explicit.clone()),
+            }),
+            Some(explicit)
+        );
     }
 
     #[test]
@@ -767,6 +878,14 @@ allowed_functions = ["mean", "stats::median", "+"]
         assert!(
             config_str.contains("[editor]"),
             "Should have [editor] section"
+        );
+        assert!(
+            config_str.contains("mode = \"persistent\""),
+            "History should default to persistent mode"
+        );
+        assert!(
+            !config_str.contains("disabled"),
+            "Deprecated history.disabled must not be serialized"
         );
     }
 

--- a/crates/arf-console/src/config/mod.rs
+++ b/crates/arf-console/src/config/mod.rs
@@ -248,10 +248,14 @@ fn history_migration_warning(document: &toml::Value) -> Option<String> {
     let history = document.get("history")?.as_table()?;
     let has_mode = history.contains_key("mode");
     let disabled = history.get("disabled").and_then(toml::Value::as_bool);
-    match (has_mode, disabled) {
-        (true, Some(_)) => Some("Config key history.disabled is deprecated and ignored because history.mode is set; use history.mode only.".to_string()),
-        (false, Some(true)) => Some("Config key history.disabled is deprecated; use history.mode = \"volatile\" instead.".to_string()),
-        (false, Some(false)) => Some("Config key history.disabled is deprecated; use history.mode = \"persistent\" instead.".to_string()),
+    let has_legacy_dir = history.contains_key("dir");
+    match (has_mode, has_legacy_dir, disabled) {
+        (true, _, Some(_)) => Some("Config key history.disabled is deprecated and ignored because history.mode is set; use history.mode only.".to_string()),
+        (false, true, Some(true)) => Some("Config keys history.disabled and history.dir are deprecated; use history.mode = \"volatile\" instead.".to_string()),
+        (false, true, Some(false)) => Some("Config keys history.disabled and history.dir are deprecated; use persistent history.mode = { dir = \"...\" } instead.".to_string()),
+        (false, true, None) => Some("Config key history.dir is deprecated; use history.mode = { dir = \"...\" } instead.".to_string()),
+        (false, false, Some(true)) => Some("Config key history.disabled is deprecated; use history.mode = \"volatile\" instead.".to_string()),
+        (false, false, Some(false)) => Some("Config key history.disabled is deprecated; use history.mode = \"persistent\" instead.".to_string()),
         _ => None,
     }
 }
@@ -542,6 +546,41 @@ mode = "volatile"
     }
 
     #[test]
+    fn test_parse_history_mode_with_directory_object() {
+        let config: Config =
+            toml::from_str("[history]\nmode = { dir = \"/custom/history\" }\n").unwrap();
+        assert!(matches!(
+            config.history.mode,
+            HistoryMode::Persistent { dir: Some(ref dir) }
+                if dir == std::path::Path::new("/custom/history")
+        ));
+
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(
+            serialized.contains("[history.mode]")
+                && serialized.contains("dir = \"/custom/history\""),
+            "serialized history config used an unexpected TOML shape: {serialized}"
+        );
+        assert!(!serialized.contains("[history]\ndir = "));
+    }
+
+    #[test]
+    fn test_history_mode_object_requires_dir_and_rejects_unknown_fields() {
+        assert!(toml::from_str::<Config>("[history]\nmode = {}\n").is_err());
+        assert!(
+            toml::from_str::<Config>("[history]\nmode = { dir = \"/tmp\", extra = true }\n")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_history_mode_rejects_legacy_dir_when_explicit() {
+        let result =
+            toml::from_str::<Config>("[history]\nmode = \"persistent\"\ndir = \"/tmp/history\"\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_legacy_history_disabled_migrates_with_warning() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("arf.toml");
@@ -583,6 +622,26 @@ mode = "volatile"
     }
 
     #[test]
+    fn test_legacy_history_dir_without_disabled_migrates_to_persistent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("arf.toml");
+        fs::write(&path, "[history]\ndir = \"/tmp/arf-history\"\n").unwrap();
+        let (config, provenance) = load_config_from_path_with_provenance(&path).unwrap();
+        assert!(matches!(
+            config.history.mode,
+            HistoryMode::Persistent { dir: Some(ref dir) }
+                if dir == std::path::Path::new("/tmp/arf-history")
+        ));
+        assert!(
+            provenance
+                .unwrap()
+                .history_migration_warning
+                .unwrap()
+                .contains("deprecated")
+        );
+    }
+
+    #[test]
     fn test_history_mode_wins_over_legacy_disabled() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("arf.toml");
@@ -596,6 +655,34 @@ mode = "volatile"
                 .contains("ignored")
         );
         assert!(matches!(config.history.mode, HistoryMode::Volatile));
+    }
+
+    #[test]
+    fn test_history_mode_object_wins_over_legacy_disabled() {
+        for disabled in [true, false] {
+            let temp = tempfile::tempdir().unwrap();
+            let path = temp.path().join("arf.toml");
+            fs::write(
+                &path,
+                format!(
+                    "[history]\nmode = {{ dir = \"/tmp/payload-history\" }}\ndisabled = {disabled}\n"
+                ),
+            )
+            .unwrap();
+            let (config, provenance) = load_config_from_path_with_provenance(&path).unwrap();
+            assert!(matches!(
+                config.history.mode,
+                HistoryMode::Persistent { dir: Some(ref dir) }
+                    if dir == std::path::Path::new("/tmp/payload-history")
+            ));
+            assert!(
+                provenance
+                    .unwrap()
+                    .history_migration_warning
+                    .unwrap()
+                    .contains("ignored")
+            );
+        }
     }
 
     #[test]
@@ -964,6 +1051,47 @@ allowed_functions = ["mean", "stats::median", "+"]
             let properties = parsed
                 .get("properties")
                 .expect("Schema should have properties");
+
+            let history = properties
+                .get("history")
+                .and_then(|value| value.get("$ref"))
+                .and_then(|value| value.as_str())
+                .and_then(|reference| reference.strip_prefix("#/$defs/"))
+                .and_then(|name| parsed.get("$defs").and_then(|defs| defs.get(name)))
+                .expect("Schema should define history");
+            let history_properties = history
+                .get("properties")
+                .expect("History schema should have properties");
+            assert!(history_properties.get("disabled").is_none());
+            assert!(history_properties.get("dir").is_none());
+            let mode = history_properties
+                .get("mode")
+                .expect("History mode should be present in schema");
+            assert!(
+                history
+                    .get("required")
+                    .and_then(|required| required.as_array())
+                    .is_none_or(|required| !required.iter().any(|name| name == "mode")),
+                "History mode must remain optional for the default persistent mode"
+            );
+            assert_eq!(mode["default"], "persistent");
+            let variants = mode
+                .get("oneOf")
+                .and_then(|variants| variants.as_array())
+                .expect("History mode should have string and object variants");
+            assert!(variants.iter().any(|variant| {
+                variant["type"] == "string"
+                    && variant["enum"]
+                        .as_array()
+                        .is_some_and(|values| values.iter().any(|value| value == "persistent"))
+            }));
+            assert!(variants.iter().any(|variant| {
+                variant["type"] == "object"
+                    && variant["additionalProperties"] == false
+                    && variant["required"]
+                        .as_array()
+                        .is_some_and(|required| required.iter().any(|name| name == "dir"))
+            }));
 
             // Should have startup section (contains r_source, show_banner, mode)
             assert!(

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -102,8 +102,8 @@ expression: schema
       "$ref": "#/$defs/HistoryConfig",
       "default": {
         "dir": null,
-        "disabled": false,
-        "menu_max_height": 15
+        "menu_max_height": 15,
+        "mode": "persistent"
       }
     },
     "ipc": {
@@ -1653,19 +1653,6 @@ expression: schema
       "description": "History configuration.",
       "type": "object",
       "properties": {
-        "dir": {
-          "description": "Custom history directory (overrides default XDG location).\nR history will be stored at `{dir}/r.db`, Shell at `{dir}/shell.db`.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null
-        },
-        "disabled": {
-          "description": "Disable history entirely.",
-          "type": "boolean",
-          "default": false
-        },
         "menu_max_height": {
           "description": "Maximum height (rows) for the history search menu (Ctrl+R).\nThe actual height is the minimum of this value and the terminal height minus overhead.",
           "type": "integer",
@@ -1674,7 +1661,40 @@ expression: schema
           "maximum": 65535,
           "minimum": 0
         }
-      }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "dir": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "mode": {
+              "type": "string",
+              "const": "persistent"
+            }
+          },
+          "required": [
+            "mode"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "volatile"
+            }
+          },
+          "required": [
+            "mode"
+          ]
+        }
+      ]
     },
     "HistoryForgetConfig": {
       "description": "Configuration for automatic removal of failed commands from history.",

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -101,7 +101,6 @@ expression: schema
     "history": {
       "$ref": "#/$defs/HistoryConfig",
       "default": {
-        "dir": null,
         "menu_max_height": 15,
         "mode": "persistent"
       }
@@ -1654,47 +1653,38 @@ expression: schema
       "type": "object",
       "properties": {
         "menu_max_height": {
-          "description": "Maximum height (rows) for the history search menu (Ctrl+R).\nThe actual height is the minimum of this value and the terminal height minus overhead.",
+          "description": "Maximum height (rows) for the history search menu (Ctrl+R).",
           "type": "integer",
           "format": "uint16",
           "default": 15,
           "maximum": 65535,
           "minimum": 0
-        }
-      },
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "dir": {
-              "type": [
-                "string",
-                "null"
-              ],
-              "default": null
-            },
-            "mode": {
-              "type": "string",
-              "const": "persistent"
-            }
-          },
-          "required": [
-            "mode"
-          ]
         },
-        {
-          "type": "object",
-          "properties": {
-            "mode": {
+        "mode": {
+          "default": "persistent",
+          "oneOf": [
+            {
               "type": "string",
-              "const": "volatile"
+              "enum": [
+                "persistent",
+                "volatile"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "dir": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "dir"
+              ]
             }
-          },
-          "required": [
-            "mode"
           ]
         }
-      ]
+      }
     },
     "HistoryForgetConfig": {
       "description": "Configuration for automatic removal of failed commands from history.",

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__default_config.snap
@@ -56,7 +56,7 @@ auto_paren_limit = 50
 
 [history]
 menu_max_height = 15
-disabled = false
+mode = "persistent"
 
 [ipc.eval]
 allowed_functions = []

--- a/crates/arf-console/src/history/import.rs
+++ b/crates/arf-console/src/history/import.rs
@@ -342,12 +342,13 @@ enum DuplicateAction {
 impl DedupSet {
     /// Build a dedup set while the writable target store is already open.
     pub fn from_history(history: &HistoryStore) -> Result<Self> {
-        Self::from_connection(rusqlite::Connection::open(history.path()).with_context(|| {
-            format!(
-                "Failed to read history database: {}",
-                history.path().display()
-            )
-        })?)
+        let path = history
+            .path()
+            .ok_or_else(|| anyhow::anyhow!("history store has no persistent path"))?;
+        Self::from_connection(
+            rusqlite::Connection::open(path)
+                .with_context(|| format!("Failed to read history database: {}", path.display()))?,
+        )
     }
 
     /// Build a dedup set by opening a history database in read-only mode.

--- a/crates/arf-console/src/history/import/tests/dedup.rs
+++ b/crates/arf-console/src/history/import/tests/dedup.rs
@@ -129,7 +129,7 @@ fn duplicate_repair_preserves_hostname_set_by_hostname_override() {
 fn stale_duplicate_repair_skips_when_command_line_changed() {
     let mut fixture = ImportFixture::new();
     fixture.import([r("selected")]);
-    let path = fixture.targets.r_history.path().to_owned();
+    let path = fixture.targets.r_history.path().unwrap().to_owned();
     let r_dedup = DedupSet::from_db(&path).unwrap();
     rusqlite::Connection::open(&path)
         .unwrap()
@@ -160,7 +160,7 @@ fn stale_duplicate_repair_skips_when_timestamp_changed() {
     let changed_timestamp = timestamp("2024-06-15T14:30:46Z");
     let mut fixture = ImportFixture::new();
     fixture.import([r("timestamp selected").at(original_timestamp)]);
-    let path = fixture.targets.r_history.path().to_owned();
+    let path = fixture.targets.r_history.path().unwrap().to_owned();
     let r_dedup = DedupSet::from_db(&path).unwrap();
     rusqlite::Connection::open(&path)
         .unwrap()
@@ -328,7 +328,7 @@ fn repeated_repairs_have_the_same_dry_run_and_real_counts() {
     let mut fixture = ImportFixture::new();
     fixture.import([r("repeated repair").at(timestamp)]);
 
-    let dedup = DedupSet::from_db(fixture.targets.r_history.path()).unwrap();
+    let dedup = DedupSet::from_db(fixture.targets.r_history.path().unwrap()).unwrap();
     let dry = import_entries_dry_run(&entries, Some(&dedup), None);
     let real = fixture.import_with(
         entries,

--- a/crates/arf-console/src/history/mod.rs
+++ b/crates/arf-console/src/history/mod.rs
@@ -13,6 +13,6 @@ pub use metadata::HistoryExtraInfo;
 pub use reedline_adapter::ReedlineHistoryAdapter;
 #[allow(unused_imports)]
 pub use store::{
-    HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistorySaveReceipt, HistoryStore,
-    VolatileHistoryReason,
+    HistoryFailureDetail, HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistorySaveReceipt,
+    HistoryStore, VolatileHistoryReason,
 };

--- a/crates/arf-console/src/history/mod.rs
+++ b/crates/arf-console/src/history/mod.rs
@@ -11,6 +11,7 @@ mod store;
 
 pub use metadata::HistoryExtraInfo;
 pub use reedline_adapter::ReedlineHistoryAdapter;
+#[allow(unused_imports)]
 pub use store::{
     HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistorySaveReceipt, HistoryStore,
     VolatileHistoryReason,

--- a/crates/arf-console/src/history/mod.rs
+++ b/crates/arf-console/src/history/mod.rs
@@ -11,4 +11,7 @@ mod store;
 
 pub use metadata::HistoryExtraInfo;
 pub use reedline_adapter::ReedlineHistoryAdapter;
-pub use store::{HistoryHandle, HistorySaveOutcome, HistorySaveReceipt, HistoryStore};
+pub use store::{
+    HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistorySaveReceipt, HistoryStore,
+    VolatileHistoryReason,
+};

--- a/crates/arf-console/src/history/store.rs
+++ b/crates/arf-console/src/history/store.rs
@@ -18,7 +18,8 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 pub struct HistoryStore {
     inner: Arc<Mutex<SqliteBackedHistory>>,
-    path: PathBuf,
+    path: Option<PathBuf>,
+    session: Option<HistorySessionId>,
 }
 
 /// The result of the most recent adapter save.
@@ -62,6 +63,60 @@ pub struct HistoryHandle {
     pub receipt: HistorySaveReceipt,
 }
 
+/// Runtime history lifecycle. Keeping this state explicit prevents a failed
+/// persistent open from being confused with an intentional volatile session.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum HistoryRuntime {
+    Persistent(HistoryHandle),
+    Volatile {
+        handle: HistoryHandle,
+        reason: VolatileHistoryReason,
+    },
+    Unavailable {
+        requested_path: Option<PathBuf>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VolatileHistoryReason {
+    Configured,
+    Fallback { requested_path: PathBuf },
+}
+
+impl HistoryRuntime {
+    pub fn handle(&self) -> Option<&HistoryHandle> {
+        match self {
+            Self::Persistent(handle) | Self::Volatile { handle, .. } => Some(handle),
+            Self::Unavailable { .. } => None,
+        }
+    }
+
+    pub fn store(&self) -> Option<HistoryStore> {
+        self.handle().map(|handle| handle.store.clone())
+    }
+
+    pub fn receipt_outcome(&self) -> Option<HistorySaveOutcome> {
+        self.handle().and_then(|handle| handle.receipt.take())
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.handle().is_some()
+    }
+
+    #[allow(dead_code)]
+    pub fn requested_path(&self) -> Option<&std::path::Path> {
+        match self {
+            Self::Persistent(handle) => handle.store.path(),
+            Self::Volatile { reason, .. } => match reason {
+                VolatileHistoryReason::Configured => None,
+                VolatileHistoryReason::Fallback { requested_path } => Some(requested_path),
+            },
+            Self::Unavailable { requested_path } => requested_path.as_deref(),
+        }
+    }
+}
+
 impl HistoryStore {
     /// Open or create a history database.
     pub fn open(
@@ -75,16 +130,38 @@ impl HistoryStore {
                 session_id,
                 session_timestamp,
             )?)),
-            path,
+            path: Some(path),
+            session: session_id,
         })
     }
 
-    pub(crate) fn path(&self) -> &std::path::Path {
-        &self.path
+    /// Create an arf-owned in-memory SQLite history store.
+    pub fn in_memory(
+        session_id: Option<HistorySessionId>,
+        _session_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner: Arc::new(Mutex::new(SqliteBackedHistory::in_memory()?)),
+            path: None,
+            session: session_id,
+        })
+    }
+
+    /// Compare ownership identity without opening another backend.
+    pub(crate) fn same_owner(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    pub(crate) fn path(&self) -> Option<&std::path::Path> {
+        self.path.as_deref()
     }
 
     /// Save an item with SQL `NULL` in `more_info`.
     pub fn save_unknown(&self, item: HistoryItem) -> Result<HistoryItem> {
+        let mut item = item;
+        if item.session_id.is_none() {
+            item.session_id = self.session;
+        }
         let typed = convert_history_item(item, None::<HistoryExtraInfo>);
         let saved = self
             .inner
@@ -96,6 +173,10 @@ impl HistoryStore {
 
     /// Save an item with metadata already determined by arf.
     pub fn save_known(&self, item: HistoryItem, metadata: HistoryExtraInfo) -> Result<HistoryItem> {
+        let mut item = item;
+        if item.session_id.is_none() {
+            item.session_id = self.session;
+        }
         let typed = convert_history_item(item, Some(metadata));
         let saved = self
             .inner
@@ -110,6 +191,10 @@ impl HistoryStore {
         &self,
         item: HistoryItem<HistoryExtraInfo>,
     ) -> Result<HistoryItem<HistoryExtraInfo>> {
+        let mut item = item;
+        if item.session_id.is_none() {
+            item.session_id = self.session;
+        }
         self.inner
             .lock()
             .map_err(|_| lock_error())?
@@ -122,7 +207,22 @@ impl HistoryStore {
         id: HistoryItemId,
         source: HistoryItem<HistoryExtraInfo>,
     ) -> Result<bool> {
-        let _history = self.inner.lock().map_err(|_| lock_error())?;
+        // This is the one import-only escape hatch from reedline's typed API.
+        // Holding the store mutex prevents the raw transaction from racing an
+        // adapter write; the helper itself never escapes this ownership boundary.
+        let _store_lock = self.inner.lock().map_err(|_| lock_error())?;
+        self.set_missing_fields_with_raw_transaction(id, source)
+    }
+
+    /// Backfill legacy rows whose `more_info` may contain malformed JSON.
+    ///
+    /// Reedline's typed loader intentionally rejects malformed metadata, so
+    /// import repair must use SQL COALESCE while the owning store is locked.
+    fn set_missing_fields_with_raw_transaction(
+        &self,
+        id: HistoryItemId,
+        source: HistoryItem<HistoryExtraInfo>,
+    ) -> Result<bool> {
         let serialized_metadata = source
             .more_info
             .as_ref()
@@ -133,7 +233,10 @@ impl HistoryStore {
                     format!("could not serialize more_info: {error}"),
                 ))
             })?;
-        let mut connection = rusqlite::Connection::open(&self.path).map_err(sqlite_error)?;
+        let Some(path) = self.path.as_ref() else {
+            return Ok(false);
+        };
+        let mut connection = rusqlite::Connection::open(path).map_err(sqlite_error)?;
         connection
             .busy_timeout(std::time::Duration::from_secs(5))
             .map_err(sqlite_error)?;
@@ -210,10 +313,18 @@ impl HistoryStore {
         self.inner
             .lock()
             .map_err(|_| lock_error())?
-            .update(id, &|mut item| {
+            .update_with_extra::<HistoryExtraInfo>(id, &|mut item| {
                 item.exit_status = Some(exit_status);
                 item
             })
+    }
+
+    /// Count all rows without exposing the concrete reedline backend.
+    pub fn count_all(&self) -> Result<i64> {
+        self.count(SearchQuery::everything(
+            reedline::SearchDirection::Backward,
+            None,
+        ))
     }
 
     pub fn load(&self, id: HistoryItemId) -> Result<HistoryItem> {
@@ -236,6 +347,64 @@ impl HistoryStore {
         self.inner.lock().map_err(|_| lock_error())?.search(query)
     }
 
+    /// Search with an exact session scope and a result limit.
+    ///
+    /// Reedline's session filter intentionally includes rows from before the
+    /// current session, which is useful for interactive recall but not for the
+    /// IPC contract. This owned API applies exact filtering after each bounded
+    /// backend page and keeps scanning by ID until the requested number of rows
+    /// is collected. Callers never need to materialize the whole database.
+    pub(crate) fn search_strict_session<F>(
+        &self,
+        mut make_query: F,
+        session_id: Option<HistorySessionId>,
+        all_sessions: bool,
+        limit: i64,
+        start_time: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<HistoryItem>>
+    where
+        F: FnMut(Option<HistoryItemId>) -> SearchQuery,
+    {
+        const PAGE_SIZE: i64 = 128;
+        if limit <= 0 {
+            return Ok(Vec::new());
+        }
+
+        if all_sessions && start_time.is_none() {
+            let mut query = make_query(None);
+            query.limit = Some(limit);
+            return self.search(query);
+        }
+
+        let mut matched = Vec::new();
+        let mut start_id = None;
+        loop {
+            let mut query = make_query(start_id);
+            // Never let reedline apply its two-stage session semantics here.
+            query.filter.session = None;
+            query.limit = Some(PAGE_SIZE);
+            let page = self.search(query)?;
+            let page_len = page.len();
+            let next_start_id = page.last().and_then(|item| item.id);
+            matched.extend(page.into_iter().filter(|item| {
+                (all_sessions || item.session_id == session_id)
+                    && start_time.is_none_or(|start| {
+                        item.start_timestamp
+                            .is_some_and(|timestamp| timestamp >= start)
+                    })
+            }));
+            if matched.len() >= limit as usize || page_len < PAGE_SIZE as usize {
+                matched.truncate(limit as usize);
+                return Ok(matched);
+            }
+            let Some(next_start_id) = next_start_id else {
+                matched.truncate(limit as usize);
+                return Ok(matched);
+            };
+            start_id = Some(next_start_id);
+        }
+    }
+
     pub fn update(
         &self,
         id: HistoryItemId,
@@ -255,6 +424,17 @@ impl HistoryStore {
         self.inner.lock().map_err(|_| lock_error())?.delete(id)
     }
 
+    /// Delete several rows while holding the owning backend lock once.
+    pub(crate) fn delete_many(&self, ids: &[HistoryItemId]) -> Result<usize> {
+        let mut history = self.inner.lock().map_err(|_| lock_error())?;
+        let mut deleted = 0;
+        for id in ids {
+            history.delete(*id)?;
+            deleted += 1;
+        }
+        Ok(deleted)
+    }
+
     pub fn sync(&self) -> std::io::Result<()> {
         self.inner
             .lock()
@@ -263,7 +443,7 @@ impl HistoryStore {
     }
 
     pub fn session(&self) -> Option<HistorySessionId> {
-        self.inner.lock().ok().and_then(|history| history.session())
+        self.session
     }
 
     #[cfg(test)]
@@ -343,6 +523,72 @@ mod tests {
             .unwrap();
         assert_eq!(unknown_typed.more_info, None);
         assert_eq!(known_typed.more_info, Some(HistoryExtraInfo::default()));
+    }
+
+    #[test]
+    fn strict_session_search_pages_before_applying_limit() {
+        let current = reedline::Reedline::create_history_session_id().unwrap();
+        let other = reedline::Reedline::create_history_session_id().unwrap();
+        let store = HistoryStore::in_memory(Some(current), None).unwrap();
+
+        for command in ["current old", "current new"] {
+            let mut item = HistoryItem::from_command_line(command);
+            item.session_id = Some(current);
+            store.save_unknown(item).unwrap();
+        }
+        for index in 0..128 {
+            let mut item = HistoryItem::from_command_line(format!("other {index}"));
+            item.session_id = Some(other);
+            store.save_unknown(item).unwrap();
+        }
+
+        let rows = store
+            .search_strict_session(
+                |start_id| SearchQuery {
+                    direction: reedline::SearchDirection::Backward,
+                    start_time: None,
+                    end_time: None,
+                    start_id,
+                    end_id: None,
+                    limit: None,
+                    filter: reedline::SearchFilter::anything(None),
+                },
+                Some(current),
+                false,
+                2,
+                None,
+            )
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|item| item.session_id == Some(current)));
+    }
+
+    #[test]
+    fn strict_session_search_handles_future_time_without_rows() {
+        let current = reedline::Reedline::create_history_session_id().unwrap();
+        let store = HistoryStore::in_memory(Some(current), None).unwrap();
+        let rows = store
+            .search_strict_session(
+                |start_id| SearchQuery {
+                    direction: reedline::SearchDirection::Backward,
+                    start_time: None,
+                    end_time: None,
+                    start_id,
+                    end_id: None,
+                    limit: None,
+                    filter: reedline::SearchFilter::anything(None),
+                },
+                Some(current),
+                false,
+                50,
+                Some(
+                    chrono::DateTime::parse_from_rfc3339("2999-01-01T00:00:00Z")
+                        .unwrap()
+                        .with_timezone(&chrono::Utc),
+                ),
+            )
+            .unwrap();
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/crates/arf-console/src/history/store.rs
+++ b/crates/arf-console/src/history/store.rs
@@ -73,14 +73,31 @@ pub enum HistoryRuntime {
         reason: VolatileHistoryReason,
     },
     Unavailable {
-        requested_path: Option<PathBuf>,
+        failure: HistoryFailureDetail,
+        previous_failure: Option<HistoryFailureDetail>,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VolatileHistoryReason {
     Configured,
-    Fallback { requested_path: Option<PathBuf> },
+    Fallback {
+        persistent_failure: HistoryFailureDetail,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HistoryFailureDetail {
+    stage: HistoryFailureStage,
+    path: Option<PathBuf>,
+    message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HistoryFailureStage {
+    PersistentPathResolution,
+    PersistentOpen,
+    MemoryInitialization,
 }
 
 impl HistoryRuntime {
@@ -95,33 +112,76 @@ impl HistoryRuntime {
         session_id: Option<HistorySessionId>,
         session_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Self {
+        Self::initialize_with_factories(
+            mode,
+            requested_path,
+            session_id,
+            session_timestamp,
+            HistoryStore::open,
+            HistoryStore::in_memory,
+        )
+    }
+
+    /// Apply the lifecycle decision with injectable backend factories.
+    ///
+    /// The factories are kept private so production callers cannot bypass the
+    /// single runtime construction path. Unit tests use this helper to cover
+    /// initialization failures that the operating system cannot reliably
+    /// reproduce on every platform.
+    fn initialize_with_factories<Open, Memory>(
+        mode: &crate::config::HistoryMode,
+        requested_path: Option<PathBuf>,
+        session_id: Option<HistorySessionId>,
+        session_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+        mut open: Open,
+        mut in_memory: Memory,
+    ) -> Self
+    where
+        Open: FnMut(
+            PathBuf,
+            Option<HistorySessionId>,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<HistoryStore>,
+        Memory: FnMut(
+            Option<HistorySessionId>,
+            Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<HistoryStore>,
+    {
         let make_handle = |store: HistoryStore| HistoryHandle {
             store,
             receipt: HistorySaveReceipt::new(),
         };
 
         if matches!(mode, crate::config::HistoryMode::Volatile) {
-            return match HistoryStore::in_memory(session_id, session_timestamp) {
+            return match in_memory(session_id, session_timestamp) {
                 Ok(store) => Self::Volatile {
                     handle: make_handle(store),
                     reason: VolatileHistoryReason::Configured,
                 },
-                Err(_) => Self::Unavailable { requested_path },
+                Err(error) => Self::Unavailable {
+                    failure: HistoryFailureDetail::memory(error),
+                    previous_failure: None,
+                },
             };
         }
 
-        if let Some(path) = requested_path.clone()
-            && let Ok(store) = HistoryStore::open(path, session_id, session_timestamp)
-        {
-            return Self::Persistent(make_handle(store));
-        }
+        let persistent_failure = match requested_path.clone() {
+            Some(path) => match open(path.clone(), session_id, session_timestamp) {
+                Ok(store) => return Self::Persistent(make_handle(store)),
+                Err(error) => HistoryFailureDetail::persistent_open(path, error),
+            },
+            None => HistoryFailureDetail::persistent_path(),
+        };
 
-        match HistoryStore::in_memory(session_id, session_timestamp) {
+        match in_memory(session_id, session_timestamp) {
             Ok(store) => Self::Volatile {
                 handle: make_handle(store),
-                reason: VolatileHistoryReason::Fallback { requested_path },
+                reason: VolatileHistoryReason::Fallback { persistent_failure },
             },
-            Err(_) => Self::Unavailable { requested_path },
+            Err(error) => Self::Unavailable {
+                failure: HistoryFailureDetail::memory(error),
+                previous_failure: Some(persistent_failure),
+            },
         }
     }
 
@@ -182,19 +242,38 @@ impl HistoryRuntime {
     /// Persistent and intentionally configured volatile runtimes are healthy
     /// states and therefore do not produce a warning.
     pub fn startup_warning(&self) -> Option<String> {
+        let detail = self.diagnostic_detail()?;
+        Some(match self.requested_path() {
+            Some(path) => format!("{detail} (requested path: {})", path.display()),
+            None => detail,
+        })
+    }
+
+    /// Human-readable detail shared by startup warnings, `:info`, and JSON.
+    pub fn diagnostic_detail(&self) -> Option<String> {
         match self {
             Self::Persistent(_) => None,
             Self::Volatile { reason, .. } => match reason {
                 VolatileHistoryReason::Configured => None,
-                VolatileHistoryReason::Fallback { requested_path } => Some(match requested_path {
-                    Some(path) => format!("fallback; requested path: {}", path.display()),
-                    None => "fallback; no persistent path".to_string(),
-                }),
+                VolatileHistoryReason::Fallback { persistent_failure } => Some(format!(
+                    "{}; using volatile fallback",
+                    persistent_failure.describe(),
+                )),
             },
-            Self::Unavailable { requested_path } => Some(match requested_path {
-                Some(path) => format!("history unavailable; requested path: {}", path.display()),
-                None => "history unavailable; no persistent path".to_string(),
-            }),
+            Self::Unavailable {
+                failure,
+                previous_failure,
+            } => {
+                let mut details = previous_failure
+                    .as_ref()
+                    .map(|failure| failure.describe())
+                    .unwrap_or_default();
+                if !details.is_empty() {
+                    details.push_str("; ");
+                }
+                details.push_str(&failure.describe());
+                Some(details)
+            }
         }
     }
 
@@ -203,10 +282,84 @@ impl HistoryRuntime {
             Self::Persistent(handle) => handle.store.path(),
             Self::Volatile { reason, .. } => match reason {
                 VolatileHistoryReason::Configured => None,
-                VolatileHistoryReason::Fallback { requested_path } => requested_path.as_deref(),
+                VolatileHistoryReason::Fallback { persistent_failure } => persistent_failure.path(),
             },
-            Self::Unavailable { requested_path } => requested_path.as_deref(),
+            Self::Unavailable {
+                previous_failure, ..
+            } => previous_failure
+                .as_ref()
+                .and_then(HistoryFailureDetail::path),
         }
+    }
+}
+
+impl HistoryFailureDetail {
+    #[cfg(test)]
+    pub(crate) fn test_memory() -> Self {
+        Self {
+            stage: HistoryFailureStage::MemoryInitialization,
+            path: None,
+            message: "test memory initialization failure".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_persistent_open(path: PathBuf) -> Self {
+        Self {
+            stage: HistoryFailureStage::PersistentOpen,
+            path: Some(path),
+            message: "test persistent open failure".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_path_resolution() -> Self {
+        Self::persistent_path()
+    }
+
+    fn persistent_path() -> Self {
+        Self {
+            stage: HistoryFailureStage::PersistentPathResolution,
+            path: None,
+            message: "no persistent history path is available".to_string(),
+        }
+    }
+
+    fn persistent_open(path: PathBuf, error: reedline::ReedlineError) -> Self {
+        Self {
+            stage: HistoryFailureStage::PersistentOpen,
+            path: Some(path),
+            message: error.to_string(),
+        }
+    }
+
+    fn memory(error: reedline::ReedlineError) -> Self {
+        Self {
+            stage: HistoryFailureStage::MemoryInitialization,
+            path: None,
+            message: error.to_string(),
+        }
+    }
+
+    fn describe(&self) -> String {
+        match self.stage {
+            HistoryFailureStage::PersistentPathResolution => {
+                format!(
+                    "persistent history path resolution failed: {}",
+                    self.message
+                )
+            }
+            HistoryFailureStage::PersistentOpen => {
+                format!("persistent history open failed: {}", self.message)
+            }
+            HistoryFailureStage::MemoryInitialization => {
+                format!("volatile history initialization failed: {}", self.message)
+            }
+        }
+    }
+
+    fn path(&self) -> Option<&std::path::Path> {
+        self.path.as_deref()
     }
 }
 
@@ -583,10 +736,80 @@ mod tests {
     use super::*;
     use serde_json::Value;
 
+    fn injected_failure(message: &str) -> Result<HistoryStore> {
+        Err(reedline::ReedlineError(
+            reedline::ReedlineErrorVariants::HistoryDatabaseError(message.to_string()),
+        ))
+    }
+
     fn open_store() -> (tempfile::TempDir, HistoryStore) {
         let dir = tempfile::tempdir().unwrap();
         let store = HistoryStore::open(dir.path().join("history.db"), None, None).unwrap();
         (dir, store)
+    }
+
+    #[test]
+    fn configured_volatile_memory_failure_is_unavailable_without_previous_failure() {
+        let runtime = HistoryRuntime::initialize_with_factories(
+            &crate::config::HistoryMode::Volatile,
+            None,
+            None,
+            None,
+            |_path, _session, _timestamp| injected_failure("persistent must not be opened"),
+            |_session, _timestamp| injected_failure("configured memory failure"),
+        );
+
+        assert!(runtime.requested_path().is_none());
+        let HistoryRuntime::Unavailable {
+            failure,
+            previous_failure,
+        } = runtime
+        else {
+            panic!("configured volatile initialization should be unavailable");
+        };
+        assert_eq!(failure.stage, HistoryFailureStage::MemoryInitialization);
+        assert!(failure.message.contains("configured memory failure"));
+        assert!(previous_failure.is_none());
+    }
+
+    #[test]
+    fn persistent_failure_and_memory_failure_are_both_retained() {
+        let requested_path = PathBuf::from("/requested/history.db");
+        let runtime = HistoryRuntime::initialize_with_factories(
+            &crate::config::HistoryMode::Persistent { dir: None },
+            Some(requested_path.clone()),
+            None,
+            None,
+            |_path, _session, _timestamp| injected_failure("persistent open failure"),
+            |_session, _timestamp| injected_failure("fallback memory failure"),
+        );
+
+        let detail = runtime.diagnostic_detail().expect("unavailable detail");
+        assert_eq!(runtime.requested_path(), Some(requested_path.as_path()));
+        let HistoryRuntime::Unavailable {
+            failure,
+            previous_failure,
+        } = runtime
+        else {
+            panic!("persistent and fallback initialization should be unavailable");
+        };
+        assert_eq!(failure.stage, HistoryFailureStage::MemoryInitialization);
+        assert!(failure.message.contains("fallback memory failure"));
+        let previous_failure = previous_failure.expect("persistent failure should be retained");
+        assert_eq!(previous_failure.stage, HistoryFailureStage::PersistentOpen);
+        assert!(previous_failure.message.contains("persistent open failure"));
+        assert!(detail.contains("fallback memory failure"));
+        let requested_path_text = requested_path.to_string_lossy();
+        assert_eq!(detail.matches(requested_path_text.as_ref()).count(), 0);
+        let warning = HistoryRuntime::Unavailable {
+            failure: HistoryFailureDetail::test_memory(),
+            previous_failure: Some(HistoryFailureDetail::test_persistent_open(
+                requested_path.clone(),
+            )),
+        }
+        .startup_warning()
+        .expect("unavailable warning");
+        assert_eq!(warning.matches(requested_path_text.as_ref()).count(), 1);
     }
 
     #[test]

--- a/crates/arf-console/src/history/store.rs
+++ b/crates/arf-console/src/history/store.rs
@@ -8,7 +8,7 @@
 
 use super::metadata::HistoryExtraInfo;
 use reedline::{
-    History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId, Result,
+    History, HistoryItem, HistoryItemExtraInfo, HistoryItemId, HistorySessionId, Reedline, Result,
     SearchQuery, SqliteBackedHistory,
 };
 use std::path::PathBuf;
@@ -66,7 +66,6 @@ pub struct HistoryHandle {
 /// Runtime history lifecycle. Keeping this state explicit prevents a failed
 /// persistent open from being confused with an intentional volatile session.
 #[derive(Clone)]
-#[allow(dead_code)]
 pub enum HistoryRuntime {
     Persistent(HistoryHandle),
     Volatile {
@@ -81,10 +80,63 @@ pub enum HistoryRuntime {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VolatileHistoryReason {
     Configured,
-    Fallback { requested_path: PathBuf },
+    Fallback { requested_path: Option<PathBuf> },
 }
 
 impl HistoryRuntime {
+    /// Construct the complete history lifecycle decision for one runtime.
+    ///
+    /// Persistent open failures (including an unavailable default path) are
+    /// deliberately represented as volatile fallbacks.  Only failure to
+    /// create that fallback reaches `Unavailable`.
+    pub fn initialize(
+        mode: &crate::config::HistoryMode,
+        requested_path: Option<PathBuf>,
+        session_id: Option<HistorySessionId>,
+        session_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Self {
+        let make_handle = |store: HistoryStore| HistoryHandle {
+            store,
+            receipt: HistorySaveReceipt::new(),
+        };
+
+        if matches!(mode, crate::config::HistoryMode::Volatile) {
+            return match HistoryStore::in_memory(session_id, session_timestamp) {
+                Ok(store) => Self::Volatile {
+                    handle: make_handle(store),
+                    reason: VolatileHistoryReason::Configured,
+                },
+                Err(_) => Self::Unavailable { requested_path },
+            };
+        }
+
+        if let Some(path) = requested_path.clone()
+            && let Ok(store) = HistoryStore::open(path, session_id, session_timestamp)
+        {
+            return Self::Persistent(make_handle(store));
+        }
+
+        match HistoryStore::in_memory(session_id, session_timestamp) {
+            Ok(store) => Self::Volatile {
+                handle: make_handle(store),
+                reason: VolatileHistoryReason::Fallback { requested_path },
+            },
+            Err(_) => Self::Unavailable { requested_path },
+        }
+    }
+
+    /// Install this runtime's owned adapter on an editor, if available.
+    pub fn attach_to_editor(&self, line_editor: Reedline) -> Reedline {
+        let Some(handle) = self.handle() else {
+            return line_editor;
+        };
+        let adapter =
+            super::ReedlineHistoryAdapter::new(handle.store.clone(), handle.receipt.clone());
+        line_editor
+            .with_history_session_id(handle.store.session())
+            .with_history(Box::new(adapter))
+    }
+
     pub fn handle(&self) -> Option<&HistoryHandle> {
         match self {
             Self::Persistent(handle) | Self::Volatile { handle, .. } => Some(handle),
@@ -104,13 +156,54 @@ impl HistoryRuntime {
         self.handle().is_some()
     }
 
-    #[allow(dead_code)]
+    /// Stable state label for diagnostics and machine-readable startup info.
+    pub fn state_name(&self) -> &'static str {
+        match self {
+            Self::Persistent(_) => "persistent",
+            Self::Volatile { .. } => "volatile",
+            Self::Unavailable { .. } => "unavailable",
+        }
+    }
+
+    /// Stable machine-readable reason for a non-persistent runtime.
+    pub fn reason_name(&self) -> Option<&'static str> {
+        match self {
+            Self::Persistent(_) => None,
+            Self::Volatile { reason, .. } => Some(match reason {
+                VolatileHistoryReason::Configured => "configured",
+                VolatileHistoryReason::Fallback { .. } => "fallback",
+            }),
+            Self::Unavailable { .. } => Some("initialization_failed"),
+        }
+    }
+
+    /// Human-readable startup warning for degraded runtimes.
+    ///
+    /// Persistent and intentionally configured volatile runtimes are healthy
+    /// states and therefore do not produce a warning.
+    pub fn startup_warning(&self) -> Option<String> {
+        match self {
+            Self::Persistent(_) => None,
+            Self::Volatile { reason, .. } => match reason {
+                VolatileHistoryReason::Configured => None,
+                VolatileHistoryReason::Fallback { requested_path } => Some(match requested_path {
+                    Some(path) => format!("fallback; requested path: {}", path.display()),
+                    None => "fallback; no persistent path".to_string(),
+                }),
+            },
+            Self::Unavailable { requested_path } => Some(match requested_path {
+                Some(path) => format!("history unavailable; requested path: {}", path.display()),
+                None => "history unavailable; no persistent path".to_string(),
+            }),
+        }
+    }
+
     pub fn requested_path(&self) -> Option<&std::path::Path> {
         match self {
             Self::Persistent(handle) => handle.store.path(),
             Self::Volatile { reason, .. } => match reason {
                 VolatileHistoryReason::Configured => None,
-                VolatileHistoryReason::Fallback { requested_path } => Some(requested_path),
+                VolatileHistoryReason::Fallback { requested_path } => requested_path.as_deref(),
             },
             Self::Unavailable { requested_path } => requested_path.as_deref(),
         }

--- a/crates/arf-console/src/ipc/mod.rs
+++ b/crates/arf-console/src/ipc/mod.rs
@@ -28,7 +28,6 @@ use protocol::{
     IpcRequest, IpcResponse, R_BUSY, R_EVAL_NOT_ALLOWED, R_NOT_AT_PROMPT, RSessionInfo,
     SessionResult, USER_IS_TYPING, UserInputResult,
 };
-use std::path::PathBuf;
 use std::sync::{
     Arc, Mutex, OnceLock,
     atomic::{AtomicBool, Ordering},
@@ -196,9 +195,8 @@ static HEADLESS_SHUTDOWN: OnceLock<Arc<AtomicBool>> = OnceLock::new();
 /// persisted to the same SQLite history database used by the REPL.
 static HEADLESS_HISTORY: OnceLock<HistoryStore> = OnceLock::new();
 
-/// History database path and session ID, shared between REPL and headless modes.
-/// Used by the `history` IPC method to open a read-only connection for queries.
-static HISTORY_DB_INFO: OnceLock<(PathBuf, Option<reedline::HistorySessionId>)> = OnceLock::new();
+/// The single history owner shared by REPL/headless history queries and saves.
+static HISTORY_STORE: OnceLock<HistoryStore> = OnceLock::new();
 
 /// Channel receiver for IPC requests (server → main thread).
 /// Wrapped in Option so it can be replaced on restart.
@@ -799,22 +797,19 @@ pub fn clear_history_session_id() {
 /// Once set, `headless_handle_request` will persist evaluated commands
 /// (both `evaluate` and `user_input`) to the SQLite history database.
 pub fn set_headless_history(history: HistoryStore) {
+    let ipc_history = history.clone();
     if HEADLESS_HISTORY.set(history).is_err() {
         log::warn!(
             "Headless history backend already initialized; ignoring duplicate set_headless_history call"
         );
     }
+    set_history_store(ipc_history);
 }
 
-/// Store the history database path and session ID for IPC queries.
-///
-/// Called during startup (both REPL and headless) so that the `history`
-/// IPC method can open a read-only connection to query history entries.
-pub fn set_history_db_info(path: PathBuf, session_id: Option<reedline::HistorySessionId>) {
-    if HISTORY_DB_INFO.set((path, session_id)).is_err() {
-        log::warn!(
-            "History DB info already initialized; ignoring duplicate set_history_db_info call"
-        );
+/// Register the already-open history owner for IPC queries.
+pub fn set_history_store(history: HistoryStore) {
+    if HISTORY_STORE.set(history).is_err() {
+        log::warn!("History store already initialized; ignoring duplicate set_history_store call");
     }
 }
 
@@ -827,11 +822,10 @@ pub(crate) enum HistoryQueryError {
     Internal(String),
 }
 
-/// Query the history database and return matching entries.
+/// Query the history store and return matching entries.
 ///
-/// Opens a read-only `rusqlite::Connection` for each query to avoid WAL
-/// and DDL side effects that `SqliteBackedHistory::with_file` would cause.
-/// This prevents conflicts with the main REPL/headless history connection.
+/// Queries use the already-open owner, avoiding competing WAL/DDL connections
+/// and making volatile history available to IPC for the current session.
 pub(crate) fn query_history(params: &HistoryParams) -> Result<HistoryResult, HistoryQueryError> {
     if params.limit < 1 {
         return Err(HistoryQueryError::InvalidParams(format!(
@@ -840,11 +834,12 @@ pub(crate) fn query_history(params: &HistoryParams) -> Result<HistoryResult, His
         )));
     }
 
-    let (db_path, session_id) = HISTORY_DB_INFO.get().ok_or_else(|| {
+    let store = HISTORY_STORE.get().ok_or_else(|| {
         HistoryQueryError::Internal(
-            "History is not available (no history database configured)".to_string(),
+            "History is not available (no history store configured)".to_string(),
         )
     })?;
+    let session_id = store.session();
 
     // When not requesting all sessions, require a valid session_id.
     if !params.all_sessions && session_id.is_none() {
@@ -875,70 +870,50 @@ pub(crate) fn query_history(params: &HistoryParams) -> Result<HistoryResult, His
         None
     };
 
-    // Open read-only to avoid WAL/DDL conflicts with the main history
-    // connection (same pattern as pager/history_browser.rs).
-    let db =
-        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .map_err(|e| {
-                HistoryQueryError::Internal(format!("Failed to open history database: {e}"))
-            })?;
-
-    // Build SQL query with optional WHERE clauses.
-    let mut sql = String::from(
-        "SELECT command_line, start_timestamp, session_id, cwd, exit_status \
-         FROM history WHERE 1=1",
-    );
-    let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-
-    if !params.all_sessions
-        && let Some(sid) = session_id
-    {
-        sql.push_str(" AND session_id = ?");
-        params_vec.push(Box::new(i64::from(*sid)));
-    }
-    if let Some(ref cwd) = params.cwd {
-        sql.push_str(" AND cwd = ?");
-        params_vec.push(Box::new(cwd.clone()));
-    }
-    if let Some(ref grep) = params.grep {
-        // Use instr() instead of LIKE to avoid wildcard escaping issues
-        // (same approach as reedline's Substring search).
-        sql.push_str(" AND instr(command_line, ?) >= 1");
-        params_vec.push(Box::new(grep.clone()));
-    }
-    if let Some(ms) = since_ms {
-        sql.push_str(" AND start_timestamp >= ?");
-        params_vec.push(Box::new(ms));
-    }
-    sql.push_str(" ORDER BY id DESC LIMIT ?");
-    params_vec.push(Box::new(params.limit));
-
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| &**p).collect();
-
-    let mut stmt = db
-        .prepare(&sql)
-        .map_err(|e| HistoryQueryError::Internal(format!("Failed to prepare query: {e}")))?;
-    let entries = stmt
-        .query_map(param_refs.as_slice(), |row| {
-            let ts_ms: Option<i64> = row.get(1)?;
-            let timestamp: Option<String> = ts_ms.and_then(|ms| {
-                chrono::Utc
-                    .timestamp_millis_opt(ms)
-                    .single()
-                    .map(|t| t.to_rfc3339())
-            });
-            let sid: Option<i64> = row.get(2)?;
-            Ok(HistoryEntry {
-                command: row.get(0)?,
-                timestamp,
-                cwd: row.get(3)?,
-                exit_status: row.get(4)?,
-                session_id: sid,
-            })
+    // Do not pass the session to reedline's filter: its persistent semantics
+    // intentionally include rows from before the current session. The owned
+    // store applies strict session matching over bounded pages and applies the
+    // limit only after matching rows are collected.
+    let cwd = params.cwd.clone();
+    let grep = params.grep.clone();
+    let start_time = since_ms.and_then(|ms| chrono::Utc.timestamp_millis_opt(ms).single());
+    let rows = store
+        .search_strict_session(
+            |start_id| {
+                let mut filter = reedline::SearchFilter::anything(None);
+                filter.cwd_exact = cwd.clone();
+                filter.command_line = grep.clone().map(reedline::CommandLineSearch::Substring);
+                reedline::SearchQuery {
+                    direction: reedline::SearchDirection::Backward,
+                    // reedline 0.50's start_time SQL uses a misspelled column.
+                    // The owned store applies this bound after each page.
+                    start_time: None,
+                    end_time: None,
+                    start_id,
+                    end_id: None,
+                    limit: None,
+                    filter,
+                }
+            },
+            session_id,
+            params.all_sessions,
+            params.limit,
+            start_time,
+        )
+        .map_err(|e| {
+            log::error!("Strict history query failed: {e}");
+            HistoryQueryError::Internal(format!("History query failed: {e}"))
+        })?;
+    let entries = rows
+        .into_iter()
+        .map(|row| HistoryEntry {
+            command: row.command_line,
+            timestamp: row.start_timestamp.map(|time| time.to_rfc3339()),
+            cwd: row.cwd,
+            exit_status: row.exit_status,
+            session_id: row.session_id.map(i64::from),
         })
-        .map_err(|e| HistoryQueryError::Internal(format!("History query failed: {e}")))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| HistoryQueryError::Internal(format!("Failed to read history row: {e}")))?;
+        .collect();
 
     Ok(HistoryResult {
         entries,
@@ -961,7 +936,7 @@ fn save_to_headless_history(code: &str, exit_status: Option<i64>) {
         .ok()
         .map(|p| p.to_string_lossy().into_owned());
     item.exit_status = exit_status;
-    item.session_id = HISTORY_DB_INFO.get().and_then(|(_, sid)| *sid);
+    item.session_id = HEADLESS_HISTORY.get().and_then(HistoryStore::session);
     if let Err(e) = h.save_known(item, HistoryExtraInfo::default()) {
         log::warn!("Failed to save headless history: {}", e);
     }

--- a/crates/arf-console/src/ipc/protocol.rs
+++ b/crates/arf-console/src/ipc/protocol.rs
@@ -151,8 +151,8 @@ pub struct SessionResult {
     pub started_at: String,
     /// Log file path, or `null` if no log file is configured and output is sent to stderr.
     pub log_file: Option<String>,
-    /// History session ID (nanosecond timestamp), or `null` in headless mode,
-    /// when history is disabled, or when no history directory is available.
+    /// History session ID (nanosecond timestamp), or `null` only when history
+    /// initialization is unavailable.
     pub history_session_id: Option<i64>,
     /// R session information, or `null` if R is unavailable.
     pub r: Option<RSessionInfo>,
@@ -202,8 +202,8 @@ pub struct HistoryEntry {
 
 /// Result of the `history` method.
 ///
-/// All fields are always present. `session_id` is `null` when history is
-/// disabled or no session ID is available.
+/// All fields are always present. `session_id` is `null` only when no history
+/// session is available.
 #[derive(Debug, Serialize)]
 pub struct HistoryResult {
     pub entries: Vec<HistoryEntry>,

--- a/crates/arf-console/src/ipc/server/tests.rs
+++ b/crates/arf-console/src/ipc/server/tests.rs
@@ -255,7 +255,7 @@ fn test_session_result_includes_history_session_id() {
     let json = serde_json::to_value(&result).unwrap();
     assert_eq!(json["history_session_id"], session_id);
 
-    // Without history_session_id (headless mode)
+    // Without history_session_id (history initialization unavailable)
     super::super::set_session_meta(
         "/tmp/test.sock".to_string(),
         "2026-01-01T00:00:00+00:00".to_string(),

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -44,9 +44,8 @@ pub struct SessionInfo {
     /// Log file path, or `None` if no log file is configured.
     #[serde(default)]
     pub log_file: Option<String>,
-    /// History session ID (nanosecond timestamp), or `None` when history is
-    /// disabled, when no history directory is available, or when the history
-    /// database failed to open.
+    /// History session ID (nanosecond timestamp), or `None` when history
+    /// initialization is unavailable.
     #[serde(default)]
     pub history_session_id: Option<i64>,
 }

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -437,7 +437,19 @@ fn run() -> Result<()> {
     }
 
     let session_id = create_session_id(&config);
-    let session_id_raw = session_id.map(i64::from);
+
+    // Prepare both owned history runtimes before IPC advertises the session.
+    // The server then exposes a store that is already the same owner used by
+    // typed input and the interactive editor.
+    let mut repl = Repl::new(
+        config,
+        config_path,
+        config_status,
+        r_source_status,
+        r_home,
+        session_id,
+    )?;
+    repl.prepare_history();
 
     // Start IPC server if requested.
     //
@@ -450,9 +462,9 @@ fn run() -> Result<()> {
     if cli.with_ipc {
         match ipc::start_server(
             cli.ipc_bind.as_deref(),
-            r_home.as_ref().map(|path| path.display().to_string()),
+            repl.r_home_for_ipc(),
             None,
-            session_id_raw,
+            repl.history_session_id_raw(),
             ipc::session::SessionType::Interactive,
         ) {
             Ok(session) => {
@@ -472,15 +484,7 @@ fn run() -> Result<()> {
         }
     }
 
-    // Create and run the REPL
-    let mut repl = Repl::new(
-        config,
-        config_path,
-        config_status,
-        r_source_status,
-        r_home,
-        session_id,
-    )?;
+    // Run the REPL with runtimes prepared above.
     let repl_result = repl.run();
 
     // Cleanup IPC server on exit (idempotent — also covers :ipc start).

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -453,12 +453,9 @@ fn run() -> Result<()> {
 
     // Start IPC server if requested.
     //
-    // NOTE: The IPC server is started before history databases are opened (which
-    // happens inside `Repl::run_*`). This means there is a brief window where the
-    // on-disk session file advertises a non-null `history_session_id` even though
-    // history has not been confirmed yet. A session ID remains advertised for
-    // persistent and volatile stores, and is cleared only if initialization
-    // ultimately becomes unavailable.
+    // History runtimes and the R-owned IPC store were prepared above, so the
+    // server advertises a session ID only after the R runtime is confirmed
+    // available. The REPL later attaches those same owners to its editors.
     if cli.with_ipc {
         match ipc::start_server(
             cli.ipc_bind.as_deref(),

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -287,9 +287,11 @@ fn run() -> Result<()> {
 
     // History configuration: CLI flag overrides default XDG location
     if cli.history.no_history {
-        config.history.disabled = true;
+        config.history.mode = config::HistoryMode::Volatile;
     } else if let Some(history_dir) = &cli.history.history_dir {
-        config.history.dir = Some(history_dir.clone());
+        config.history.mode = config::HistoryMode::Persistent {
+            dir: Some(history_dir.clone()),
+        };
     }
 
     // Warn if auto-format is enabled (via config) but Air CLI is not available
@@ -437,25 +439,14 @@ fn run() -> Result<()> {
     let session_id = create_session_id(&config);
     let session_id_raw = session_id.map(i64::from);
 
-    // Register history DB path for IPC history queries.
-    // Note: the DB file may not exist yet at this point (first run); that's OK
-    // because SqliteBackedHistory::with_file creates it on open. In the REPL
-    // path, reedline opens the DB later in Repl::run_*, which also creates it.
-    if !config.history.disabled {
-        let history_dir = config.history.dir.clone().or_else(config::history_dir);
-        if let Some(dir) = history_dir {
-            ipc::set_history_db_info(dir.join("r.db"), session_id);
-        }
-    }
-
     // Start IPC server if requested.
     //
     // NOTE: The IPC server is started before history databases are opened (which
-    // happens inside `Repl::run_*`).  This means there is a brief window where
-    // the on-disk session file advertises a non-null `history_session_id` even
-    // though history has not been confirmed yet.  If history initialization later
-    // fails, `clear_history_session_id()` is called to set it back to `null`.
-    // In practice the window is negligibly short (milliseconds).
+    // happens inside `Repl::run_*`). This means there is a brief window where the
+    // on-disk session file advertises a non-null `history_session_id` even though
+    // history has not been confirmed yet. A session ID remains advertised for
+    // persistent and volatile stores, and is cleared only if initialization
+    // ultimately becomes unavailable.
     if cli.with_ipc {
         match ipc::start_server(
             cli.ipc_bind.as_deref(),

--- a/crates/arf-console/src/pager/history_browser.rs
+++ b/crates/arf-console/src/pager/history_browser.rs
@@ -12,7 +12,7 @@ use super::{
     with_alternate_screen,
 };
 use crate::fuzzy::fuzzy_match;
-use chrono::TimeZone;
+use crate::history::HistoryStore;
 use crossterm::{
     ExecutableCommand, cursor,
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind},
@@ -21,9 +21,7 @@ use crossterm::{
     terminal::{self, BeginSynchronizedUpdate, ClearType, EndSynchronizedUpdate},
 };
 use reedline::{HistoryItem, HistoryItemId};
-use rusqlite::{Connection, OpenFlags, params_from_iter};
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Maximum number of history entries to load from database.
@@ -148,8 +146,8 @@ struct HistoryBrowser {
     feedback_message: Option<String>,
     /// Database mode (R or Shell).
     db_mode: HistoryDbMode,
-    /// Path to the history database.
-    db_path: PathBuf,
+    /// The already-open arf-owned history store.
+    store: HistoryStore,
     /// Scroll animation state for the selected item's long text.
     text_scroll: TextScrollState,
     /// Whether we're showing the delete confirmation dialog.
@@ -164,7 +162,7 @@ struct HistoryBrowser {
 
 impl HistoryBrowser {
     /// Create a new history browser.
-    fn new(entries: Vec<HistoryItem>, db_mode: HistoryDbMode, db_path: PathBuf) -> Self {
+    fn new(entries: Vec<HistoryItem>, db_mode: HistoryDbMode, store: HistoryStore) -> Self {
         let browsable: Vec<BrowsableHistoryItem> = entries
             .into_iter()
             .map(|item| BrowsableHistoryItem {
@@ -183,7 +181,7 @@ impl HistoryBrowser {
             scroll_offset: 0,
             feedback_message: None,
             db_mode,
-            db_path,
+            store,
             text_scroll: TextScrollState::new(),
             show_delete_dialog: false,
             filter_active: false,
@@ -299,10 +297,8 @@ impl HistoryBrowser {
 
     /// Delete all selected items from the database.
     ///
-    /// Opens a separate read-write connection and executes a single batch DELETE.
-    /// This avoids using `SqliteBackedHistory::with_file()` which would create a
-    /// competing WAL connection alongside the main REPL's history connection,
-    /// risking cache inconsistency and database corruption.
+    /// Deletes through the already-open arf-owned store. The browser owns no
+    /// database connection and never holds the store lock during UI input.
     fn delete_selected(&mut self) -> io::Result<()> {
         // Collect IDs to delete
         let ids_to_delete: Vec<i64> = self
@@ -317,22 +313,26 @@ impl HistoryBrowser {
             return Ok(());
         }
 
-        // Open a direct connection for the delete operation only.
-        // We intentionally avoid SqliteBackedHistory::with_file() here because it
-        // sets journal_mode=wal and runs DDL (CREATE TABLE IF NOT EXISTS), which
-        // conflicts with the main REPL's active WAL connection to the same database.
-        let db = Connection::open(&self.db_path).map_err(io::Error::other)?;
-        db.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(io::Error::other)?;
-
-        // Batch delete in a single statement
-        let placeholders: Vec<&str> = ids_to_delete.iter().map(|_| "?").collect();
-        let sql = format!(
-            "DELETE FROM history WHERE id IN ({})",
-            placeholders.join(", ")
-        );
-        db.execute(&sql, params_from_iter(&ids_to_delete))
-            .map_err(io::Error::other)?;
+        let ids: Vec<HistoryItemId> = ids_to_delete
+            .iter()
+            .copied()
+            .map(HistoryItemId::new)
+            .collect();
+        if let Err(error) = self.store.delete_many(&ids) {
+            // A backend error can occur after a prefix of ids was deleted.
+            // Reload from the owner before returning so the UI cannot retain
+            // rows that no longer exist (or hide rows that were not deleted).
+            self.entries = load_history(&self.store)?
+                .into_iter()
+                .map(|item| BrowsableHistoryItem {
+                    item,
+                    selected: false,
+                })
+                .collect();
+            self.cached_selected_count = 0;
+            self.update_filter();
+            return Err(io::Error::other(error));
+        }
 
         // Remove deleted entries from our list
         let feedback = format!("Deleted {} entries", ids_to_delete.len());
@@ -970,49 +970,13 @@ impl HistoryBrowser {
     }
 }
 
-/// Load history entries from the database in read-only mode.
+/// Load history entries through the already-open arf-owned store.
 ///
-/// Using read-only mode avoids WAL (Write-Ahead Logging) conflicts with the
-/// main REPL's history connection. This prevents "database disk image is malformed"
-/// errors when browsing history while the REPL is actively using the database.
-fn load_history(db_path: &Path) -> io::Result<Vec<HistoryItem>> {
-    // Open in read-only mode to avoid WAL conflicts
-    let db = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(io::Error::other)?;
-
-    let mut stmt = db
-        .prepare(
-            "SELECT id, command_line, start_timestamp, hostname, cwd, duration_ms, exit_status
-             FROM history
-             ORDER BY id DESC
-             LIMIT ?",
-        )
-        .map_err(io::Error::other)?;
-
-    let items = stmt
-        .query_map([MAX_ENTRIES], |row| {
-            Ok(HistoryItem {
-                id: Some(HistoryItemId::new(row.get(0)?)),
-                command_line: row.get(1)?,
-                start_timestamp: row
-                    .get::<_, Option<i64>>(2)?
-                    .and_then(|ms| chrono::Utc.timestamp_millis_opt(ms).single()),
-                session_id: None,
-                hostname: row.get(3)?,
-                cwd: row.get(4)?,
-                duration: row
-                    .get::<_, Option<i64>>(5)?
-                    .and_then(|ms| u64::try_from(ms).ok())
-                    .map(std::time::Duration::from_millis),
-                exit_status: row.get(6)?,
-                more_info: None,
-            })
-        })
-        .map_err(io::Error::other)?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(io::Error::other)?;
-
-    Ok(items)
+/// The browser keeps no database lock while its UI loop is running.
+fn load_history(store: &HistoryStore) -> io::Result<Vec<HistoryItem>> {
+    let mut query = reedline::SearchQuery::everything(reedline::SearchDirection::Backward, None);
+    query.limit = Some(MAX_ENTRIES);
+    store.search(query).map_err(io::Error::other)
 }
 
 /// Calculate layout widths for the history browser columns.
@@ -1050,24 +1014,24 @@ fn flatten_multiline(s: &str) -> String {
 /// Run the history browser.
 ///
 /// # Arguments
-/// * `db_path` - Path to the SQLite history database
+/// * `store` - The already-open arf-owned history store
 /// * `mode` - The database mode (R or Shell)
 ///
 /// # Returns
 /// The result of the browser interaction.
 pub fn run_history_browser(
-    db_path: &Path,
+    store: &HistoryStore,
     mode: HistoryDbMode,
 ) -> io::Result<HistoryBrowserResult> {
     // Load history entries
-    let entries = load_history(db_path)?;
+    let entries = load_history(store)?;
 
     if entries.is_empty() {
         println!("# No history entries found.");
         return Ok(HistoryBrowserResult::Cancelled);
     }
 
-    let mut browser = HistoryBrowser::new(entries, mode, db_path.to_path_buf());
+    let mut browser = HistoryBrowser::new(entries, mode, store.clone());
     browser.run()
 }
 

--- a/crates/arf-console/src/pager/history_browser/tests.rs
+++ b/crates/arf-console/src/pager/history_browser/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rusqlite::Connection;
 
 #[test]
 fn test_history_filter_parse_empty() {
@@ -140,11 +141,11 @@ fn test_db_mode_display_name() {
 }
 
 /// Create a temporary history database with test entries.
-/// Returns the temp dir (must be kept alive) and the db path.
+/// Returns the temp dir (must be kept alive) and the arf-owned store.
 ///
 /// NOTE: The schema here must match reedline's `SqliteBackedHistory` table
 /// definition. If reedline changes its schema, this helper must be updated.
-fn create_test_db(entries: &[(&str, Option<&str>)]) -> (tempfile::TempDir, PathBuf) {
+fn create_test_db(entries: &[(&str, Option<&str>)]) -> (tempfile::TempDir, HistoryStore) {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test_history.db");
     let db = Connection::open(&db_path).unwrap();
@@ -169,18 +170,19 @@ fn create_test_db(entries: &[(&str, Option<&str>)]) -> (tempfile::TempDir, PathB
         )
         .unwrap();
     }
-    (dir, db_path)
+    let store = HistoryStore::open(db_path, None, None).unwrap();
+    (dir, store)
 }
 
 #[test]
 fn test_load_history_returns_entries_in_desc_order() {
-    let (_dir, db_path) = create_test_db(&[
+    let (_dir, store) = create_test_db(&[
         ("first_cmd", Some("host1")),
         ("second_cmd", Some("host2")),
         ("third_cmd", None),
     ]);
 
-    let items = load_history(&db_path).unwrap();
+    let items = load_history(&store).unwrap();
     assert_eq!(items.len(), 3);
     // Descending order by id
     assert_eq!(items[0].command_line, "third_cmd");
@@ -193,17 +195,17 @@ fn test_load_history_returns_entries_in_desc_order() {
 
 #[test]
 fn test_load_history_empty_db() {
-    let (_dir, db_path) = create_test_db(&[]);
-    let items = load_history(&db_path).unwrap();
+    let (_dir, store) = create_test_db(&[]);
+    let items = load_history(&store).unwrap();
     assert!(items.is_empty());
 }
 
 #[test]
 fn test_delete_selected_removes_from_db_and_entries() {
-    let (_dir, db_path) = create_test_db(&[("cmd_a", None), ("cmd_b", None), ("cmd_c", None)]);
+    let (_dir, store) = create_test_db(&[("cmd_a", None), ("cmd_b", None), ("cmd_c", None)]);
 
-    let entries = load_history(&db_path).unwrap();
-    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, db_path.clone());
+    let entries = load_history(&store).unwrap();
+    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, store.clone());
 
     // Select the first item (cmd_c, id=3) and the third item (cmd_a, id=1)
     browser.cursor = 0;
@@ -220,29 +222,29 @@ fn test_delete_selected_removes_from_db_and_entries() {
     assert_eq!(browser.selected_count(), 0);
 
     // Verify database state
-    let remaining = load_history(&db_path).unwrap();
+    let remaining = load_history(&store).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].command_line, "cmd_b");
 }
 
 #[test]
 fn test_delete_selected_no_selection_is_noop() {
-    let (_dir, db_path) = create_test_db(&[("cmd_a", None)]);
-    let entries = load_history(&db_path).unwrap();
-    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, db_path.clone());
+    let (_dir, store) = create_test_db(&[("cmd_a", None)]);
+    let entries = load_history(&store).unwrap();
+    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, store.clone());
 
     browser.delete_selected().unwrap();
 
     assert_eq!(browser.entries.len(), 1);
-    let remaining = load_history(&db_path).unwrap();
+    let remaining = load_history(&store).unwrap();
     assert_eq!(remaining.len(), 1);
 }
 
 #[test]
 fn test_delete_selected_all_entries() {
-    let (_dir, db_path) = create_test_db(&[("cmd_a", None), ("cmd_b", None)]);
-    let entries = load_history(&db_path).unwrap();
-    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, db_path.clone());
+    let (_dir, store) = create_test_db(&[("cmd_a", None), ("cmd_b", None)]);
+    let entries = load_history(&store).unwrap();
+    let mut browser = HistoryBrowser::new(entries, HistoryDbMode::R, store.clone());
 
     browser.select_all_visible();
     assert_eq!(browser.selected_count(), 2);
@@ -251,7 +253,7 @@ fn test_delete_selected_all_entries() {
 
     assert!(browser.entries.is_empty());
     assert!(browser.filtered.is_empty());
-    let remaining = load_history(&db_path).unwrap();
+    let remaining = load_history(&store).unwrap();
     assert!(remaining.is_empty());
 }
 

--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -223,7 +223,7 @@ fn generate_info_lines(
 }
 
 fn history_runtime_label(runtime: &HistoryRuntime) -> String {
-    match runtime {
+    let label = match runtime {
         HistoryRuntime::Persistent(_) => runtime
             .requested_path()
             .map(|path| format!("persistent ({})", mask_home_path(path)))
@@ -232,8 +232,8 @@ fn history_runtime_label(runtime: &HistoryRuntime) -> String {
             crate::history::VolatileHistoryReason::Configured => {
                 "volatile (session only)".to_string()
             }
-            crate::history::VolatileHistoryReason::Fallback { requested_path } => {
-                match requested_path {
+            crate::history::VolatileHistoryReason::Fallback { .. } => {
+                match runtime.requested_path() {
                     Some(path) => format!(
                         "volatile (fallback; requested path: {})",
                         mask_home_path(path)
@@ -242,10 +242,14 @@ fn history_runtime_label(runtime: &HistoryRuntime) -> String {
                 }
             }
         },
-        HistoryRuntime::Unavailable { requested_path } => match requested_path {
+        HistoryRuntime::Unavailable { .. } => match runtime.requested_path() {
             Some(path) => format!("unavailable (requested path: {})", mask_home_path(path)),
             None => "unavailable".to_string(),
         },
+    };
+    match runtime.diagnostic_detail() {
+        Some(detail) if !label.contains(&detail) => format!("{label}; {detail}"),
+        _ => label,
     }
 }
 
@@ -351,6 +355,7 @@ fn style_info_line(line: &str) -> Line<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::history::HistoryFailureDetail;
 
     #[test]
     fn test_mask_env_value_with_home() {
@@ -492,7 +497,8 @@ mod tests {
 
     fn unavailable_history() -> HistoryRuntime {
         HistoryRuntime::Unavailable {
-            requested_path: None,
+            failure: HistoryFailureDetail::test_memory(),
+            previous_failure: None,
         }
     }
 
@@ -638,7 +644,8 @@ mod tests {
     #[test]
     fn history_runtime_labels_cover_all_lifecycle_states() {
         use crate::history::{
-            HistoryHandle, HistorySaveReceipt, HistoryStore, VolatileHistoryReason,
+            HistoryFailureDetail, HistoryHandle, HistorySaveReceipt, HistoryStore,
+            VolatileHistoryReason,
         };
 
         let store = HistoryStore::in_memory(None, None).unwrap();
@@ -653,17 +660,20 @@ mod tests {
         let fallback_with_path = HistoryRuntime::Volatile {
             handle: handle(),
             reason: VolatileHistoryReason::Fallback {
-                requested_path: Some("/tmp/history.db".into()),
+                persistent_failure: HistoryFailureDetail::test_persistent_open(
+                    "/tmp/history.db".into(),
+                ),
             },
         };
         let fallback_without_path = HistoryRuntime::Volatile {
             handle: handle(),
             reason: VolatileHistoryReason::Fallback {
-                requested_path: None,
+                persistent_failure: HistoryFailureDetail::test_path_resolution(),
             },
         };
         let unavailable = HistoryRuntime::Unavailable {
-            requested_path: None,
+            failure: HistoryFailureDetail::test_memory(),
+            previous_failure: None,
         };
         let persistent_dir = tempfile::tempdir().unwrap();
         let persistent_path = persistent_dir.path().join("history.db");
@@ -678,6 +688,6 @@ mod tests {
         assert!(
             history_runtime_label(&fallback_without_path).contains("fallback; no persistent path")
         );
-        assert_eq!(history_runtime_label(&unavailable), "unavailable");
+        assert!(history_runtime_label(&unavailable).starts_with("unavailable"));
     }
 }

--- a/crates/arf-console/src/pager/session_info.rs
+++ b/crates/arf-console/src/pager/session_info.rs
@@ -4,6 +4,7 @@ use super::{PagerAction, PagerConfig, PagerContent, copy_to_clipboard, run};
 use crate::config::{ConfigStatus, RSourceStatus, mask_home_path};
 use crate::editor::prompt::get_r_version;
 use crate::external::{formatter, rig};
+use crate::history::HistoryRuntime;
 use crate::repl::state::PromptRuntimeConfig;
 
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -16,16 +17,16 @@ pub fn display_session_info(
     prompt_config: &PromptRuntimeConfig,
     config_path: &Option<PathBuf>,
     config_status: ConfigStatus,
-    r_history_path: &Option<PathBuf>,
-    shell_history_path: &Option<PathBuf>,
+    r_history: &HistoryRuntime,
+    shell_history: &HistoryRuntime,
     r_source_status: &RSourceStatus,
 ) {
     let lines = generate_info_lines(
         prompt_config,
         config_path,
         config_status,
-        r_history_path,
-        shell_history_path,
+        r_history,
+        shell_history,
         r_source_status,
     );
 
@@ -47,8 +48,8 @@ fn generate_info_lines(
     prompt_config: &PromptRuntimeConfig,
     config_path: &Option<PathBuf>,
     config_status: ConfigStatus,
-    r_history_path: &Option<PathBuf>,
-    shell_history_path: &Option<PathBuf>,
+    r_history: &HistoryRuntime,
+    shell_history: &HistoryRuntime,
     r_source_status: &RSourceStatus,
 ) -> Vec<String> {
     let mut lines = Vec::new();
@@ -180,13 +181,17 @@ fn generate_info_lines(
 
     lines.push(String::new());
 
-    // History paths
-    if let Some(path) = r_history_path {
-        lines.push(format!("R history:      {}", mask_home_path(path)));
-    }
-    if let Some(path) = shell_history_path {
-        lines.push(format!("Shell history:  {}", mask_home_path(path)));
-    }
+    // History lifecycle state.  Volatile runtimes intentionally have no
+    // persistent path to display, while fallbacks retain the requested path
+    // as a diagnostic without implying that it was opened.
+    lines.push(format!(
+        "R history:      {}",
+        history_runtime_label(r_history)
+    ));
+    lines.push(format!(
+        "Shell history:  {}",
+        history_runtime_label(shell_history)
+    ));
 
     lines.push(String::new());
 
@@ -215,6 +220,33 @@ fn generate_info_lines(
     }
 
     lines
+}
+
+fn history_runtime_label(runtime: &HistoryRuntime) -> String {
+    match runtime {
+        HistoryRuntime::Persistent(_) => runtime
+            .requested_path()
+            .map(|path| format!("persistent ({})", mask_home_path(path)))
+            .unwrap_or_else(|| "persistent".to_string()),
+        HistoryRuntime::Volatile { reason, .. } => match reason {
+            crate::history::VolatileHistoryReason::Configured => {
+                "volatile (session only)".to_string()
+            }
+            crate::history::VolatileHistoryReason::Fallback { requested_path } => {
+                match requested_path {
+                    Some(path) => format!(
+                        "volatile (fallback; requested path: {})",
+                        mask_home_path(path)
+                    ),
+                    None => "volatile (fallback; no persistent path)".to_string(),
+                }
+            }
+        },
+        HistoryRuntime::Unavailable { requested_path } => match requested_path {
+            Some(path) => format!("unavailable (requested path: {})", mask_home_path(path)),
+            None => "unavailable".to_string(),
+        },
+    }
 }
 
 /// Mask home directory in environment variable value.
@@ -458,6 +490,12 @@ mod tests {
         PromptRuntimeConfig::builder(PromptFormatter::default(), "r> ", "+  ", "[bash] $ ").build()
     }
 
+    fn unavailable_history() -> HistoryRuntime {
+        HistoryRuntime::Unavailable {
+            requested_path: None,
+        }
+    }
+
     #[test]
     fn test_generate_info_lines_config_path_none() {
         // Read SHELL through PromptFormatter::new and R_HOME through generate_info_lines.
@@ -467,8 +505,8 @@ mod tests {
             &config,
             &None,
             ConfigStatus::Ok,
-            &None,
-            &None,
+            &unavailable_history(),
+            &unavailable_history(),
             &RSourceStatus::Path,
         );
         let config_line = lines
@@ -494,8 +532,8 @@ mod tests {
             &config,
             &Some(path),
             ConfigStatus::Ok,
-            &None,
-            &None,
+            &unavailable_history(),
+            &unavailable_history(),
             &RSourceStatus::Path,
         );
         let config_line = lines
@@ -530,8 +568,8 @@ mod tests {
             &config,
             &Some(path),
             ConfigStatus::Ok,
-            &None,
-            &None,
+            &unavailable_history(),
+            &unavailable_history(),
             &RSourceStatus::Path,
         );
         let config_line = lines
@@ -556,8 +594,8 @@ mod tests {
             &config,
             &Some(path),
             ConfigStatus::ParseError,
-            &None,
-            &None,
+            &unavailable_history(),
+            &unavailable_history(),
             &RSourceStatus::Path,
         );
         let config_line = lines
@@ -582,8 +620,8 @@ mod tests {
             &config,
             &Some(path),
             ConfigStatus::ReadError,
-            &None,
-            &None,
+            &unavailable_history(),
+            &unavailable_history(),
             &RSourceStatus::Path,
         );
         let config_line = lines
@@ -595,5 +633,51 @@ mod tests {
             "Read error should be shown: {}",
             config_line
         );
+    }
+
+    #[test]
+    fn history_runtime_labels_cover_all_lifecycle_states() {
+        use crate::history::{
+            HistoryHandle, HistorySaveReceipt, HistoryStore, VolatileHistoryReason,
+        };
+
+        let store = HistoryStore::in_memory(None, None).unwrap();
+        let handle = || HistoryHandle {
+            store: store.clone(),
+            receipt: HistorySaveReceipt::new(),
+        };
+        let configured = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Configured,
+        };
+        let fallback_with_path = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Fallback {
+                requested_path: Some("/tmp/history.db".into()),
+            },
+        };
+        let fallback_without_path = HistoryRuntime::Volatile {
+            handle: handle(),
+            reason: VolatileHistoryReason::Fallback {
+                requested_path: None,
+            },
+        };
+        let unavailable = HistoryRuntime::Unavailable {
+            requested_path: None,
+        };
+        let persistent_dir = tempfile::tempdir().unwrap();
+        let persistent_path = persistent_dir.path().join("history.db");
+        let persistent = HistoryRuntime::Persistent(HistoryHandle {
+            store: HistoryStore::open(persistent_path.clone(), None, None).unwrap(),
+            receipt: HistorySaveReceipt::new(),
+        });
+
+        assert!(history_runtime_label(&persistent).contains("persistent ("));
+        assert!(history_runtime_label(&configured).contains("volatile (session only)"));
+        assert!(history_runtime_label(&fallback_with_path).contains("fallback; requested path"));
+        assert!(
+            history_runtime_label(&fallback_without_path).contains("fallback; no persistent path")
+        );
+        assert_eq!(history_runtime_label(&unavailable), "unavailable");
     }
 }

--- a/crates/arf-console/src/repl/history.rs
+++ b/crates/arf-console/src/repl/history.rs
@@ -1,22 +1,60 @@
 //! REPL history setup and persistence helpers.
 
+use crate::config::HistoryMode;
 use crate::history::{
-    HistoryExtraInfo, HistoryHandle, HistorySaveOutcome, HistoryStore, ReedlineHistoryAdapter,
+    HistoryExtraInfo, HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistoryStore,
+    ReedlineHistoryAdapter, VolatileHistoryReason,
 };
 use reedline::{History, HistoryItem, HistoryItemId, HistorySessionId, Reedline};
 
 /// Set up history for a line editor with a specific database path.
 ///
-/// The optional handle is absent when no persistent path was configured or
-/// when the database could not be opened.  Reedline still retains its default
-/// history implementation in either case.
+/// Every available runtime uses an arf-owned SQLite backend. Persistent open
+/// failures explicitly degrade to an in-memory backend; no reedline default
+/// backend is installed implicitly.
 pub(super) fn setup_history(
     line_editor: Reedline,
     history_path: Option<std::path::PathBuf>,
     session_id: Option<HistorySessionId>,
-) -> (Reedline, Option<HistoryHandle>) {
+
+    mode: &HistoryMode,
+) -> (Reedline, HistoryRuntime) {
+    if matches!(mode, HistoryMode::Volatile) {
+        match HistoryStore::in_memory(session_id, Some(chrono::Utc::now())) {
+            Ok(store) => {
+                let receipt = crate::history::HistorySaveReceipt::new();
+                let adapter = ReedlineHistoryAdapter::new(store.clone(), receipt.clone());
+                let handle = HistoryHandle { store, receipt };
+                return (
+                    line_editor
+                        .with_history_session_id(session_id)
+                        .with_history(Box::new(adapter)),
+                    HistoryRuntime::Volatile {
+                        handle,
+                        reason: VolatileHistoryReason::Configured,
+                    },
+                );
+            }
+            Err(error) => {
+                log::warn!("Failed to create volatile history database: {error}");
+                return (
+                    line_editor,
+                    HistoryRuntime::Unavailable {
+                        requested_path: None,
+                    },
+                );
+            }
+        }
+    }
+
     let Some(path) = history_path else {
-        return (line_editor, None);
+        log::warn!("Persistent history requested but no history path is available");
+        return (
+            line_editor,
+            HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
+        );
     };
 
     match HistoryStore::open(path.clone(), session_id, Some(chrono::Utc::now())) {
@@ -27,7 +65,7 @@ pub(super) fn setup_history(
             let editor = line_editor
                 .with_history_session_id(session_id)
                 .with_history(Box::new(adapter));
-            (editor, Some(handle))
+            (editor, HistoryRuntime::Persistent(handle))
         }
         Err(error) => {
             log::warn!(
@@ -35,7 +73,34 @@ pub(super) fn setup_history(
                 path.display(),
                 error
             );
-            (line_editor, None)
+            match HistoryStore::in_memory(session_id, Some(chrono::Utc::now())) {
+                Ok(store) => {
+                    let receipt = crate::history::HistorySaveReceipt::new();
+                    let adapter = ReedlineHistoryAdapter::new(store.clone(), receipt.clone());
+                    let handle = HistoryHandle { store, receipt };
+                    let editor = line_editor
+                        .with_history_session_id(session_id)
+                        .with_history(Box::new(adapter));
+                    (
+                        editor,
+                        HistoryRuntime::Volatile {
+                            handle,
+                            reason: VolatileHistoryReason::Fallback {
+                                requested_path: path,
+                            },
+                        },
+                    )
+                }
+                Err(fallback_error) => {
+                    log::warn!("Failed to create volatile history fallback: {fallback_error}");
+                    (
+                        line_editor,
+                        HistoryRuntime::Unavailable {
+                            requested_path: Some(path),
+                        },
+                    )
+                }
+            }
         }
     }
 }
@@ -43,12 +108,11 @@ pub(super) fn setup_history(
 /// Save code injected into an interactive session with known ordinary-command
 /// metadata.  History failures are non-fatal to the IPC operation.
 ///
-/// Without a persistent store, reedline keeps its own default backend — an
-/// in-memory ring buffer — and ordinary typed input still lands there, so IPC
-/// code must too or it silently drops out of in-session recall. That backend is
-/// the only writer in that case, so the two branches must stay exclusive:
-/// saving through the editor while the adapter is installed would write to
-/// SQLite a second time.
+/// When the runtime reaches the final unavailable state, the caller may supply
+/// a non-owned in-memory backend. Ordinary typed input still lands there, so
+/// IPC code must use the same backend or it silently drops out of in-session
+/// recall. The two branches stay exclusive: saving through the editor while an
+/// owned adapter is installed would write to SQLite a second time.
 ///
 /// No ID is returned for the in-memory branch. `FileBackedHistory` hands back a
 /// deque index that shifts as the buffer evicts old entries, refuses `update`
@@ -97,7 +161,7 @@ pub(super) fn save_ipc_history(
 /// means "arf does not know".  Writing `false` would claim that arf knows the
 /// row was an ordinary command when the adapter did not save one successfully.
 pub(super) fn finalize_history(
-    handle: Option<&HistoryHandle>,
+    handle: Option<&HistoryRuntime>,
     outcome: Option<HistorySaveOutcome>,
     is_meta_command: bool,
 ) {
@@ -108,7 +172,9 @@ pub(super) fn finalize_history(
         return;
     };
 
-    if let Err(error) = handle.store.finalize_meta_command(id, is_meta_command) {
+    if let Some(store) = handle.store()
+        && let Err(error) = store.finalize_meta_command(id, is_meta_command)
+    {
         log::warn!("Failed to finalize history metadata for {id}: {error}");
     }
 }
@@ -116,7 +182,7 @@ pub(super) fn finalize_history(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::RSourceStatus;
+    use crate::config::{HistoryMode, RSourceStatus};
     use crate::editor::prompt::PromptFormatter;
     use crate::history::HistorySaveReceipt;
     use crate::repl::meta_command::process_meta_command;
@@ -127,6 +193,64 @@ mod tests {
 
     fn everything_query() -> SearchQuery {
         SearchQuery::everything(SearchDirection::Forward, None)
+    }
+
+    #[test]
+    fn setup_history_explicit_volatile_is_configured_runtime() {
+        let session_id = Reedline::create_history_session_id();
+        let (_, runtime) =
+            setup_history(Reedline::create(), None, session_id, &HistoryMode::Volatile);
+
+        assert!(matches!(
+            &runtime,
+            HistoryRuntime::Volatile {
+                reason: VolatileHistoryReason::Configured,
+                ..
+            }
+        ));
+        assert!(runtime.store().is_some());
+    }
+
+    #[test]
+    fn setup_history_persistent_open_failure_is_fallback_runtime() {
+        let temp_dir = tempfile::tempdir().expect("create temporary history directory");
+        let requested_path = temp_dir.path().to_path_buf();
+        let (_, runtime) = setup_history(
+            Reedline::create(),
+            Some(requested_path.clone()),
+            Reedline::create_history_session_id(),
+            &HistoryMode::Persistent {
+                dir: Some(requested_path.clone()),
+            },
+        );
+
+        match runtime {
+            HistoryRuntime::Volatile {
+                handle,
+                reason:
+                    VolatileHistoryReason::Fallback {
+                        requested_path: path,
+                    },
+            } => {
+                assert_eq!(path, requested_path);
+                assert!(handle.store.session().is_some());
+            }
+            other => panic!(
+                "expected persistent open fallback, got {}",
+                runtime_name(&other)
+            ),
+        }
+    }
+
+    fn runtime_name(runtime: &HistoryRuntime) -> &'static str {
+        match runtime {
+            HistoryRuntime::Persistent(_) => "persistent",
+            HistoryRuntime::Volatile { reason, .. } => match reason {
+                VolatileHistoryReason::Configured => "configured volatile",
+                VolatileHistoryReason::Fallback { .. } => "fallback volatile",
+            },
+            HistoryRuntime::Unavailable { .. } => "unavailable",
+        }
     }
 
     #[test]
@@ -166,6 +290,7 @@ mod tests {
             store: store.clone(),
             receipt: receipt.clone(),
         };
+        let runtime = HistoryRuntime::Persistent(handle.clone());
 
         let mut adapter = ReedlineHistoryAdapter::new(store, receipt.clone());
         let saved = adapter
@@ -173,7 +298,7 @@ mod tests {
             .unwrap();
         let id = saved.id.unwrap();
 
-        finalize_history(Some(&handle), receipt.take(), false);
+        finalize_history(Some(&runtime), receipt.take(), false);
         let reopened = SqliteBackedHistory::with_file(path.clone(), None, None).unwrap();
         assert_eq!(
             reopened
@@ -185,7 +310,7 @@ mod tests {
 
         // An empty line is never saved by reedline, so its empty receipt
         // outcome must not re-finalize the previous row.
-        finalize_history(Some(&handle), receipt.take(), true);
+        finalize_history(Some(&runtime), receipt.take(), true);
         let reopened = SqliteBackedHistory::with_file(path, None, None).unwrap();
         assert_eq!(
             reopened
@@ -205,6 +330,7 @@ mod tests {
             store: store.clone(),
             receipt: receipt.clone(),
         };
+        let runtime = HistoryRuntime::Persistent(handle.clone());
         let mut adapter = ReedlineHistoryAdapter::new(store.clone(), receipt);
         let id = adapter
             .save(HistoryItem::from_command_line(r"ordinary command"))
@@ -215,7 +341,7 @@ mod tests {
 
         // The same taken value is passed to both consumers, as it is on the
         // ordinary top-level R path: finalization and pending exit status.
-        finalize_history(Some(&handle), outcome, false);
+        finalize_history(Some(&runtime), outcome, false);
         let pending_history_context = PendingHistoryContext::Command {
             store: Some(store.clone()),
             history_id: match outcome {
@@ -236,12 +362,10 @@ mod tests {
         assert_eq!(stored.exit_status, Some(0));
     }
 
-    /// Without a persistent store, reedline keeps an in-memory backend that
-    /// ordinary typed input still reaches, so IPC code has to reach it too --
-    /// otherwise injected commands vanish from in-session recall under
-    /// `--no-history` or when the database fails to open.
+    /// Without an owned store, a caller-provided in-memory backend still
+    /// receives ordinary typed input, so IPC code has to reach it too.
     #[test]
-    fn ipc_history_falls_back_to_the_in_memory_backend_without_a_store() {
+    fn ipc_history_uses_the_caller_backend_without_an_owned_store() {
         let mut memory = FileBackedHistory::default();
 
         assert!(save_ipc_history(&mut memory, None, r#"print("hi")"#, None).is_none());
@@ -291,8 +415,12 @@ mod tests {
             process_meta_command(
                 input,
                 &mut prompt,
-                &None,
-                &None,
+                &HistoryRuntime::Unavailable {
+                    requested_path: None,
+                },
+                &HistoryRuntime::Unavailable {
+                    requested_path: None,
+                },
                 &RSourceStatus::Path,
                 &mut dir_stack,
                 None,

--- a/crates/arf-console/src/repl/history.rs
+++ b/crates/arf-console/src/repl/history.rs
@@ -1,17 +1,14 @@
 //! REPL history setup and persistence helpers.
 
+#[cfg(test)]
 use crate::config::HistoryMode;
-use crate::history::{
-    HistoryExtraInfo, HistoryHandle, HistoryRuntime, HistorySaveOutcome, HistoryStore,
-    ReedlineHistoryAdapter, VolatileHistoryReason,
-};
-use reedline::{History, HistoryItem, HistoryItemId, HistorySessionId, Reedline};
+use crate::history::{HistoryExtraInfo, HistoryRuntime, HistorySaveOutcome, HistoryStore};
+#[cfg(test)]
+use reedline::Reedline;
+use reedline::{History, HistoryItem, HistoryItemId, HistorySessionId};
 
-/// Set up history for a line editor with a specific database path.
-///
-/// Every available runtime uses an arf-owned SQLite backend. Persistent open
-/// failures explicitly degrade to an in-memory backend; no reedline default
-/// backend is installed implicitly.
+/// Set up an editor using the shared history lifecycle factory.
+#[cfg(test)]
 pub(super) fn setup_history(
     line_editor: Reedline,
     history_path: Option<std::path::PathBuf>,
@@ -19,90 +16,10 @@ pub(super) fn setup_history(
 
     mode: &HistoryMode,
 ) -> (Reedline, HistoryRuntime) {
-    if matches!(mode, HistoryMode::Volatile) {
-        match HistoryStore::in_memory(session_id, Some(chrono::Utc::now())) {
-            Ok(store) => {
-                let receipt = crate::history::HistorySaveReceipt::new();
-                let adapter = ReedlineHistoryAdapter::new(store.clone(), receipt.clone());
-                let handle = HistoryHandle { store, receipt };
-                return (
-                    line_editor
-                        .with_history_session_id(session_id)
-                        .with_history(Box::new(adapter)),
-                    HistoryRuntime::Volatile {
-                        handle,
-                        reason: VolatileHistoryReason::Configured,
-                    },
-                );
-            }
-            Err(error) => {
-                log::warn!("Failed to create volatile history database: {error}");
-                return (
-                    line_editor,
-                    HistoryRuntime::Unavailable {
-                        requested_path: None,
-                    },
-                );
-            }
-        }
-    }
-
-    let Some(path) = history_path else {
-        log::warn!("Persistent history requested but no history path is available");
-        return (
-            line_editor,
-            HistoryRuntime::Unavailable {
-                requested_path: None,
-            },
-        );
-    };
-
-    match HistoryStore::open(path.clone(), session_id, Some(chrono::Utc::now())) {
-        Ok(store) => {
-            let receipt = crate::history::HistorySaveReceipt::new();
-            let adapter = ReedlineHistoryAdapter::new(store.clone(), receipt.clone());
-            let handle = HistoryHandle { store, receipt };
-            let editor = line_editor
-                .with_history_session_id(session_id)
-                .with_history(Box::new(adapter));
-            (editor, HistoryRuntime::Persistent(handle))
-        }
-        Err(error) => {
-            log::warn!(
-                "Failed to open history database {}: {}",
-                path.display(),
-                error
-            );
-            match HistoryStore::in_memory(session_id, Some(chrono::Utc::now())) {
-                Ok(store) => {
-                    let receipt = crate::history::HistorySaveReceipt::new();
-                    let adapter = ReedlineHistoryAdapter::new(store.clone(), receipt.clone());
-                    let handle = HistoryHandle { store, receipt };
-                    let editor = line_editor
-                        .with_history_session_id(session_id)
-                        .with_history(Box::new(adapter));
-                    (
-                        editor,
-                        HistoryRuntime::Volatile {
-                            handle,
-                            reason: VolatileHistoryReason::Fallback {
-                                requested_path: path,
-                            },
-                        },
-                    )
-                }
-                Err(fallback_error) => {
-                    log::warn!("Failed to create volatile history fallback: {fallback_error}");
-                    (
-                        line_editor,
-                        HistoryRuntime::Unavailable {
-                            requested_path: Some(path),
-                        },
-                    )
-                }
-            }
-        }
-    }
+    let runtime =
+        HistoryRuntime::initialize(mode, history_path, session_id, Some(chrono::Utc::now()));
+    let line_editor = runtime.attach_to_editor(line_editor);
+    (line_editor, runtime)
 }
 
 /// Save code injected into an interactive session with known ordinary-command
@@ -184,7 +101,9 @@ mod tests {
     use super::*;
     use crate::config::{HistoryMode, RSourceStatus};
     use crate::editor::prompt::PromptFormatter;
-    use crate::history::HistorySaveReceipt;
+    use crate::history::{
+        HistoryHandle, HistorySaveReceipt, ReedlineHistoryAdapter, VolatileHistoryReason,
+    };
     use crate::repl::meta_command::process_meta_command;
     use crate::repl::state::{PendingHistoryContext, PromptRuntimeConfig};
     use reedline::{
@@ -232,7 +151,7 @@ mod tests {
                         requested_path: path,
                     },
             } => {
-                assert_eq!(path, requested_path);
+                assert_eq!(path.as_deref(), Some(requested_path.as_path()));
                 assert!(handle.store.session().is_some());
             }
             other => panic!(
@@ -240,6 +159,25 @@ mod tests {
                 runtime_name(&other)
             ),
         }
+    }
+
+    #[test]
+    fn setup_history_persistent_without_path_is_fallback_without_requested_path() {
+        let (_, runtime) = setup_history(
+            Reedline::create(),
+            None,
+            Reedline::create_history_session_id(),
+            &HistoryMode::Persistent { dir: None },
+        );
+        assert!(matches!(
+            runtime,
+            HistoryRuntime::Volatile {
+                reason: VolatileHistoryReason::Fallback {
+                    requested_path: None
+                },
+                ..
+            }
+        ));
     }
 
     fn runtime_name(runtime: &HistoryRuntime) -> &'static str {

--- a/crates/arf-console/src/repl/history.rs
+++ b/crates/arf-console/src/repl/history.rs
@@ -102,7 +102,8 @@ mod tests {
     use crate::config::{HistoryMode, RSourceStatus};
     use crate::editor::prompt::PromptFormatter;
     use crate::history::{
-        HistoryHandle, HistorySaveReceipt, ReedlineHistoryAdapter, VolatileHistoryReason,
+        HistoryFailureDetail, HistoryHandle, HistorySaveReceipt, ReedlineHistoryAdapter,
+        VolatileHistoryReason,
     };
     use crate::repl::meta_command::process_meta_command;
     use crate::repl::state::{PendingHistoryContext, PromptRuntimeConfig};
@@ -142,16 +143,18 @@ mod tests {
                 dir: Some(requested_path.clone()),
             },
         );
+        assert!(
+            runtime
+                .startup_warning()
+                .is_some_and(|warning| warning.contains("persistent history open failed"))
+        );
 
+        assert_eq!(runtime.requested_path(), Some(requested_path.as_path()));
         match runtime {
             HistoryRuntime::Volatile {
                 handle,
-                reason:
-                    VolatileHistoryReason::Fallback {
-                        requested_path: path,
-                    },
+                reason: VolatileHistoryReason::Fallback { .. },
             } => {
-                assert_eq!(path.as_deref(), Some(requested_path.as_path()));
                 assert!(handle.store.session().is_some());
             }
             other => panic!(
@@ -169,12 +172,15 @@ mod tests {
             Reedline::create_history_session_id(),
             &HistoryMode::Persistent { dir: None },
         );
+        assert!(
+            runtime
+                .startup_warning()
+                .is_some_and(|warning| warning.contains("path resolution failed"))
+        );
         assert!(matches!(
             runtime,
             HistoryRuntime::Volatile {
-                reason: VolatileHistoryReason::Fallback {
-                    requested_path: None
-                },
+                reason: VolatileHistoryReason::Fallback { .. },
                 ..
             }
         ));
@@ -354,10 +360,12 @@ mod tests {
                 input,
                 &mut prompt,
                 &HistoryRuntime::Unavailable {
-                    requested_path: None,
+                    failure: HistoryFailureDetail::test_memory(),
+                    previous_failure: None,
                 },
                 &HistoryRuntime::Unavailable {
-                    requested_path: None,
+                    failure: HistoryFailureDetail::test_memory(),
+                    previous_failure: None,
                 },
                 &RSourceStatus::Path,
                 &mut dir_stack,

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -3,8 +3,8 @@
 use crate::completion::path::expand_tilde;
 use crate::config::RSourceStatus;
 use crate::external::formatter;
+use crate::history::{HistoryRuntime, HistoryStore};
 use crate::pager::HistoryDbMode;
-use reedline::{History, SqliteBackedHistory};
 use std::path::PathBuf;
 
 use super::shell::confirm_action;
@@ -30,7 +30,14 @@ pub enum MetaCommandResult {
     /// Display changelog (caller runs pager)
     ShowChangelog,
     /// Open the history browser (caller runs pager)
-    ShowHistoryBrowser { path: PathBuf, mode: HistoryDbMode },
+    ShowHistoryBrowser {
+        store: HistoryStore,
+        mode: HistoryDbMode,
+    },
+    /// Clear stores after the caller has finalized the command provenance.
+    ClearHistory {
+        stores: Vec<(&'static str, HistoryStore)>,
+    },
     /// Display history schema (caller runs pager)
     ShowHistorySchema,
 }
@@ -40,8 +47,8 @@ pub enum MetaCommandResult {
 pub fn process_meta_command(
     input: &str,
     prompt_config: &mut PromptRuntimeConfig,
-    r_history_path: &Option<PathBuf>,
-    shell_history_path: &Option<PathBuf>,
+    r_history: &HistoryRuntime,
+    shell_history: &HistoryRuntime,
     r_source_status: &RSourceStatus,
     dir_stack: &mut Vec<PathBuf>,
     history_session_id: Option<i64>,
@@ -179,8 +186,8 @@ pub fn process_meta_command(
                 "browse" => {
                     let target = parts.get(2).copied().unwrap_or("");
                     process_history_browse(
-                        r_history_path,
-                        shell_history_path,
+                        r_history,
+                        shell_history,
                         target,
                         prompt_config.is_shell_enabled(),
                     )
@@ -188,8 +195,8 @@ pub fn process_meta_command(
                 "clear" => {
                     let target = parts.get(2).copied().unwrap_or("");
                     process_history_clear(
-                        r_history_path,
-                        shell_history_path,
+                        r_history,
+                        shell_history,
                         target,
                         prompt_config.is_shell_enabled(),
                     )
@@ -333,44 +340,41 @@ pub fn process_meta_command(
 
 /// Process :history browse command.
 fn process_history_browse(
-    r_history_path: &Option<PathBuf>,
-    shell_history_path: &Option<PathBuf>,
+    r_history: &HistoryRuntime,
+    shell_history: &HistoryRuntime,
     target: &str,
     is_shell_mode: bool,
 ) -> Option<MetaCommandResult> {
     // Determine which database to browse
-    let (mode, path) = match target {
+    let (mode, runtime) = match target {
         "" => {
             // Default: browse based on current mode
             if is_shell_mode {
-                (HistoryDbMode::Shell, shell_history_path.as_ref())
+                (HistoryDbMode::Shell, shell_history)
             } else {
-                (HistoryDbMode::R, r_history_path.as_ref())
+                (HistoryDbMode::R, r_history)
             }
         }
-        "r" | "R" => (HistoryDbMode::R, r_history_path.as_ref()),
-        "shell" => (HistoryDbMode::Shell, shell_history_path.as_ref()),
+        "r" | "R" => (HistoryDbMode::R, r_history),
+        "shell" => (HistoryDbMode::Shell, shell_history),
         _ => {
             arf_println!("Unknown target: {}. Use r or shell.", target);
             return Some(MetaCommandResult::Handled);
         }
     };
 
-    let Some(db_path) = path else {
-        arf_println!("History is disabled for {} mode.", mode.display_name());
+    let Some(store) = runtime.store() else {
+        arf_println!("History is unavailable for {} mode.", mode.display_name());
         return Some(MetaCommandResult::Handled);
     };
 
-    Some(MetaCommandResult::ShowHistoryBrowser {
-        path: db_path.clone(),
-        mode,
-    })
+    Some(MetaCommandResult::ShowHistoryBrowser { store, mode })
 }
 
 /// Process :history clear command.
 fn process_history_clear(
-    r_history_path: &Option<PathBuf>,
-    shell_history_path: &Option<PathBuf>,
+    r_history: &HistoryRuntime,
+    shell_history: &HistoryRuntime,
     target: &str,
     is_shell_mode: bool,
 ) -> Option<MetaCommandResult> {
@@ -390,30 +394,24 @@ fn process_history_clear(
     };
 
     // Collect paths to clear based on target
-    let paths_to_clear: Vec<(&str, &PathBuf)> = match clear_target {
-        "r" => r_history_path
-            .as_ref()
-            .map(|p| vec![("R", p)])
-            .unwrap_or_default(),
-        "shell" => shell_history_path
-            .as_ref()
-            .map(|p| vec![("Shell", p)])
-            .unwrap_or_default(),
+    let runtimes: Vec<(&str, &HistoryRuntime)> = match clear_target {
+        "r" => vec![("R", r_history)],
+        "shell" => vec![("Shell", shell_history)],
         "all" => {
-            let mut paths = Vec::new();
-            if let Some(p) = r_history_path.as_ref() {
-                paths.push(("R", p));
-            }
-            if let Some(p) = shell_history_path.as_ref() {
-                paths.push(("Shell", p));
-            }
-            paths
+            vec![("R", r_history), ("Shell", shell_history)]
         }
         _ => unreachable!(),
     };
 
-    if paths_to_clear.is_empty() {
-        arf_println!("History is disabled.");
+    let stores = dedup_history_stores(
+        runtimes
+            .into_iter()
+            .filter_map(|(name, runtime)| runtime.store().map(|store| (name, store)))
+            .collect(),
+    );
+
+    if stores.is_empty() {
+        arf_println!("History is unavailable.");
         return Some(MetaCommandResult::Handled);
     }
 
@@ -421,18 +419,13 @@ fn process_history_clear(
     let mut total_count = 0i64;
     let mut counts: Vec<(&str, i64)> = Vec::new();
 
-    for (name, path) in &paths_to_clear {
-        match SqliteBackedHistory::with_file((*path).clone(), None, None) {
-            Ok(history) => {
-                if let Ok(count) = history.count_all() {
-                    counts.push((name, count));
-                    total_count += count;
-                }
+    for (name, store) in &stores {
+        match store.count_all() {
+            Ok(count) => {
+                counts.push((name, count));
+                total_count += count;
             }
-            Err(_) => {
-                // Database doesn't exist yet, treat as 0 entries
-                counts.push((name, 0));
-            }
+            Err(error) => arf_println!("Failed to read {} history: {}", name, error),
         }
     }
 
@@ -458,29 +451,21 @@ fn process_history_clear(
         return Some(MetaCommandResult::Handled);
     }
 
-    // Perform clear on each database
-    let mut cleared_count = 0i64;
-    for (name, path) in &paths_to_clear {
-        match SqliteBackedHistory::with_file((*path).clone(), None, None) {
-            Ok(mut history) => {
-                if let Ok(count) = history.count_all()
-                    && count > 0
-                {
-                    if let Err(e) = history.clear() {
-                        arf_println!("Failed to clear {} history: {}", name, e);
-                    } else {
-                        cleared_count += count;
-                    }
-                }
-            }
-            Err(_) => {
-                // Database doesn't exist, nothing to clear
-            }
-        }
-    }
+    Some(MetaCommandResult::ClearHistory { stores })
+}
 
-    arf_println!("Cleared {} history entries.", cleared_count);
-    Some(MetaCommandResult::Handled)
+fn dedup_history_stores(stores: Vec<(&str, HistoryStore)>) -> Vec<(&str, HistoryStore)> {
+    let mut unique: Vec<(&str, HistoryStore)> = Vec::new();
+    for (name, store) in stores {
+        if unique
+            .iter()
+            .any(|(_, existing)| existing.same_owner(&store))
+        {
+            continue;
+        }
+        unique.push((name, store));
+    }
+    unique
 }
 
 /// Change the current working directory.
@@ -552,16 +537,20 @@ mod tests {
     fn call_meta(
         input: &str,
         config: &mut PromptRuntimeConfig,
-        r_history_path: &Option<PathBuf>,
-        shell_history_path: &Option<PathBuf>,
+        _r_history_path: &Option<PathBuf>,
+        _shell_history_path: &Option<PathBuf>,
         status: &RSourceStatus,
     ) -> Option<MetaCommandResult> {
         let mut dir_stack = Vec::new();
         process_meta_command(
             input,
             config,
-            r_history_path,
-            shell_history_path,
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
             status,
             &mut dir_stack,
             None,
@@ -905,8 +894,12 @@ mod tests {
         let result = process_meta_command(
             &format!(":cd {}", tmp.path().display()),
             &mut config,
-            &None,
-            &None,
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
             &status,
             &mut dir_stack,
             None,
@@ -927,8 +920,12 @@ mod tests {
         let result = process_meta_command(
             &format!(":pushd {}", tmp.path().display()),
             &mut config,
-            &None,
-            &None,
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
             &status,
             &mut dir_stack,
             None,
@@ -940,8 +937,12 @@ mod tests {
         let result = process_meta_command(
             ":popd",
             &mut config,
-            &None,
-            &None,
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
+            &HistoryRuntime::Unavailable {
+                requested_path: None,
+            },
             &status,
             &mut dir_stack,
             None,
@@ -1099,5 +1100,16 @@ mod tests {
         // :shell! is not a valid command (! only supported on restart/switch)
         let result = call_meta(":shell!", &mut config, &None, &None, &status);
         assert!(matches!(result, Some(MetaCommandResult::Unknown(_))));
+    }
+
+    #[test]
+    fn history_clear_deduplicates_shared_store_owners() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = HistoryStore::open(dir.path().join("history.db"), None, None).unwrap();
+        let unique = HistoryStore::open(dir.path().join("other.db"), None, None).unwrap();
+        let stores =
+            dedup_history_stores(vec![("R", store.clone()), ("Shell", store), ("R", unique)]);
+        assert_eq!(stores.len(), 2);
+        assert_eq!(stores[0].0, "R");
     }
 }

--- a/crates/arf-console/src/repl/meta_command.rs
+++ b/crates/arf-console/src/repl/meta_command.rs
@@ -523,6 +523,7 @@ pub(crate) fn dir_command_hint(shell_cmd: &str) -> Option<&'static str> {
 mod tests {
     use super::*;
     use crate::editor::prompt::PromptFormatter;
+    use crate::history::HistoryFailureDetail;
 
     fn create_test_prompt_config() -> PromptRuntimeConfig {
         PromptRuntimeConfig::builder(PromptFormatter::default(), "r> ", "+  ", "[bash] $ ").build()
@@ -546,10 +547,12 @@ mod tests {
             input,
             config,
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             status,
             &mut dir_stack,
@@ -895,10 +898,12 @@ mod tests {
             &format!(":cd {}", tmp.path().display()),
             &mut config,
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &status,
             &mut dir_stack,
@@ -921,10 +926,12 @@ mod tests {
             &format!(":pushd {}", tmp.path().display()),
             &mut config,
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &status,
             &mut dir_stack,
@@ -938,10 +945,12 @@ mod tests {
             ":popd",
             &mut config,
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &HistoryRuntime::Unavailable {
-                requested_path: None,
+                failure: HistoryFailureDetail::test_memory(),
+                previous_failure: None,
             },
             &status,
             &mut dir_stack,

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -15,7 +15,7 @@ use crate::completion::menu::{FunctionAwareMenu, StateSyncHistoryMenu};
 use crate::completion::shell::ShellCompleter;
 use crate::config::{
     AutoSuggestions, Config, ConfigStatus, EditorMode, ModeIndicatorPosition, RSourceStatus,
-    history_dir,
+    history_dir_for_mode,
 };
 use crate::editor::hinter::RLanguageHinter;
 use crate::editor::mode::new_editor_state_ref;
@@ -278,19 +278,13 @@ impl Repl {
 
     /// Get the R history database path based on configuration.
     fn r_history_path(&self) -> Option<std::path::PathBuf> {
-        if self.config.history.disabled {
-            return None;
-        }
-        let dir = self.config.history.dir.clone().or_else(history_dir);
+        let dir = history_dir_for_mode(&self.config.history.mode);
         dir.map(|d| d.join("r.db"))
     }
 
     /// Get the Shell history database path based on configuration.
     fn shell_history_path(&self) -> Option<std::path::PathBuf> {
-        if self.config.history.disabled {
-            return None;
-        }
-        let dir = self.config.history.dir.clone().or_else(history_dir);
+        let dir = history_dir_for_mode(&self.config.history.mode);
         dir.map(|d| d.join("shell.db"))
     }
 
@@ -360,8 +354,12 @@ impl Repl {
         let line_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for R mode
-        let (mut line_editor, r_history_handle) =
-            setup_history(line_editor, self.r_history_path(), self.session_id);
+        let (mut line_editor, r_history_handle) = setup_history(
+            line_editor,
+            self.r_history_path(),
+            self.session_id,
+            &self.config.history.mode,
+        );
 
         // Set up edit mode (Vi or Emacs) with conditional ':' keybinding
         let editor_state = new_editor_state_ref();
@@ -500,9 +498,13 @@ impl Repl {
         // Create shell line editor with separate history
         let (shell_line_editor, shell_history_handle) = self.create_shell_line_editor();
 
+        if let Some(store) = r_history_handle.store() {
+            crate::ipc::set_history_store(store);
+        }
+
         // If neither history DB was opened, clear the session ID from IPC metadata
         // so clients are not misled about history isolation being active.
-        if r_history_handle.is_none() && shell_history_handle.is_none() {
+        if !r_history_handle.is_available() && !shell_history_handle.is_available() {
             crate::ipc::clear_history_session_id();
         }
 
@@ -561,7 +563,8 @@ impl Repl {
                 sponge_queue: state::SpongeQueue::new(),
                 dir_stack: Vec::new(),
                 // Only expose session ID if at least one history DB was opened
-                history_session_id: if r_history_handle.is_some() || shell_history_handle.is_some()
+                history_session_id: if r_history_handle.is_available()
+                    || shell_history_handle.is_available()
                 {
                     self.session_id
                 } else {
@@ -629,12 +632,12 @@ impl Repl {
                 && !repl_state.sponge_queue.is_empty()
             {
                 for id_to_delete in repl_state.sponge_queue.drain_failed_ids() {
-                    if let Some(handle) = &repl_state.r_history {
-                        let _ = handle.store.delete(id_to_delete);
+                    if let Some(store) = repl_state.r_history.store() {
+                        let _ = store.delete(id_to_delete);
                     }
                 }
-                if let Some(handle) = &repl_state.r_history {
-                    let _ = handle.store.sync();
+                if let Some(store) = repl_state.r_history.store() {
+                    let _ = store.sync();
                 }
             }
         });
@@ -653,14 +656,21 @@ impl Repl {
         let line_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for R mode
-        let (mut line_editor, history_handle) =
-            setup_history(line_editor, self.r_history_path(), self.session_id);
+        let (mut line_editor, history_handle) = setup_history(
+            line_editor,
+            self.r_history_path(),
+            self.session_id,
+            &self.config.history.mode,
+        );
+        if let Some(store) = history_handle.store() {
+            crate::ipc::set_history_store(store);
+        }
 
         // If history DB failed to open, clear the session ID from IPC metadata
-        if history_handle.is_none() {
+        if !history_handle.is_available() {
             crate::ipc::clear_history_session_id();
         }
-        let history_session_id = if history_handle.is_some() {
+        let history_session_id = if history_handle.is_available() {
             self.history_session_id_raw()
         } else {
             None
@@ -768,15 +778,13 @@ impl Repl {
         loop {
             match line_editor.read_line(&prompt) {
                 Ok(Signal::Success(line)) => {
-                    let save_outcome = history_handle
-                        .as_ref()
-                        .and_then(|handle| handle.receipt.take());
+                    let save_outcome = history_handle.receipt_outcome();
 
                     let trimmed = line.trim();
                     if trimmed.is_empty() {
                         // A whitespace-only buffer is still saved by reedline,
                         // so record that it is an ordinary line before skipping.
-                        finalize_history(history_handle.as_ref(), save_outcome, false);
+                        finalize_history(Some(&history_handle), save_outcome, false);
                         continue;
                     }
 
@@ -785,14 +793,14 @@ impl Repl {
                     if let Some(result) = process_meta_command(
                         &line,
                         &mut prompt_config,
-                        &r_history_path,
-                        &shell_history_path,
+                        &history_handle,
+                        &history_handle,
                         &self.r_source_status,
                         &mut dir_stack,
                         history_session_id,
                         self.r_home.as_deref(),
                     ) {
-                        finalize_history(history_handle.as_ref(), save_outcome, true);
+                        finalize_history(Some(&history_handle), save_outcome, true);
                         // Clear duration so the previous R command's time
                         // does not persist in the prompt after a meta command.
                         prompt_config.clear_command_duration();
@@ -813,7 +821,7 @@ impl Repl {
                         }
                     }
 
-                    finalize_history(history_handle.as_ref(), save_outcome, false);
+                    finalize_history(Some(&history_handle), save_outcome, false);
 
                     // Not a meta command - show R not initialized message
                     println!("{}", format!("[R not initialized] {}", line).dark_grey());
@@ -847,13 +855,17 @@ impl Repl {
     /// Create a shell mode line editor with separate history.
     ///
     /// Shell mode uses a separate SQLite history database from R mode.
-    fn create_shell_line_editor(&self) -> (Reedline, Option<crate::history::HistoryHandle>) {
+    fn create_shell_line_editor(&self) -> (Reedline, crate::history::HistoryRuntime) {
         // Create shell editor with bracketed paste enabled
         let shell_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for Shell mode (separate from R)
-        let (mut shell_editor, history_handle) =
-            setup_history(shell_editor, self.shell_history_path(), self.session_id);
+        let (mut shell_editor, history_handle) = setup_history(
+            shell_editor,
+            self.shell_history_path(),
+            self.session_id,
+            &self.config.history.mode,
+        );
 
         // Use same edit mode as R editor
         shell_editor = match self.config.editor.mode {
@@ -1002,8 +1014,23 @@ fn handle_meta_command_result(
             with_ipc_alternate_guard(crate::pager::display_changelog);
             MetaAction::Continue
         }
-        MetaCommandResult::ShowHistoryBrowser { path, mode } => {
-            run_pager_history_browser(&path, mode);
+        MetaCommandResult::ShowHistoryBrowser { store, mode } => {
+            run_pager_history_browser(&store, mode);
+            MetaAction::Continue
+        }
+        MetaCommandResult::ClearHistory { stores } => {
+            let mut cleared_count = 0i64;
+            for (name, store) in stores {
+                match store.count_all() {
+                    Ok(count) if count > 0 => match store.clear() {
+                        Ok(()) => cleared_count += count,
+                        Err(error) => arf_println!("Failed to clear {} history: {}", name, error),
+                    },
+                    Ok(_) => {}
+                    Err(error) => arf_println!("Failed to read {} history: {}", name, error),
+                }
+            }
+            arf_println!("Cleared {} history entries.", cleared_count);
             MetaAction::Continue
         }
         MetaCommandResult::ShowHistorySchema => {

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -21,6 +21,7 @@ use crate::editor::hinter::RLanguageHinter;
 use crate::editor::mode::new_editor_state_ref;
 use crate::editor::prompt::PromptFormatter;
 use crate::highlighter::{CombinedHighlighter, MetaCommandHighlighter};
+use crate::history::HistoryRuntime;
 use anyhow::Result;
 use crossterm::{
     ExecutableCommand,
@@ -44,7 +45,10 @@ use crate::editor::keybindings::{
 };
 use crate::editor::validator::RValidator;
 use banner::{format_banner, format_override_line};
-use history::{finalize_history, setup_history};
+use history::finalize_history;
+#[cfg(test)]
+#[allow(unused_imports)]
+use history::setup_history;
 use meta_command::{MetaCommandResult, process_meta_command};
 use pager_ui::{run_pager_help_browser, run_pager_history_browser, with_ipc_alternate_guard};
 use prompt::RPrompt;
@@ -230,6 +234,9 @@ pub struct Repl {
     prompt_formatter: PromptFormatter,
     /// Session ID for history isolation (shared across R and shell history).
     session_id: Option<HistorySessionId>,
+    /// History runtimes prepared before the IPC server advertises this session.
+    prepared_r_history: Option<HistoryRuntime>,
+    prepared_shell_history: Option<HistoryRuntime>,
 }
 
 impl Repl {
@@ -268,12 +275,77 @@ impl Repl {
             r_initialized,
             prompt_formatter,
             session_id,
+            prepared_r_history: None,
+            prepared_shell_history: None,
         })
     }
 
+    /// Initialize both owned runtimes before IPC becomes reachable.
+    pub(crate) fn prepare_history(&mut self) {
+        if self.prepared_r_history.is_some() {
+            return;
+        }
+        let (r_runtime, shell_runtime) = self.initialize_history_runtimes();
+        Self::report_history_runtime("R", &r_runtime);
+        Self::report_history_runtime("Shell", &shell_runtime);
+        if let Some(store) = r_runtime.store() {
+            crate::ipc::set_history_store(store);
+        }
+        if !r_runtime.is_available() {
+            crate::ipc::clear_history_session_id();
+        }
+        self.prepared_r_history = Some(r_runtime);
+        self.prepared_shell_history = Some(shell_runtime);
+    }
+
+    /// Build the independent R and shell owners without registering either
+    /// one globally. This keeps construction testable and makes global IPC
+    /// registration an explicit responsibility of `prepare_history`.
+    fn initialize_history_runtimes(&self) -> (HistoryRuntime, HistoryRuntime) {
+        let r_runtime = HistoryRuntime::initialize(
+            &self.config.history.mode,
+            self.r_history_path(),
+            self.session_id,
+            Some(chrono::Utc::now()),
+        );
+        let shell_runtime = HistoryRuntime::initialize(
+            &self.config.history.mode,
+            self.shell_history_path(),
+            self.session_id,
+            Some(chrono::Utc::now()),
+        );
+        (r_runtime, shell_runtime)
+    }
+
+    fn report_history_runtime(label: &str, runtime: &HistoryRuntime) {
+        if let Some(diagnostic) = runtime.startup_warning() {
+            eprintln!("Warning: {label} history: {diagnostic}");
+            log::warn!("{label} history: {diagnostic}");
+        }
+    }
+
+    fn prepared_r_history(&self) -> HistoryRuntime {
+        self.prepared_r_history
+            .clone()
+            .expect("history runtimes must be prepared before the REPL starts")
+    }
+
+    fn prepared_shell_history(&self) -> HistoryRuntime {
+        self.prepared_shell_history
+            .clone()
+            .expect("history runtimes must be prepared before the REPL starts")
+    }
+
     /// Get the history session ID as an i64 (for IPC).
-    fn history_session_id_raw(&self) -> Option<i64> {
-        self.session_id.map(i64::from)
+    pub(crate) fn history_session_id_raw(&self) -> Option<i64> {
+        self.prepared_r_history()
+            .store()
+            .and_then(|store| store.session())
+            .map(i64::from)
+    }
+
+    pub(crate) fn r_home_for_ipc(&self) -> Option<String> {
+        self.r_home.as_ref().map(|path| path.display().to_string())
     }
 
     /// Get the R history database path based on configuration.
@@ -307,6 +379,9 @@ impl Repl {
 
     /// Run the REPL main loop.
     pub fn run(&mut self) -> Result<()> {
+        // Keep direct callers safe while preserving the invariant that all
+        // runtime consumers use the owners registered before IPC startup.
+        self.prepare_history();
         // Show startup banner unless disabled
         if self.config.startup.show_banner {
             let banner = format_banner(
@@ -354,12 +429,8 @@ impl Repl {
         let line_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for R mode
-        let (mut line_editor, r_history_handle) = setup_history(
-            line_editor,
-            self.r_history_path(),
-            self.session_id,
-            &self.config.history.mode,
-        );
+        let r_history_handle = self.prepared_r_history();
+        let mut line_editor = r_history_handle.attach_to_editor(line_editor);
 
         // Set up edit mode (Vi or Emacs) with conditional ':' keybinding
         let editor_state = new_editor_state_ref();
@@ -498,15 +569,8 @@ impl Repl {
         // Create shell line editor with separate history
         let (shell_line_editor, shell_history_handle) = self.create_shell_line_editor();
 
-        if let Some(store) = r_history_handle.store() {
-            crate::ipc::set_history_store(store);
-        }
-
-        // If neither history DB was opened, clear the session ID from IPC metadata
-        // so clients are not misled about history isolation being active.
-        if !r_history_handle.is_available() && !shell_history_handle.is_available() {
-            crate::ipc::clear_history_session_id();
-        }
+        // The R runtime was registered before the IPC server started; shell
+        // history remains a separate owner for shell-mode commands.
 
         // Create prompt runtime config with unexpanded templates
         // Templates are expanded dynamically in build_main_prompt() to track cwd changes
@@ -543,9 +607,6 @@ impl Repl {
         .build();
 
         // Get history paths for :history commands
-        let r_history_path = self.r_history_path();
-        let shell_history_path = self.shell_history_path();
-
         // Store state in thread-local
         REPL_STATE.with(|state| {
             *state.borrow_mut() = Some(ReplState {
@@ -555,17 +616,14 @@ impl Repl {
                 should_exit: false,
                 config_path: self.config_path.clone(),
                 config_status: self.config_status,
-                r_history_path,
-                shell_history_path,
                 r_source_status: self.r_source_status.clone(),
                 r_home: self.r_home.clone(),
                 forget_config: self.config.experimental.history_forget.clone(),
                 sponge_queue: state::SpongeQueue::new(),
                 dir_stack: Vec::new(),
-                // Only expose session ID if at least one history DB was opened
-                history_session_id: if r_history_handle.is_available()
-                    || shell_history_handle.is_available()
-                {
+                // IPC advertises the R runtime's session only; shell history
+                // remains separately owned and is not an IPC filter source.
+                history_session_id: if r_history_handle.is_available() {
                     self.session_id
                 } else {
                     None
@@ -656,17 +714,11 @@ impl Repl {
         let line_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for R mode
-        let (mut line_editor, history_handle) = setup_history(
-            line_editor,
-            self.r_history_path(),
-            self.session_id,
-            &self.config.history.mode,
-        );
-        if let Some(store) = history_handle.store() {
-            crate::ipc::set_history_store(store);
-        }
-
-        // If history DB failed to open, clear the session ID from IPC metadata
+        let history_handle = self.prepared_r_history();
+        let mut line_editor = history_handle.attach_to_editor(line_editor);
+        // Meta commands use the already-prepared shell owner directly.
+        let shell_history_handle = self.prepared_shell_history();
+        // Only an available R runtime is advertised for IPC history filtering.
         if !history_handle.is_available() {
             crate::ipc::clear_history_session_id();
         }
@@ -768,8 +820,6 @@ impl Repl {
                     self.config.colors.prompt.vi.clone(),
                 )
                 .build();
-        let r_history_path = self.r_history_path();
-        let shell_history_path = self.shell_history_path();
         // Separate dir_stack for standalone mode (R not initialized).
         // The R mainloop path stores its own dir_stack in ReplState.
         // These two paths are mutually exclusive, so no sharing is needed.
@@ -794,7 +844,7 @@ impl Repl {
                         &line,
                         &mut prompt_config,
                         &history_handle,
-                        &history_handle,
+                        &shell_history_handle,
                         &self.r_source_status,
                         &mut dir_stack,
                         history_session_id,
@@ -808,8 +858,8 @@ impl Repl {
                             prompt_config: &prompt_config,
                             config_path: &self.config_path,
                             config_status: self.config_status,
-                            r_history_path: &r_history_path,
-                            shell_history_path: &shell_history_path,
+                            r_history: &history_handle,
+                            shell_history: &shell_history_handle,
                             r_source_status: &self.r_source_status,
                         };
                         match handle_meta_command_result(result, &ctx) {
@@ -860,12 +910,8 @@ impl Repl {
         let shell_editor = Reedline::create().use_bracketed_paste(true);
 
         // Set up SQLite-backed history for Shell mode (separate from R)
-        let (mut shell_editor, history_handle) = setup_history(
-            shell_editor,
-            self.shell_history_path(),
-            self.session_id,
-            &self.config.history.mode,
-        );
+        let history_handle = self.prepared_shell_history();
+        let mut shell_editor = history_handle.attach_to_editor(shell_editor);
 
         // Use same edit mode as R editor
         shell_editor = match self.config.editor.mode {
@@ -965,8 +1011,8 @@ struct SessionInfoContext<'a> {
     prompt_config: &'a PromptRuntimeConfig,
     config_path: &'a Option<std::path::PathBuf>,
     config_status: ConfigStatus,
-    r_history_path: &'a Option<std::path::PathBuf>,
-    shell_history_path: &'a Option<std::path::PathBuf>,
+    r_history: &'a HistoryRuntime,
+    shell_history: &'a HistoryRuntime,
     r_source_status: &'a RSourceStatus,
 }
 
@@ -1003,8 +1049,8 @@ fn handle_meta_command_result(
                     ctx.prompt_config,
                     ctx.config_path,
                     ctx.config_status,
-                    ctx.r_history_path,
-                    ctx.shell_history_path,
+                    ctx.r_history,
+                    ctx.shell_history,
                     ctx.r_source_status,
                 );
             });
@@ -1041,5 +1087,33 @@ fn handle_meta_command_result(
             }
             MetaAction::Continue
         }
+    }
+}
+
+#[cfg(test)]
+mod history_runtime_tests {
+    use super::*;
+
+    #[test]
+    fn prepared_r_and_shell_histories_are_distinct_stable_owners() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.history.mode = crate::config::HistoryMode::Persistent {
+            dir: Some(temp_dir.path().to_path_buf()),
+        };
+        let repl = Repl::new(
+            config,
+            None,
+            ConfigStatus::Ok,
+            RSourceStatus::Path,
+            None,
+            Reedline::create_history_session_id(),
+        )
+        .unwrap();
+        let (r_runtime, shell_runtime) = repl.initialize_history_runtimes();
+        let r_store = r_runtime.store().unwrap();
+        let shell_store = shell_runtime.store().unwrap();
+        assert!(!r_store.same_owner(&shell_store));
+        assert!(shell_runtime.store().unwrap().same_owner(&shell_store));
     }
 }

--- a/crates/arf-console/src/repl/pager_ui.rs
+++ b/crates/arf-console/src/repl/pager_ui.rs
@@ -38,8 +38,12 @@ pub(super) fn run_pager_help_browser(query: &str) {
 }
 
 /// Run the history browser pager, wrapping with IPC alternate mode.
-pub(super) fn run_pager_history_browser(path: &std::path::Path, mode: crate::pager::HistoryDbMode) {
-    let browser_result = with_ipc_alternate_guard(|| crate::pager::run_history_browser(path, mode));
+pub(super) fn run_pager_history_browser(
+    store: &crate::history::HistoryStore,
+    mode: crate::pager::HistoryDbMode,
+) {
+    let browser_result =
+        with_ipc_alternate_guard(|| crate::pager::run_history_browser(store, mode));
 
     match browser_result {
         Ok(crate::pager::HistoryBrowserResult::Copied(cmd)) => {

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -144,7 +144,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         approve_interactive_ipc_operation(&op.code, reply)
                     {
                         setup_visible_eval(reply, timeout);
-                        let store = state.r_history.as_ref().map(|handle| handle.store.clone());
+                        let store = state.r_history.store();
                         let history_id = save_ipc_history(
                             state.line_editor.history_mut(),
                             store,
@@ -153,7 +153,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         );
                         if !op.code.trim().is_empty() {
                             state.pending_history_context = PendingHistoryContext::Command {
-                                store: state.r_history.as_ref().map(|handle| handle.store.clone()),
+                                store: state.r_history.store(),
                                 history_id,
                             };
                         }
@@ -172,7 +172,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         approve_interactive_ipc_operation(&op.code, reply)
                     {
                         accept_user_input(reply);
-                        let store = state.r_history.as_ref().map(|handle| handle.store.clone());
+                        let store = state.r_history.store();
                         let history_id = save_ipc_history(
                             state.line_editor.history_mut(),
                             store,
@@ -181,7 +181,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         );
                         if !op.code.trim().is_empty() {
                             state.pending_history_context = PendingHistoryContext::Command {
-                                store: state.r_history.as_ref().map(|handle| handle.store.clone()),
+                                store: state.r_history.store(),
                                 history_id,
                             };
                         }
@@ -237,9 +237,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
 
             match editor.read_line(&prompt) {
                 Ok(Signal::Success(line)) => {
-                    let save_outcome = history_handle
-                        .as_ref()
-                        .and_then(|handle| handle.receipt.take());
+                    let save_outcome = history_handle.receipt_outcome();
 
                     // For non-standard prompts (menus, etc.), pass input directly to R
                     // without any processing (meta commands, shell mode, reprex, autoformat)
@@ -252,7 +250,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         // an exit status, which matters most when that entry
                         // came from IPC and cannot be recovered from reedline's
                         // own last-command context.
-                        finalize_history(history_handle.as_ref(), save_outcome, false);
+                        finalize_history(Some(&history_handle), save_outcome, false);
                         return Some(line);
                     }
 
@@ -260,14 +258,14 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                     if let Some(result) = process_meta_command(
                         &line,
                         &mut state.prompt_config,
-                        &state.r_history_path,
-                        &state.shell_history_path,
+                        &state.r_history,
+                        &state.shell_history,
                         &state.r_source_status,
                         &mut state.dir_stack,
                         state.history_session_id.map(i64::from),
                         state.r_home.as_deref(),
                     ) {
-                        finalize_history(history_handle.as_ref(), save_outcome, true);
+                        finalize_history(Some(&history_handle), save_outcome, true);
                         // Clear duration so the previous R command's time
                         // does not persist in the prompt after a meta command.
                         state.prompt_config.clear_command_duration();
@@ -288,7 +286,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                         }
                     }
 
-                    finalize_history(history_handle.as_ref(), save_outcome, false);
+                    finalize_history(Some(&history_handle), save_outcome, false);
 
                     // Shell mode: execute as shell command instead of R
                     if is_shell_mode {
@@ -355,7 +353,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                             _ => None,
                         };
                         state.pending_history_context = PendingHistoryContext::Command {
-                            store: history_handle.map(|handle| handle.store),
+                            store: history_handle.store(),
                             history_id,
                         };
                     }
@@ -463,13 +461,13 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
 
                         let history_id = save_ipc_history(
                             editor.history_mut(),
-                            history_handle.as_ref().map(|handle| handle.store.clone()),
+                            history_handle.store(),
                             &op.code,
                             state.history_session_id,
                         );
                         if !op.code.trim().is_empty() {
                             state.pending_history_context = PendingHistoryContext::Command {
-                                store: history_handle.as_ref().map(|handle| handle.store.clone()),
+                                store: history_handle.store(),
                                 history_id,
                             };
                         }

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -273,8 +273,8 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                             prompt_config: &state.prompt_config,
                             config_path: &state.config_path,
                             config_status: state.config_status,
-                            r_history_path: &state.r_history_path,
-                            shell_history_path: &state.shell_history_path,
+                            r_history: &state.r_history,
+                            shell_history: &state.shell_history,
                             r_source_status: &state.r_source_status,
                         };
                         match handle_meta_command_result(result, &ctx) {

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -62,9 +62,9 @@ pub struct ReplState {
     pub config_path: Option<PathBuf>,
     /// Status of config file loading (for :info display).
     pub config_status: ConfigStatus,
-    /// Path to the R history database (for :history commands).
+    /// Resolved R history database path for :info; `None` for volatile history.
     pub r_history_path: Option<PathBuf>,
-    /// Path to the Shell history database (for :history commands).
+    /// Resolved shell history database path for :info; `None` for volatile history.
     pub shell_history_path: Option<PathBuf>,
     /// How R was resolved at startup (for :info display and :switch gating).
     pub r_source_status: RSourceStatus,
@@ -78,10 +78,10 @@ pub struct ReplState {
     pub dir_stack: Vec<PathBuf>,
     /// History session ID for R history entries and IPC metadata.
     pub history_session_id: Option<HistorySessionId>,
-    /// Persistent R history store and adapter save receipt.
-    pub r_history: Option<crate::history::HistoryHandle>,
-    /// Persistent shell history store and adapter save receipt.
-    pub shell_history: Option<crate::history::HistoryHandle>,
+    /// R history store and adapter save receipt for the active runtime.
+    pub r_history: crate::history::HistoryRuntime,
+    /// Shell history store and adapter save receipt for the active runtime.
+    pub shell_history: crate::history::HistoryRuntime,
     /// History context for the command whose evaluation just completed.
     pub pending_history_context: PendingHistoryContext,
 }

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -62,10 +62,6 @@ pub struct ReplState {
     pub config_path: Option<PathBuf>,
     /// Status of config file loading (for :info display).
     pub config_status: ConfigStatus,
-    /// Resolved R history database path for :info; `None` for volatile history.
-    pub r_history_path: Option<PathBuf>,
-    /// Resolved shell history database path for :info; `None` for volatile history.
-    pub shell_history_path: Option<PathBuf>,
     /// How R was resolved at startup (for :info display and :switch gating).
     pub r_source_status: RSourceStatus,
     /// R_HOME reported by the running R at startup, if R initialized successfully.

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_fish.snap
@@ -73,7 +73,7 @@ complete -c arf -n "__fish_arf_needs_command" -l with-ipc -d 'Enable IPC server 
 complete -c arf -n "__fish_arf_needs_command" -l ipc-eval-unrestricted -d 'Disable the IPC evaluate allowlist for this server startup only'
 complete -c arf -n "__fish_arf_needs_command" -l no-auto-match -d 'Disable auto-matching of brackets and quotes (for testing)'
 complete -c arf -n "__fish_arf_needs_command" -l no-completion -d 'Disable completion menu (for testing)'
-complete -c arf -n "__fish_arf_needs_command" -l no-history -d 'Disable history (no history saved or loaded)'
+complete -c arf -n "__fish_arf_needs_command" -l no-history -d 'Keep history only in memory for this session (no history loaded or saved)'
 complete -c arf -n "__fish_arf_needs_command" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_needs_command" -s V -l version -d 'Print version'
 complete -c arf -n "__fish_arf_needs_command" -f -a "completions" -d 'Generate shell completion scripts'
@@ -104,7 +104,7 @@ complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcomm
 complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l from -d 'Source format to import from' -r -f -a "radian\t'radian history file (~/.radian_history)'
 r\t'R native history file (.Rhistory)'
 arf\t'Another arf SQLite history database'"
-complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l file -d 'Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=history.dir/r.db' -r -F
+complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l file -d 'Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=persistent history `dir`/r.db' -r -F
 complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l hostname -d 'Override hostname for imported entries. Marks entries to distinguish them from native arf history' -r
 complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l r-table -d 'Table name for R history when importing from unified export file' -r
 complete -c arf -n "__fish_arf_using_subcommand history; and __fish_seen_subcommand_from import" -l shell-table -d 'Table name for shell history when importing from unified export file' -r
@@ -174,7 +174,7 @@ complete -c arf -n "__fish_arf_using_subcommand headless" -l vanilla -d 'Start R
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-environ -d '[R] Don\'t read the site and user environment files'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-site-file -d '[R] Don\'t read the site-wide Rprofile'
 complete -c arf -n "__fish_arf_using_subcommand headless" -l no-init-file -d '[R] Don\'t read the user\'s .Rprofile'
-complete -c arf -n "__fish_arf_using_subcommand headless" -l no-history -d 'Disable history (no history saved or loaded)'
+complete -c arf -n "__fish_arf_using_subcommand headless" -l no-history -d 'Keep history only in memory for this session (no history loaded or saved)'
 complete -c arf -n "__fish_arf_using_subcommand headless" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c arf -n "__fish_arf_using_subcommand r; and not __fish_seen_subcommand_from resolve help" -s h -l help -d 'Print help'
 complete -c arf -n "__fish_arf_using_subcommand r; and not __fish_seen_subcommand_from resolve help" -f -a "resolve" -d 'Resolve the R installation arf would use without starting R'

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_powershell.snap
@@ -76,7 +76,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--ipc-eval-unrestricted', '--ipc-eval-unrestricted', [CompletionResultType]::ParameterName, 'Disable the IPC evaluate allowlist for this server startup only')
             [CompletionResult]::new('--no-auto-match', '--no-auto-match', [CompletionResultType]::ParameterName, 'Disable auto-matching of brackets and quotes (for testing)')
             [CompletionResult]::new('--no-completion', '--no-completion', [CompletionResultType]::ParameterName, 'Disable completion menu (for testing)')
-            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Disable history (no history saved or loaded)')
+            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Keep history only in memory for this session (no history loaded or saved)')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
@@ -148,7 +148,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
         }
         'arf;history;import' {
             [CompletionResult]::new('--from', '--from', [CompletionResultType]::ParameterName, 'Source format to import from')
-            [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=history.dir/r.db')
+            [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=persistent history `dir`/r.db')
             [CompletionResult]::new('--hostname', '--hostname', [CompletionResultType]::ParameterName, 'Override hostname for imported entries. Marks entries to distinguish them from native arf history')
             [CompletionResult]::new('--r-table', '--r-table', [CompletionResultType]::ParameterName, 'Table name for R history when importing from unified export file')
             [CompletionResult]::new('--shell-table', '--shell-table', [CompletionResultType]::ParameterName, 'Table name for shell history when importing from unified export file')
@@ -294,7 +294,7 @@ Register-ArgumentCompleter -Native -CommandName 'arf' -ScriptBlock {
             [CompletionResult]::new('--no-environ', '--no-environ', [CompletionResultType]::ParameterName, '[R] Don''t read the site and user environment files')
             [CompletionResult]::new('--no-site-file', '--no-site-file', [CompletionResultType]::ParameterName, '[R] Don''t read the site-wide Rprofile')
             [CompletionResult]::new('--no-init-file', '--no-init-file', [CompletionResultType]::ParameterName, '[R] Don''t read the user''s .Rprofile')
-            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Disable history (no history saved or loaded)')
+            [CompletionResult]::new('--no-history', '--no-history', [CompletionResultType]::ParameterName, 'Keep history only in memory for this session (no history loaded or saved)')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break

--- a/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__completions_zsh.snap
@@ -70,7 +70,7 @@ _arf() {
 '--ipc-eval-unrestricted[Disable the IPC evaluate allowlist for this server startup only]' \
 '--no-auto-match[Disable auto-matching of brackets and quotes (for testing)]' \
 '--no-completion[Disable completion menu (for testing)]' \
-'--no-history[Disable history (no history saved or loaded)]' \
+'--no-history[Keep history only in memory for this session (no history loaded or saved)]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
@@ -178,7 +178,7 @@ _arguments "${_arguments_options[@]}" : \
 '--from=[Source format to import from]:FROM:((radian\:"radian history file (~/.radian_history)"
 r\:"R native history file (.Rhistory)"
 arf\:"Another arf SQLite history database"))' \
-'--file=[Path to the history file/database to import. Defaults\: radian=~/.radian_history, r=.Rhistory, arf=history.dir/r.db]:FILE:_files' \
+'--file=[Path to the history file/database to import. Defaults\: radian=~/.radian_history, r=.Rhistory, arf=persistent history \`dir\`/r.db]:FILE:_files' \
 '--hostname=[Override hostname for imported entries. Marks entries to distinguish them from native arf history]:HOSTNAME:_default' \
 '--r-table=[Table name for R history when importing from unified export file]:R_TABLE:_default' \
 '--shell-table=[Table name for shell history when importing from unified export file]:SHELL_TABLE:_default' \
@@ -370,7 +370,7 @@ _arguments "${_arguments_options[@]}" : \
 '--no-environ[\[R\] Don'\''t read the site and user environment files]' \
 '--no-site-file[\[R\] Don'\''t read the site-wide Rprofile]' \
 '--no-init-file[\[R\] Don'\''t read the user'\''s .Rprofile]' \
-'--no-history[Disable history (no history saved or loaded)]' \
+'--no-history[Keep history only in memory for this session (no history loaded or saved)]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
@@ -85,7 +85,7 @@ Options:
           
           R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
-          Config: history.mode = "persistent" and its `dir` field
+          Config: history.mode = { dir = "..." }
           
           [env: ARF_HISTORY_DIR=]
 

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_headless.snap
@@ -85,14 +85,14 @@ Options:
           
           R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
-          Config: history.dir
+          Config: history.mode = "persistent" and its `dir` field
           
           [env: ARF_HISTORY_DIR=]
 
       --no-history
-          Disable history (no history saved or loaded)
+          Keep history only in memory for this session (no history loaded or saved)
           
-          Config: history.disabled
+          Overrides config: history.mode = "volatile"
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_history_import.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_history_import.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/arf-console/src/cli.rs
+source: crates/arf-console/src/cli/mod.rs
 expression: help
 ---
 Import history from another source (experimental)
@@ -18,7 +18,7 @@ Options:
           - arf:    Another arf SQLite history database
 
       --file <FILE>
-          Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=history.dir/r.db
+          Path to the history file/database to import. Defaults: radian=~/.radian_history, r=.Rhistory, arf=persistent history `dir`/r.db
 
       --hostname <HOSTNAME>
           Override hostname for imported entries. Marks entries to distinguish them from native arf history

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
@@ -130,7 +130,7 @@ Options:
           
           R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
-          Config: history.mode = "persistent" and its `dir` field
+          Config: history.mode = { dir = "..." }
           
           [env: ARF_HISTORY_DIR=]
 

--- a/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
+++ b/crates/arf-console/src/snapshots/arf__cli__tests__help_long.snap
@@ -130,14 +130,14 @@ Options:
           
           R history is stored at `{dir}/r.db`. The interactive console also stores shell history at `{dir}/shell.db`.
           
-          Config: history.dir
+          Config: history.mode = "persistent" and its `dir` field
           
           [env: ARF_HISTORY_DIR=]
 
       --no-history
-          Disable history (no history saved or loaded)
+          Keep history only in memory for this session (no history loaded or saved)
           
-          Config: history.disabled
+          Overrides config: history.mode = "volatile"
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/arf-console/tests/common/mod.rs
+++ b/crates/arf-console/tests/common/mod.rs
@@ -132,7 +132,7 @@ impl Terminal {
 
         // Build command
         let mut cmd = CommandBuilder::new(bin_path);
-        // Disable history by default to avoid writing to user's actual history file during tests.
+        // Use volatile history by default to avoid writing to user's actual history file during tests.
         // Skip this if --history-dir is explicitly provided (for history-related tests).
         let has_history_dir = args.contains(&"--history-dir");
         if !has_history_dir {

--- a/crates/arf-console/tests/headless/history.rs
+++ b/crates/arf-console/tests/headless/history.rs
@@ -560,20 +560,22 @@ fn test_ipc_history_all_sessions() {
     );
 }
 
-/// Test that history returns an error when history is disabled.
+/// Volatile history remains queryable in-process but is never written to disk.
 #[test]
-fn test_ipc_history_disabled() {
+fn test_ipc_history_volatile() {
     let tmp = tempfile::TempDir::new().expect("create temp dir");
     let history_dir = tmp.path().to_str().unwrap();
 
     let process = HeadlessProcess::spawn_with_args(&["--history-dir", history_dir, "--no-history"])
         .expect("spawn headless");
 
+    process.ipc_eval("1 + 1").expect("eval should run");
     let result = process.ipc_history(&[]).expect("history query");
-    // Should fail because history is not configured
+    // The volatile in-memory owner is available for the lifetime of the process.
     assert!(
-        !result.success,
-        "history should fail when disabled: stdout={}, stderr={}",
+        result.success,
+        "history should be queryable in volatile mode: stdout={}, stderr={}",
         result.stdout, result.stderr
     );
+    assert!(result.stdout.contains("1 + 1"));
 }

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -66,7 +66,7 @@ exit 1
     }
 
     fn command(&self) -> Command {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_arf"));
+        let mut command = isolated_command(self._temp.path());
         command
             .env("PATH", &self.bin_dir)
             .env("FAKE_R_HOME", &self.fake_r_home)
@@ -75,6 +75,19 @@ exit 1
             .env_remove("ARF_R_VERSION");
         command
     }
+}
+
+/// Build a resolve command that cannot see the developer's global arf config.
+fn isolated_command(temp_path: &std::path::Path) -> Command {
+    let home_dir = temp_path.join("home");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_arf"));
+    command
+        .env("HOME", home_dir)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("XDG_CACHE_HOME");
+    command
 }
 
 #[cfg(unix)]
@@ -165,7 +178,7 @@ exit 1
 #[test]
 fn resolve_found_emits_descriptor_with_target() {
     let temp = tempfile::tempdir().unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+    let output = isolated_command(temp.path())
         .args(["r", "resolve", "--r-home"])
         .arg(temp.path())
         .output()
@@ -208,7 +221,7 @@ fn resolve_relative_r_home_uses_one_absolute_path_representation() {
     let r_home = temp.path().join("rh");
     std::fs::create_dir(&r_home).unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+    let output = isolated_command(temp.path())
         .args(["r", "resolve", "--r-home", "rh"])
         .current_dir(temp.path())
         .output()
@@ -586,7 +599,7 @@ fn resolve_broken_config_falls_back_with_diagnostic() {
     let r_home = temp.path().join("r-home");
     std::fs::create_dir(&r_home).unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+    let output = isolated_command(temp.path())
         .args(["r", "resolve", "--config"])
         .arg(&config)
         .args(["--r-home"])
@@ -615,7 +628,7 @@ fn resolve_broken_config_falls_back_with_diagnostic() {
 #[test]
 fn resolve_environment_source_reports_environment_origin() {
     let temp = tempfile::tempdir().unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+    let output = isolated_command(temp.path())
         .args(["r", "resolve"])
         .env("ARF_R_HOME", temp.path())
         .output()
@@ -792,7 +805,7 @@ fn resolve_r_binary_failure_is_internal_error() {
 fn resolve_missing_r_home_returns_invalid_params_exit_code() {
     let temp = tempfile::tempdir().unwrap();
     let missing_r_home = temp.path().join("missing-r-home");
-    let output = Command::new(env!("CARGO_BIN_EXE_arf"))
+    let output = isolated_command(temp.path())
         .args(["r", "resolve", "--r-home"])
         .arg(missing_r_home)
         .output()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,8 +95,8 @@ auto_paren_limit = 50      # Max packages to check for function paren insertion
 
 [history]
 menu_max_height = 15       # Maximum height of history search menu (Ctrl+R)
-disabled = false           # Disable history entirely
-# dir = "/custom/path"     # Custom history directory (optional)
+mode = "persistent"        # "persistent" or session-only "volatile"
+# dir = "/custom/path"     # Custom directory when mode is persistent (optional)
 
 [r]
 auto_width = true          # Sync R's options(width) with terminal size
@@ -663,9 +663,15 @@ Rig selectors are separate from version specifications:
 ```toml
 [history]
 menu_max_height = 15   # Maximum height of Ctrl+R menu
-disabled = false       # Disable history
+mode = "persistent"   # "persistent" loads/saves SQLite; "volatile" is session-only
 dir = "/custom/path"   # Custom history directory (optional)
 ```
+
+Older configurations using `history.disabled` are accepted for migration. arf
+prints a startup warning and maps `disabled = true` to `mode = "volatile"`, or
+`disabled = false` to `mode = "persistent"`; an explicit `mode` takes priority
+when both keys are present. Update the file to use `history.mode` and remove
+`history.disabled`.
 
 ### Environment Variable
 
@@ -687,7 +693,7 @@ The history directory is resolved with the following priority (highest first):
 ### CLI Options
 
 ```bash
-arf --no-history              # Disable history
+arf --no-history              # Use volatile session-only history (no disk load/save)
 arf --history-dir /path/to   # Custom history directory
 ```
 
@@ -951,8 +957,8 @@ Command-line options take precedence over their corresponding config file settin
 | `--no-banner` | `startup.show_banner` |
 | `--reprex` | `startup.mode.reprex` |
 | `--auto-format` | `startup.mode.autoformat` |
-| `--no-history` | `history.disabled` |
-| `--history-dir` / `ARF_HISTORY_DIR` | `history.dir` |
+| `--no-history` | `history.mode = "volatile"` |
+| `--history-dir` / `ARF_HISTORY_DIR` | `history.mode = "persistent"` with `dir` |
 
 Example:
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -668,12 +668,6 @@ mode = "persistent"   # "persistent" loads/saves SQLite; "volatile" is session-o
 # mode = { dir = "/custom/path" }
 ```
 
-Older configurations using `history.disabled` or top-level `history.dir` are accepted for migration. arf
-prints a startup warning and maps `disabled = true` to `mode = "volatile"`, or
-`disabled = false` to `mode = "persistent"`; an explicit `mode` takes priority
-when both keys are present. Update the file to use `history.mode` and remove
-`history.disabled` and top-level `history.dir`.
-
 ### Environment Variable
 
 The `ARF_HISTORY_DIR` environment variable can be used to override the history directory. This is useful for devcontainer Features that persist history via Docker volumes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ auto_paren_limit = 50      # Max packages to check for function paren insertion
 [history]
 menu_max_height = 15       # Maximum height of history search menu (Ctrl+R)
 mode = "persistent"        # "persistent" or session-only "volatile"
-# dir = "/custom/path"     # Custom directory when mode is persistent (optional)
+# mode = { dir = "/custom/path" }  # Custom directory when mode is persistent
 
 [r]
 auto_width = true          # Sync R's options(width) with terminal size
@@ -664,14 +664,15 @@ Rig selectors are separate from version specifications:
 [history]
 menu_max_height = 15   # Maximum height of Ctrl+R menu
 mode = "persistent"   # "persistent" loads/saves SQLite; "volatile" is session-only
-dir = "/custom/path"   # Custom history directory (optional)
+# For a custom persistent directory, use instead:
+# mode = { dir = "/custom/path" }
 ```
 
-Older configurations using `history.disabled` are accepted for migration. arf
+Older configurations using `history.disabled` or top-level `history.dir` are accepted for migration. arf
 prints a startup warning and maps `disabled = true` to `mode = "volatile"`, or
 `disabled = false` to `mode = "persistent"`; an explicit `mode` takes priority
 when both keys are present. Update the file to use `history.mode` and remove
-`history.disabled`.
+`history.disabled` and top-level `history.dir`.
 
 ### Environment Variable
 
@@ -687,7 +688,7 @@ The history directory is resolved with the following priority (highest first):
 
 1. CLI `--history-dir`
 2. `ARF_HISTORY_DIR` environment variable
-3. TOML `[history] dir`
+3. TOML `[history] mode = { dir = "..." }`
 4. XDG default
 
 ### CLI Options
@@ -958,7 +959,7 @@ Command-line options take precedence over their corresponding config file settin
 | `--reprex` | `startup.mode.reprex` |
 | `--auto-format` | `startup.mode.autoformat` |
 | `--no-history` | `history.mode = "volatile"` |
-| `--history-dir` / `ARF_HISTORY_DIR` | `history.mode = "persistent"` with `dir` |
+| `--history-dir` / `ARF_HISTORY_DIR` | `history.mode = { dir = "..." }` |
 
 Example:
 ```bash

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -60,7 +60,12 @@ When `--json` is specified, arf prints session connection info to stdout as a si
   "cwd": "/workspace",
   "started_at": "2026-03-22T10:00:00+09:00",
   "log_file": null,
-  "history_session_id": null,
+  "history_session_id": 1742601600000000000,
+  "history_runtime": {
+    "state": "persistent",
+    "path": "/home/user/.local/share/arf/history/r.db",
+    "reason": null
+  },
   "r_source_override": {
     "state": "applied",
     "provider": "toml-key",
@@ -73,7 +78,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version`, `r_home`, and `log_file` may be `null`; `history_session_id` is `null` only when history initialization is unavailable. `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `r_home`, and `log_file` may be `null`; `history_session_id` is `null` only when history initialization is unavailable. `history_runtime` reports `persistent`, configured `volatile`, fallback `volatile`, or `unavailable`; its `path` is a diagnostic path when one was requested (for example, for a persistent or fallback open, or an unavailable initialization). `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or history fallback diagnostics) that would otherwise only appear on stderr.
 
 The IPC `r_version` is measured from a live R session; `arf r resolve` reports `resolved_version`, a prediction made before R starts.
 

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -39,7 +39,7 @@ The server runs until interrupted by `Ctrl+C`, `SIGTERM`, or `arf ipc shutdown`.
 | `--ipc-pid-file <PATH>` | Write PID to file (removed on shutdown) |
 | `--log-file <PATH>` | Redirect log output to file instead of stderr |
 | `--history-dir <PATH>` | Override history database directory |
-| `--no-history` | Disable command history |
+| `--no-history` | Keep command history in memory for this session only (no disk load/save) |
 | `--quiet` | Suppress status messages on stderr |
 | `--config <PATH>` | Path to configuration file |
 | `--with-r-version <VER>` | R version to use via rig |
@@ -73,7 +73,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version`, `r_home`, `log_file`, and `history_session_id` may be `null`. `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `r_home`, and `log_file` may be `null`; `history_session_id` is `null` only when history initialization is unavailable. `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or R source override diagnostics) that would otherwise only appear on stderr.
 
 The IPC `r_version` is measured from a live R session; `arf r resolve` reports `resolved_version`, a prediction made before R starts.
 
@@ -489,7 +489,7 @@ When both a human and an external tool use the same session, arf prevents confli
 - If R is busy (not at the prompt), `evaluate` requests are rejected immediately with `R_BUSY`
 - If R is not at the prompt, `user_input` / `send` requests are rejected with `R_NOT_AT_PROMPT`
 - Clients are expected to handle these errors by retrying later (for example, with backoff). In interactive/REPL mode, the server accepts at most one pending request — additional requests are rejected with `INPUT_ALREADY_PENDING`. In headless mode, requests are queued and processed sequentially
-- The `session` and `history` methods do not touch R and can be called even when R is busy or not at the prompt. `session` always succeeds; `history` may fail if history is disabled or the history database cannot be accessed
+- The `session` and `history` methods do not touch R and can be called even when R is busy or not at the prompt. `session` always succeeds; `history` may fail only when no history owner is available or the store cannot be queried
 - `list` reads local session files and does not connect to any server, so it always works regardless of R state
 
 ## Transport & Security

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -64,7 +64,8 @@ When `--json` is specified, arf prints session connection info to stdout as a si
   "history_runtime": {
     "state": "persistent",
     "path": "/home/user/.local/share/arf/history/r.db",
-    "reason": null
+    "reason": null,
+    "detail": null
   },
   "r_source_override": {
     "state": "applied",
@@ -78,7 +79,7 @@ When `--json` is specified, arf prints session connection info to stdout as a si
 }
 ```
 
-All keys are always present. `r_version`, `r_home`, and `log_file` may be `null`; `history_session_id` is `null` only when history initialization is unavailable. `history_runtime` reports `persistent`, configured `volatile`, fallback `volatile`, or `unavailable`; its `path` is a diagnostic path when one was requested (for example, for a persistent or fallback open, or an unavailable initialization). `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or history fallback diagnostics) that would otherwise only appear on stderr.
+All keys are always present. `r_version`, `r_home`, and `log_file` may be `null`; `history_session_id` is `null` only when history initialization is unavailable. `history_runtime` reports `persistent`, configured `volatile`, fallback `volatile`, or `unavailable`; its `path` is a diagnostic path when one was requested (for example, for a persistent or fallback open, or an unavailable initialization), and `detail` contains an optional human-readable failure diagnostic. `r_home` is the R installation the session is using, or `null` when the session has no R. The `r_source_override` object is always present; its state is one of `applied`, `not_configured`, `no_match`, `failed`, `disabled`, or `shadowed_by_cli`, and its other fields are `null` unless an override was applied. `warnings` captures non-fatal startup issues (e.g., config parse errors or history fallback diagnostics) that would otherwise only appear on stderr.
 
 The IPC `r_version` is measured from a live R session; `arf r resolve` reports `resolved_version`, a prediction made before R starts.
 


### PR DESCRIPTION
## Summary

- replace the history enabled/disabled flag with explicit persistent and volatile modes
- keep volatile history in an arf-owned in-memory SQLite store so session recall, metadata, exit status, browser, clear, sponge, and IPC history continue to work without disk I/O
- make `HistoryRuntime` the single lifecycle model and `HistoryStore` the runtime owner used by reedline, the history browser, IPC queries, and clear operations
- initialize independent R and shell history runtimes before IPC starts, including in standalone mode
- expose the actual runtime state and concrete initialization failures through `:info`, startup warnings, and headless diagnostics
- preserve legacy `history.disabled` and top-level `history.dir` as deprecated migration inputs

## Motivation

The previous design conflated an intentional `--no-history` session with a persistent database open failure. It also relied on reedline's implicit in-memory backend and reopened history database paths from several runtime consumers. This made the lifecycle ambiguous, prevented volatile sessions from supporting the same metadata and mutation features as persistent sessions, and allowed interactive and headless initialization behavior to drift.

This PR separates configured intent from the runtime result:

```text
configured intent
  ├─ Persistent { dir }
  └─ Volatile

runtime result
  ├─ Persistent
  ├─ Volatile (configured)
  ├─ Volatile (fallback)
  └─ Unavailable
```

## Configuration

`history.mode` is optional and defaults to persistent history. The concise string forms cover the common cases:

```toml
[history]
mode = "persistent"
```

```toml
[history]
mode = "volatile"
```

A custom persistent directory is a payload of the persistent mode:

```toml
[history]
mode = { dir = "/custom/path" }
```

The object form requires `dir` and rejects unknown fields. Combining the new `mode` syntax with the deprecated top-level `history.dir` is an error rather than silently ignoring the directory.

For migration, configurations without `mode` may still use `history.disabled` and top-level `history.dir`. They emit startup warnings; `disabled = true` maps to volatile, while `disabled = false` or an omitted `disabled` maps to persistent. When `mode` and `disabled` are both present, `mode` takes priority and the ignored legacy key is reported.

## Runtime behavior

- `--no-history` selects configured volatile history for the current session. It never loads or writes a history database, while interactive recall and the rest of the history feature set remain available.
- `HistoryRuntime::initialize` is the common factory for interactive, standalone, and headless execution.
- A persistent database open failure, including the absence of a resolvable persistent path, falls back to a distinguishable volatile runtime. History is unavailable only if the in-memory fallback also fails.
- Fallback runtimes retain the persistent initialization failure. Unavailable runtimes retain the final in-memory failure and, when applicable, the preceding persistent failure. Requested paths are derived from those failures rather than stored as duplicate runtime state.
- R and shell histories have independent runtime owners. Standalone shell browse/clear operations no longer target the R store.
- History runtimes and the IPC history store are prepared before the IPC server starts, removing the startup query race.
- `:info` reports persistent paths, configured volatile sessions, fallback state and requested path, unavailable history, and concrete failure details from the runtime itself.
- Headless JSON includes `history_runtime` with stable `state`, `reason`, and `path` fields plus an optional human-readable `detail`; fallback and unavailable states are also surfaced as warnings.
- IPC's default history query remains strictly scoped to the current session and scans bounded pages through the owned store.
- Raw SQL access is limited to the import backfill path required for malformed legacy metadata.

## Breaking changes

- New configurations should use `history.mode`; legacy `history.disabled` and top-level `history.dir` are migration-only inputs.
- `--no-history` now means volatile, session-only history instead of disabling history functionality entirely.
- Headless JSON adds the always-present `history_runtime` object, including an always-present nullable `detail` field.

## Validation

- `cargo test -p arf-console --quiet`
- `cargo clippy -p arf-console --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The local test run passed all targets, including 937 unit tests (4 ignored), 46 CLI tests, 57 headless tests, 8 IPC tests, PTY suites, and resolver tests.
