### PR TITLE
feat(ipc)!: require session type in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
   For now, it seems neither of these formats is widely adopted, so arf introduces a generic `toml-key` type that allows us to specify the filename and key path and supports Cargo-style version ranges.
   Of course, we can also support other TOML files with different names and keys for specifying the R version.
 
-- **Experimental:** `arf ipc list` now reports a `session_type` field (`"headless"` or `"interactive"`) for each session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Sessions started by an older arf report `null`, which clients should treat as unknown (#283).
+- **Experimental:** `arf ipc list` now reports a required `session_type` field (`"headless"` or `"interactive"`) for each current session, so external clients can tell an agent-started headless session from an interactive REPL a person is using before sending it a `shutdown`. Session files from older arf versions that lack this field are not accepted by the current schema (#283).
 - **Experimental:** `arf ipc session`, `arf ipc list`, and `arf headless --json` now report `r_home`, the R installation the session is using, so an editor can use the same R instead of discovering one for itself. Sessions started by an older arf omit it, which clients should treat as unknown (#294).
 - **Experimental:** `arf r resolve` lets external tools such as editors learn which R arf would use without starting R. It always emits JSON on success (#290, #291, #293).
 

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -503,7 +503,7 @@ mod tests {
             r_home: Some("/opt/R/4.4.1/lib/R".to_string()),
             cwd: "/tmp".to_string(),
             started_at: "2026-01-01T00:00:00+00:00".to_string(),
-            session_type: Some(SessionType::Headless),
+            session_type: SessionType::Headless,
             log_file: None,
             history_session_id: None,
         };

--- a/crates/arf-console/src/ipc/server.rs
+++ b/crates/arf-console/src/ipc/server.rs
@@ -236,7 +236,7 @@ pub fn start_server(
         r_home,
         cwd,
         started_at: started_at.to_string(),
-        session_type: Some(session_type),
+        session_type,
         log_file,
         history_session_id,
     };

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -37,10 +37,8 @@ pub struct SessionInfo {
     pub r_home: Option<String>,
     pub cwd: String,
     pub started_at: String,
-    /// Whether this session is headless or interactive, or `None` for session
-    /// files written by an older arf that did not record this.
-    #[serde(default)]
-    pub session_type: Option<SessionType>,
+    /// Whether this session is headless or interactive.
+    pub session_type: SessionType,
     /// Log file path, or `None` if no log file is configured.
     #[serde(default)]
     pub log_file: Option<String>,
@@ -239,7 +237,7 @@ fn is_process_alive(pid: u32) -> bool {
 mod tests {
     use super::*;
 
-    fn session_info(session_type: Option<SessionType>) -> SessionInfo {
+    fn session_info(session_type: SessionType) -> SessionInfo {
         SessionInfo {
             pid: 12345,
             socket_path: "/tmp/arf.sock".to_string(),
@@ -255,7 +253,7 @@ mod tests {
 
     #[test]
     fn session_type_serializes_and_round_trips() {
-        let mut info = session_info(Some(SessionType::Headless));
+        let mut info = session_info(SessionType::Headless);
         info.r_home = Some("/opt/R/4.4.1/lib/R".to_string());
         let json = serde_json::to_value(&info).unwrap();
 
@@ -275,12 +273,12 @@ mod tests {
 }"###);
 
         let restored: SessionInfo = serde_json::from_value(json).unwrap();
-        assert_eq!(restored.session_type, Some(SessionType::Headless));
+        assert_eq!(restored.session_type, SessionType::Headless);
         assert_eq!(restored.r_home.as_deref(), Some("/opt/R/4.4.1/lib/R"));
     }
 
     #[test]
-    fn legacy_session_without_session_type_deserializes_as_unknown() {
+    fn session_type_is_required_in_session_files() {
         let json = serde_json::json!({
             "pid": 12345,
             "socket_path": "/tmp/arf.sock",
@@ -289,8 +287,21 @@ mod tests {
             "started_at": "2026-01-01T00:00:00+00:00",
         });
 
-        let info: SessionInfo = serde_json::from_value(json).unwrap();
-        assert_eq!(info.session_type, None);
+        assert!(serde_json::from_value::<SessionInfo>(json).is_err());
+    }
+
+    #[test]
+    fn null_session_type_is_rejected() {
+        let json = serde_json::json!({
+            "pid": 12345,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": "4.4.1",
+            "cwd": "/tmp",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "session_type": null,
+        });
+
+        assert!(serde_json::from_value::<SessionInfo>(json).is_err());
     }
 
     #[test]
@@ -301,6 +312,7 @@ mod tests {
             "r_version": "4.4.1",
             "cwd": "/tmp",
             "started_at": "2026-01-01T00:00:00+00:00",
+            "session_type": "interactive",
         });
 
         let info: SessionInfo = serde_json::from_value(json).unwrap();
@@ -321,7 +333,7 @@ mod tests {
         let pid = std::process::id();
         let info = SessionInfo {
             pid,
-            ..session_info(Some(SessionType::Interactive))
+            ..session_info(SessionType::Interactive)
         };
         write_session(&info).unwrap();
 
@@ -331,6 +343,6 @@ mod tests {
             std::fs::read_to_string(temp_dir.path().join(format!("{pid}.json"))).unwrap();
         let cleared: SessionInfo = serde_json::from_str(&contents).unwrap();
         assert_eq!(cleared.history_session_id, None);
-        assert_eq!(cleared.session_type, Some(SessionType::Interactive));
+        assert_eq!(cleared.session_type, SessionType::Interactive);
     }
 }

--- a/crates/arf-console/src/ipc/session.rs
+++ b/crates/arf-console/src/ipc/session.rs
@@ -21,7 +21,7 @@
 //!   (which reveal PIDs) would be visible to other users.
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const ARF_IPC_SESSIONS_DIR: &str = "ARF_IPC_SESSIONS_DIR";
 
@@ -171,19 +171,49 @@ pub fn list_sessions() -> Vec<SessionInfo> {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "json")
-            && let Ok(contents) = std::fs::read_to_string(&path)
-            && let Ok(info) = serde_json::from_str::<SessionInfo>(&contents)
-        {
-            if is_process_alive(info.pid) {
-                sessions.push(info);
-            } else {
+        if !path.extension().is_some_and(|ext| ext == "json") {
+            continue;
+        }
+
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        match serde_json::from_str::<SessionInfo>(&contents) {
+            Ok(info) if is_process_alive(info.pid) => sessions.push(info),
+            Ok(_) => {
                 let _ = std::fs::remove_file(&path);
             }
+            Err(_) => cleanup_invalid_session_file(&path, &contents),
         }
     }
 
     sessions
+}
+
+/// Remove an invalid session file only when its JSON identifies the same dead
+/// PID as its filename. Invalid files for live processes remain hidden but are
+/// left untouched, as are files whose contents and names disagree.
+fn cleanup_invalid_session_file(path: &Path, contents: &str) {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(contents) else {
+        return;
+    };
+    let Some(pid) = json
+        .get("pid")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|pid| u32::try_from(pid).ok())
+    else {
+        return;
+    };
+    let Some(filename_pid) = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.parse::<u32>().ok())
+    else {
+        return;
+    };
+    if pid == filename_pid && !is_process_alive(pid) {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Find a session by PID, or return the only running session if PID is not specified.
@@ -302,6 +332,79 @@ mod tests {
         });
 
         assert!(serde_json::from_value::<SessionInfo>(json).is_err());
+    }
+
+    #[test]
+    fn list_sessions_removes_dead_legacy_session_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut guard = crate::test_utils::lock_env();
+        guard.set(ARF_IPC_SESSIONS_DIR, temp_dir.path());
+
+        let pid = std::process::id().saturating_add(1_000_000);
+        let path = temp_dir.path().join(format!("{pid}.json"));
+        let json = serde_json::json!({
+            "pid": pid,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": null,
+            "cwd": "/tmp",
+            "started_at": "1970-01-01T00:00:00Z",
+            "r_home": null,
+            "log_file": null,
+            "history_session_id": null,
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        assert!(list_sessions().is_empty());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn list_sessions_hides_but_keeps_live_legacy_session_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut guard = crate::test_utils::lock_env();
+        guard.set(ARF_IPC_SESSIONS_DIR, temp_dir.path());
+
+        let pid = std::process::id();
+        let path = temp_dir.path().join(format!("{pid}.json"));
+        let json = serde_json::json!({
+            "pid": pid,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": null,
+            "cwd": "/tmp",
+            "started_at": "1970-01-01T00:00:00Z",
+            "r_home": null,
+            "log_file": null,
+            "history_session_id": null,
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        assert!(list_sessions().is_empty());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn list_sessions_keeps_legacy_file_when_pid_does_not_match_filename() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut guard = crate::test_utils::lock_env();
+        guard.set(ARF_IPC_SESSIONS_DIR, temp_dir.path());
+
+        let pid = std::process::id();
+        let filename_pid = pid.saturating_add(1_000_000);
+        let path = temp_dir.path().join(format!("{filename_pid}.json"));
+        let json = serde_json::json!({
+            "pid": pid,
+            "socket_path": "/tmp/arf.sock",
+            "r_version": null,
+            "cwd": "/tmp",
+            "started_at": "1970-01-01T00:00:00Z",
+            "r_home": null,
+            "log_file": null,
+            "history_session_id": null,
+        });
+        std::fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+
+        assert!(list_sessions().is_empty());
+        assert!(path.exists());
     }
 
     #[test]

--- a/crates/arf-console/tests/headless/error_codes.rs
+++ b/crates/arf-console/tests/headless/error_codes.rs
@@ -95,6 +95,7 @@ fn test_ipc_exit_code_transport_error() {
         "r_version": null,
         "cwd": ".",
         "started_at": "1970-01-01T00:00:00Z",
+        "session_type": "interactive",
         "log_file": null,
         "history_session_id": null
     });

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -436,10 +436,8 @@ arf ipc list
 When no sessions are running, returns `{"sessions": []}` (exit 0).
 
 The `session_type` field is `"headless"` for sessions started with
-`arf headless` and `"interactive"` for sessions running an interactive
-REPL. A `null` value means the session was created by an older arf that did not
-record its type. Clients must treat `null` as unknown and must not send
-`shutdown` to that session.
+`arf headless` and `"interactive"` for sessions running an interactive REPL.
+The field is always present in current session metadata.
 
 The `r_home` field is the R installation the session is using. A `null` value
 means either that the session has no R, or that it was created by an older arf
@@ -447,10 +445,9 @@ that did not record the path: a session file written before this field existed
 is listed with `r_home` set to `null`, like any other unset field. Clients must
 treat `null` as unknown and must not assume an R installation is available.
 
-`r_version`, `r_home`, `session_type`, `log_file`, and `history_session_id` may
-all be `null`. The list is discovery metadata only; it does not include the
-effective IPC policy. Query `arf ipc session` to obtain the live policy at the
-time of the request.
+`r_version`, `r_home`, `log_file`, and `history_session_id` may be `null`. The
+list is discovery metadata only; it does not include the effective IPC policy.
+Query `arf ipc session` to obtain the live policy at the time of the request.
 
 ### `arf ipc history` — Query Command History
 


### PR DESCRIPTION
## Summary

- make `SessionInfo.session_type` required instead of optional
- reject session metadata where `session_type` is missing or `null`
- clean up stale legacy session files without restoring compatibility with the old schema
- update synthetic session fixtures, IPC documentation, and the changelog

## Rationale

The upcoming release already includes incompatible IPC session schema changes. Keeping `session_type` optional solely for compatibility with older session files no longer provides a useful compatibility guarantee. Fields that are semantically optional, such as `r_home`, `log_file`, and `history_session_id`, remain optional.

Session files from older arf versions that do not contain `session_type` are therefore not accepted by the current discovery schema.

## Legacy session cleanup

A legacy or otherwise invalid session file is removed only when:

- its JSON contains a valid PID,
- that PID matches the PID in the filename, and
- the process is no longer alive.

Files for live processes remain hidden but are left untouched. Files whose JSON PID and filename disagree are also preserved. This prevents stale legacy files from accumulating without reintroducing the old optional schema.

Regression tests cover dead legacy file cleanup, preservation of live legacy files, and preservation on PID mismatch.

## Validation

- `cargo test -p arf-console`
- `cargo fmt --check`
- `cargo clippy -p arf-console --all-targets -- -D warnings`
- `git diff --check`
