### PR TITLE
fix: show full code in IPC approval prompts

### DIFF
--- a/crates/arf-console/src/ipc/approval.rs
+++ b/crates/arf-console/src/ipc/approval.rs
@@ -1,0 +1,172 @@
+use super::protocol;
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+/// Session-only switch for interactive `send` approval. It intentionally is
+/// not part of Config or startup CLI options.
+static SEND_POLICY_ALLOW: OnceLock<AtomicBool> = OnceLock::new();
+
+fn send_policy_allow() -> &'static AtomicBool {
+    SEND_POLICY_ALLOW.get_or_init(|| AtomicBool::new(false))
+}
+
+pub fn set_send_policy_allow(allow: bool) {
+    send_policy_allow().store(allow, Ordering::Release);
+}
+
+pub fn send_policy_is_allow() -> bool {
+    send_policy_allow().load(Ordering::Acquire)
+}
+
+pub struct UserInputApproval {
+    pub approved: bool,
+    pub wrote_newline: bool,
+}
+
+/// Ask for approval immediately before an interactive `user_input` executes.
+/// The sender check prevents a timed-out request from being executed after its
+/// client has gone away. A half-close cannot be distinguished from the normal
+/// request framing, so this is necessarily best effort until the server timeout.
+pub fn approve_user_input(
+    code: &str,
+    reply: &tokio::sync::oneshot::Sender<protocol::IpcResponse>,
+) -> UserInputApproval {
+    if send_policy_is_allow() {
+        return UserInputApproval {
+            approved: !reply.is_closed(),
+            wrote_newline: false,
+        };
+    }
+    if reply.is_closed() {
+        return UserInputApproval {
+            approved: false,
+            wrote_newline: false,
+        };
+    }
+    let escaped = user_input_display(code);
+    let prompt = format!(
+        "# [arf] IPC send request: [{escaped}]\r\n# [arf] Press y to approve, any other key declines: "
+    );
+    use std::io::Write;
+    print!("{prompt}");
+    let _ = std::io::stdout().flush();
+    let finish = |approved: bool| {
+        // Raw terminals do not translate LF to CRLF; return to column zero
+        // explicitly so the agent echo is rendered on the next line.
+        if approved {
+            print!("\r\n");
+        } else {
+            print!("\r\n# [arf] IPC send declined.\r\n");
+        }
+        let _ = std::io::stdout().flush();
+        UserInputApproval {
+            approved,
+            wrote_newline: true,
+        }
+    };
+
+    // Reedline normally owns raw mode, but the fast path can reach this
+    // helper before it starts reading. Preserve whichever state we inherit.
+    let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !was_raw && crossterm::terminal::enable_raw_mode().is_err() {
+        return finish(false);
+    }
+    struct RawModeGuard {
+        was_raw: bool,
+    }
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            if !self.was_raw {
+                let _ = crossterm::terminal::disable_raw_mode();
+            }
+        }
+    }
+    let _raw_mode_guard = RawModeGuard { was_raw };
+
+    loop {
+        if reply.is_closed() {
+            return finish(false);
+        }
+        if let Err(error) = crossterm::event::poll(std::time::Duration::from_millis(50)) {
+            log::debug!("IPC send approval input failed: {error}");
+            return finish(false);
+        }
+        arf_libr::process_r_events();
+        // Keep the IPC transport responsive while waiting. R is marked busy
+        // by the caller, so later mutating requests receive R_BUSY.
+        super::poll_ipc_requests();
+        if !crossterm::event::poll(std::time::Duration::from_millis(0)).unwrap_or(false) {
+            continue;
+        }
+        match crossterm::event::read() {
+            Ok(crossterm::event::Event::Key(key)) => {
+                use crossterm::event::{KeyCode, KeyModifiers};
+                let approved = matches!(key.code, KeyCode::Char('y' | 'Y'))
+                    && matches!(key.modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT)
+                    && !reply.is_closed();
+
+                // Consume the rest of the answer before raw mode is released;
+                // otherwise characters such as Enter can reach reedline.
+                while crossterm::event::poll(std::time::Duration::from_millis(0)).unwrap_or(false) {
+                    if crossterm::event::read().is_err() {
+                        break;
+                    }
+                }
+                return finish(approved);
+            }
+            Ok(_) => continue,
+            Err(error) => {
+                log::debug!("IPC send approval input failed: {error}");
+                return finish(false);
+            }
+        }
+    }
+}
+
+pub(crate) fn user_input_display(code: &str) -> String {
+    code.chars()
+        .map(|character| {
+            if character.is_ascii_graphic() || character == ' ' {
+                character.to_string()
+            } else {
+                character.escape_default().to_string()
+            }
+        })
+        .collect()
+}
+
+pub fn reject_user_input_not_approved(reply: tokio::sync::oneshot::Sender<protocol::IpcResponse>) {
+    let _ = reply.send(protocol::IpcResponse::error(
+        protocol::INPUT_NOT_APPROVED,
+        "IPC send was not approved".to_string(),
+    ));
+}
+
+#[cfg(test)]
+mod approval_display_tests {
+    #[test]
+    fn display_includes_content_after_old_preview_limit() {
+        let source = format!(
+            "{}{}",
+            "0123456789".repeat(24),
+            r#"system("SHOULD_BE_VISIBLE")"#
+        );
+        let display = super::user_input_display(&source);
+
+        insta::assert_snapshot!(display, @r###"012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789system("SHOULD_BE_VISIBLE")"###);
+    }
+
+    #[test]
+    fn display_escapes_control_characters() {
+        let source = "line\n\tline\r\0\x1b[31m";
+        let display = super::user_input_display(source);
+
+        insta::assert_snapshot!(display, @r###"line\n\tline\r\u{0}\u{1b}[31m"###);
+        assert!(!display.contains('\n'));
+        assert!(!display.contains('\r'));
+        assert!(!display.contains('\0'));
+        assert!(!display.contains('\x1b'));
+    }
+}

--- a/crates/arf-console/src/ipc/approval.rs
+++ b/crates/arf-console/src/ipc/approval.rs
@@ -45,10 +45,7 @@ pub fn approve_user_input(
             wrote_newline: false,
         };
     }
-    let escaped = user_input_display(code);
-    let prompt = format!(
-        "# [arf] IPC send request: [{escaped}]\r\n# [arf] Press y to approve, any other key declines: "
-    );
+    let prompt = approval_prompt(code);
     use std::io::Write;
     print!("{prompt}");
     let _ = std::io::stdout().flush();
@@ -125,6 +122,20 @@ pub fn approve_user_input(
     }
 }
 
+fn approval_prompt(code: &str) -> String {
+    use crossterm::style::Stylize;
+
+    let escaped = user_input_display(code);
+    format!(
+        "{}\r\n  {}\r\n{}",
+        "# [arf] IPC send request:".dark_cyan(),
+        escaped.yellow(),
+        "# [arf] Press y to approve, any other key declines: "
+            .yellow()
+            .bold(),
+    )
+}
+
 pub(crate) fn user_input_display(code: &str) -> String {
     code.chars()
         .map(|character| {
@@ -146,6 +157,41 @@ pub fn reject_user_input_not_approved(reply: tokio::sync::oneshot::Sender<protoc
 
 #[cfg(test)]
 mod approval_display_tests {
+    fn strip_sgr(input: &str) -> String {
+        let mut output = String::new();
+        let mut chars = input.chars();
+        while let Some(character) = chars.next() {
+            if character == '\x1b' && chars.next() == Some('[') {
+                for character in chars.by_ref() {
+                    if character == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                output.push(character);
+            }
+        }
+        output
+    }
+
+    #[test]
+    fn approval_prompt_styles_and_separates_heading_code_and_confirmation() {
+        let prompt = super::approval_prompt(
+            r#"system("SHOULD_BE_VISIBLE")
+next"#,
+        );
+
+        let plain = format!("{}<END>", strip_sgr(&prompt).replace("\r\n", "\n"));
+        insta::assert_snapshot!(
+            plain,
+            @r###"
+# [arf] IPC send request:
+  system("SHOULD_BE_VISIBLE")\nnext
+# [arf] Press y to approve, any other key declines: <END>
+"###
+        );
+    }
+
     #[test]
     fn display_includes_content_after_old_preview_limit() {
         let source = format!(

--- a/crates/arf-console/src/ipc/approval.rs
+++ b/crates/arf-console/src/ipc/approval.rs
@@ -127,10 +127,11 @@ fn approval_prompt(code: &str) -> String {
 
     let escaped = user_input_display(code);
     format!(
-        "{}\r\n  {}\r\n{}",
+        "{}\r\n  {}\r\n{}{}",
         "# [arf] IPC send request:".dark_cyan(),
         escaped.yellow(),
-        "# [arf] Press y to approve, any other key declines: "
+        "# [arf] ".dark_cyan(),
+        "Press y to approve, any other key declines: "
             .yellow()
             .bold(),
     )

--- a/crates/arf-console/src/ipc/mod.rs
+++ b/crates/arf-console/src/ipc/mod.rs
@@ -14,6 +14,7 @@
 //! 2. Reedline returns `Signal::ExternalBreak(buffer)` with current editor buffer
 //! 3. REPL checks buffer: empty → accept operation, non-empty → reject with `USER_IS_TYPING`
 
+mod approval;
 mod capture;
 pub mod client;
 pub mod policy;
@@ -22,6 +23,11 @@ pub mod server;
 pub mod session;
 
 use crate::history::{HistoryExtraInfo, HistoryStore};
+#[allow(unused_imports)]
+pub use approval::{
+    UserInputApproval, approve_user_input, reject_user_input_not_approved, send_policy_is_allow,
+    set_send_policy_allow,
+};
 use chrono::TimeZone;
 use protocol::{
     EvaluateResult, HistoryEntry, HistoryParams, HistoryResult, INPUT_ALREADY_PENDING, IpcMethod,
@@ -32,160 +38,6 @@ use std::sync::{
     Arc, Mutex, OnceLock,
     atomic::{AtomicBool, Ordering},
 };
-/// Session-only switch for interactive `send` approval.  It intentionally is
-/// not part of Config or startup CLI options.
-static SEND_POLICY_ALLOW: OnceLock<AtomicBool> = OnceLock::new();
-
-fn send_policy_allow() -> &'static AtomicBool {
-    SEND_POLICY_ALLOW.get_or_init(|| AtomicBool::new(false))
-}
-
-pub fn set_send_policy_allow(allow: bool) {
-    send_policy_allow().store(allow, Ordering::Release);
-}
-
-pub fn send_policy_is_allow() -> bool {
-    send_policy_allow().load(Ordering::Acquire)
-}
-
-pub struct UserInputApproval {
-    pub approved: bool,
-    pub wrote_newline: bool,
-}
-
-/// Ask for approval immediately before an interactive `user_input` executes.
-/// The sender check prevents a timed-out request from being executed after its
-/// client has gone away.  A half-close cannot be distinguished from the normal
-/// request framing, so this is necessarily best effort until the server timeout.
-pub fn approve_user_input(
-    code: &str,
-    reply: &tokio::sync::oneshot::Sender<IpcResponse>,
-) -> UserInputApproval {
-    if send_policy_is_allow() {
-        return UserInputApproval {
-            approved: !reply.is_closed(),
-            wrote_newline: false,
-        };
-    }
-    if reply.is_closed() {
-        return UserInputApproval {
-            approved: false,
-            wrote_newline: false,
-        };
-    }
-    let escaped = user_input_preview(code);
-    let prompt = format!(
-        "# [arf] IPC send request: [{escaped}]\r\n# [arf] Press y to approve, any other key declines: "
-    );
-    use std::io::Write;
-    print!("{prompt}");
-    let _ = std::io::stdout().flush();
-    let finish = |approved: bool| {
-        // Raw terminals do not translate LF to CRLF; return to column zero
-        // explicitly so the agent echo is rendered on the next line.
-        if approved {
-            print!("\r\n");
-        } else {
-            print!("\r\n# [arf] IPC send declined.\r\n");
-        }
-        let _ = std::io::stdout().flush();
-        UserInputApproval {
-            approved,
-            wrote_newline: true,
-        }
-    };
-
-    // Reedline normally owns raw mode, but the fast path can reach this
-    // helper before it starts reading. Preserve whichever state we inherit.
-    let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
-    if !was_raw && crossterm::terminal::enable_raw_mode().is_err() {
-        return finish(false);
-    }
-    struct RawModeGuard {
-        was_raw: bool,
-    }
-    impl Drop for RawModeGuard {
-        fn drop(&mut self) {
-            if !self.was_raw {
-                let _ = crossterm::terminal::disable_raw_mode();
-            }
-        }
-    }
-    let _raw_mode_guard = RawModeGuard { was_raw };
-
-    loop {
-        if reply.is_closed() {
-            return finish(false);
-        }
-        if let Err(error) = crossterm::event::poll(std::time::Duration::from_millis(50)) {
-            log::debug!("IPC send approval input failed: {error}");
-            return finish(false);
-        }
-        arf_libr::process_r_events();
-        // Keep the IPC transport responsive while waiting. R is marked busy
-        // by the caller, so later mutating requests receive R_BUSY.
-        poll_ipc_requests();
-        if !crossterm::event::poll(std::time::Duration::from_millis(0)).unwrap_or(false) {
-            continue;
-        }
-        match crossterm::event::read() {
-            Ok(crossterm::event::Event::Key(key)) => {
-                use crossterm::event::{KeyCode, KeyModifiers};
-                let approved = matches!(key.code, KeyCode::Char('y' | 'Y'))
-                    && matches!(key.modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT)
-                    && !reply.is_closed();
-
-                // Consume the rest of the answer before raw mode is released;
-                // otherwise characters such as Enter can reach reedline.
-                while crossterm::event::poll(std::time::Duration::from_millis(0)).unwrap_or(false) {
-                    if crossterm::event::read().is_err() {
-                        break;
-                    }
-                }
-                return finish(approved);
-            }
-            Ok(_) => continue,
-            Err(error) => {
-                log::debug!("IPC send approval input failed: {error}");
-                return finish(false);
-            }
-        }
-    }
-}
-
-pub(crate) fn user_input_preview(code: &str) -> String {
-    const MAX_PREVIEW_CHARS: usize = 240;
-    let mut preview = String::new();
-    let mut preview_chars = 0;
-    let mut truncated = false;
-
-    for character in code.chars() {
-        let escaped = if character.is_ascii_graphic() || character == ' ' {
-            character.to_string()
-        } else {
-            character.escape_default().to_string()
-        };
-        let escaped_chars = escaped.chars().count();
-        if preview_chars + escaped_chars > MAX_PREVIEW_CHARS - 1 {
-            truncated = true;
-            break;
-        }
-        preview.push_str(&escaped);
-        preview_chars += escaped_chars;
-    }
-
-    if truncated {
-        preview.push('…');
-    }
-    preview
-}
-
-pub fn reject_user_input_not_approved(reply: tokio::sync::oneshot::Sender<IpcResponse>) {
-    let _ = reply.send(IpcResponse::error(
-        protocol::INPUT_NOT_APPROVED,
-        "IPC send was not approved".to_string(),
-    ));
-}
 
 /// Shutdown flag for headless mode. When set, the headless event loop exits.
 /// Not set in REPL mode (shutdown is only available in headless mode).
@@ -1231,15 +1083,3 @@ fn headless_handle_request(request: IpcRequest) {
 
 #[cfg(test)]
 mod tests;
-
-#[cfg(test)]
-mod policy_preview_tests {
-    #[test]
-    fn preview_escapes_controls_and_is_bounded() {
-        let source = format!("\n\t{}", "x".repeat(400));
-        let preview = super::user_input_preview(&source);
-        assert!(preview.starts_with("\\n\\t"));
-        assert!(preview.chars().count() <= 250);
-        assert!(preview.ends_with('…'));
-    }
-}

--- a/crates/arf-console/tests/ipc_tests.rs
+++ b/crates/arf-console/tests/ipc_tests.rs
@@ -556,7 +556,7 @@ fn test_ipc_evaluate_visible() {
         )
     });
     process
-        .wait_for_output("# [arf] Press y to approve, any other key declines: ")
+        .wait_for_output("Press y to approve, any other key declines: ")
         .expect("approval prompt should appear on the PTY");
     {
         let mut writer = process
@@ -603,7 +603,7 @@ fn test_ipc_user_input() {
         )
     });
     process
-        .wait_for_output("# [arf] Press y to approve, any other key declines: ")
+        .wait_for_output("Press y to approve, any other key declines: ")
         .expect("approval prompt should appear on the PTY");
     {
         let mut writer = process

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -166,9 +166,11 @@ mod ipc_tests {
     }
 
     fn ipc_approval_prompt(code: &str) -> String {
-        format!(r"# [arf] IPC send request: [{code}]")
-            + "\r\r\n"
-            + r"# [arf] Press y to approve, any other key declines: "
+        let sgr = r"\x1b\[[0-9;]*m";
+        format!(
+            r"{sgr}# \[arf\] IPC send request:{sgr}\r\r\n  {sgr}{}{sgr}\r\r\n(?:{sgr})+# \[arf\] Press y to approve, any other key declines: {sgr}",
+            escape(code)
+        )
     }
 
     fn send_approved_user_input(
@@ -187,7 +189,7 @@ mod ipc_tests {
             )
         });
         terminal
-            .expect(&ipc_approval_prompt(&code))
+            .expect_regex(&ipc_approval_prompt(&code))
             .expect("REPL should display the approval prompt");
         terminal.send_line("y").expect("approve IPC send");
         request
@@ -212,7 +214,7 @@ mod ipc_tests {
             )
         });
         terminal
-            .expect(&ipc_approval_prompt(&code))
+            .expect_regex(&ipc_approval_prompt(&code))
             .expect("REPL should display the approval prompt for visible evaluate");
         terminal.send_line("y").expect("approve visible evaluate");
         request
@@ -440,7 +442,7 @@ mod ipc_tests {
             )
         });
         terminal
-            .expect(&ipc_approval_prompt(code))
+            .expect_regex(&ipc_approval_prompt(code))
             .expect("REPL should display the approval prompt");
         terminal.send_line("n").expect("decline visible evaluate");
         let response = request
@@ -599,6 +601,47 @@ mod ipc_tests {
         terminal.quit().expect("Should quit cleanly");
     }
 
+    #[test]
+    fn test_ipc_approval_prompt_emits_styles_and_full_code() {
+        let mut terminal = Terminal::spawn_with_args_and_env(&["--with-ipc"], &[("NO_COLOR", "")])
+            .expect("Failed to spawn arf with IPC");
+        terminal
+            .wait_for_prompt()
+            .expect("Should show prompt after startup");
+        let socket_path = find_socket_path(terminal.process_id(), Duration::from_secs(10))
+            .expect("Should find IPC socket path");
+        let code = format!(
+            "{}{}",
+            "0123456789".repeat(24),
+            r#"system("SHOULD_BE_VISIBLE")"#,
+        );
+        let request_socket = socket_path.clone();
+        let request_code = code.clone();
+        let request = std::thread::spawn(move || {
+            send_ipc_request(
+                &request_socket,
+                "user_input",
+                serde_json::json!({ "code": request_code }),
+            )
+        });
+
+        terminal
+            .expect("\x1b[38;5;6m# [arf] IPC send request:")
+            .expect("approval heading should be dark cyan");
+        terminal
+            .expect(&format!("\x1b[38;5;11m{code}\x1b[39m"))
+            .expect("approval code should be yellow and fully visible");
+        terminal
+            .expect("\x1b[38;5;11m\x1b[1m# [arf] Press y to approve, any other key declines:")
+            .expect("approval confirmation should be bold");
+        terminal.send_line("y").expect("approve IPC send");
+        request
+            .join()
+            .expect("IPC request thread should not panic")
+            .expect("IPC request should succeed");
+        terminal.quit().expect("Should quit cleanly");
+    }
+
     /// Test that declining the default interactive approval rejects the request
     /// and does not evaluate or save it.
     #[test]
@@ -623,7 +666,7 @@ mod ipc_tests {
             )
         });
         terminal
-            .expect(&ipc_approval_prompt(marker))
+            .expect_regex(&ipc_approval_prompt(marker))
             .expect("REPL should display the approval prompt");
         terminal.send_line("n").expect("decline IPC send");
         terminal
@@ -663,7 +706,7 @@ mod ipc_tests {
             )
         });
         terminal
-            .expect(&ipc_approval_prompt("cat('ctrl_c_must_not_execute')"))
+            .expect_regex(&ipc_approval_prompt("cat('ctrl_c_must_not_execute')"))
             .expect("REPL should display the approval prompt");
         terminal.send_interrupt().expect("send Ctrl+C");
         let response = request

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -168,7 +168,7 @@ mod ipc_tests {
     fn ipc_approval_prompt(code: &str) -> String {
         let sgr = r"\x1b\[[0-9;]*m";
         format!(
-            r"{sgr}# \[arf\] IPC send request:{sgr}\r\r\n  {sgr}{}{sgr}\r\r\n(?:{sgr})+# \[arf\] Press y to approve, any other key declines: {sgr}",
+            r"{sgr}# \[arf\] IPC send request:{sgr}\r\r\n  {sgr}{}{sgr}\r\r\n(?:{sgr})+# \[arf\] (?:{sgr})+(?:{sgr})+Press y to approve, any other key declines: {sgr}",
             escape(code)
         )
     }
@@ -632,7 +632,9 @@ mod ipc_tests {
             .expect(&format!("\x1b[38;5;11m{code}\x1b[39m"))
             .expect("approval code should be yellow and fully visible");
         terminal
-            .expect("\x1b[38;5;11m\x1b[1m# [arf] Press y to approve, any other key declines:")
+            .expect(
+                "\x1b[38;5;6m# [arf] \x1b[39m\x1b[38;5;11m\x1b[1mPress y to approve, any other key declines:",
+            )
             .expect("approval confirmation should be bold");
         terminal.send_line("y").expect("approve IPC send");
         request

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -274,13 +274,23 @@ Sends code as if the user typed it at the prompt. Output goes to the session's o
 shown for human approval; in headless mode it runs immediately because there is
 no human to ask. It is not governed by the silent-eval allowlist.
 
-In an interactive REPL, `send` displays a bounded, escaped preview in this
-format and requires an explicit `y` or `Y` key for each request by default:
+In an interactive REPL, `send` displays the complete escaped code that will be
+executed after approval. Control and other non-printing characters are escaped
+so they cannot alter or spoof the terminal display. The approval block is
+shown as three separate lines and requires an explicit `y` or `Y` key for each
+request by default:
 
 ```text
-# [arf] IPC send request: [<preview>]
+# [arf] IPC send request:
+  <escaped code>
 # [arf] Press y to approve, any other key declines:
 ```
+
+The heading and `# [arf]` prefix are dark cyan, the escaped code is yellow,
+and the confirmation text is bold yellow. The three-line structure carries the
+meaning independently of color. Long code is not shortened; it remains
+available in the terminal scrollback, so the displayed escaped code corresponds
+to the complete code being approved.
 
 Any other key, including Enter, `n`, Ctrl+C, Ctrl+D, or Esc, rejects the
 request. Non-key terminal events are ignored while waiting. A read error or a


### PR DESCRIPTION
## Summary

- show the complete escaped IPC submission before interactive approval instead of truncating it after roughly 240 characters
- separate and style the approval heading, code, and confirmation text for readability
- move approval handling into a focused IPC module and update the documented prompt format
- add unit, PTY, and integration coverage for long submissions, control-character escaping, styling, and approval behavior

## Why

The approval prompt previously displayed only a shortened prefix while arf executed the full original submission after approval. An IPC client could therefore hide executable content beyond the visible portion. The prompt now shows an escaped representation of the complete code that will execute, preserving protection against terminal-control spoofing without rejecting legitimate long submissions.

## Validation

- `cargo fmt --check`
- `cargo test -p arf-console` (939 passed, 4 ignored)
- IPC approval unit tests (3 passed)
- IPC PTY tests (21 passed)
- `cargo clippy -p arf-console --all-targets -- -D warnings`
- `git diff --check`
