### PR TITLE
fix: custom R continuation prompt classification

### DIFF
--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -83,7 +83,7 @@ fn approve_interactive_ipc_operation(
 /// With the Validator in place, reedline handles multiline input internally.
 /// The callback receives complete expressions (possibly with embedded newlines)
 /// from reedline and passes them to R.
-pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
+pub(super) fn read_console_callback(r_prompt: &str, is_continuation: bool) -> Option<String> {
     REPL_STATE.with(|state| {
         // Use try_borrow_mut to detect re-entrant calls.
         // This is a defensive measure in case R unexpectedly calls ReadConsole
@@ -106,16 +106,22 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
             return None;
         }
 
+        // The low-level ReadConsole callback reads options(continue) once and
+        // supplies the result here. Classify the prompt once so every lifecycle,
+        // IPC, display, menu, formatter, and history decision shares one value.
+        let prompt_kind = classify_prompt(r_prompt, is_continuation);
+
         // Update exit_status for the previous command when a new prompt is shown.
         // This is called when R has finished evaluating and wants new input.
-        // Continuation prompts (starting with '+') mean we're still in the same expression.
+        // Continuation prompts identified by the low-level option lookup mean
+        // we're still in the same expression.
         // Non-command prompts (menus, etc.) should also not trigger exit status updates.
         // Track prompt state for IPC: true when R is idle at the command
         // prompt, false for continuation/menu/selection prompts so IPC
         // requests are correctly rejected during non-command prompts.
-        crate::ipc::set_r_at_prompt(is_r_command_prompt(r_prompt));
+        crate::ipc::set_r_at_prompt(prompt_kind.is_command());
 
-        if is_r_command_prompt(r_prompt) && !state.prompt_config.is_shell_enabled() {
+        if prompt_kind.is_command() && !state.prompt_config.is_shell_enabled() {
             let pending_history_context = std::mem::take(&mut state.pending_history_context);
             let had_error = match pending_history_context {
                 PendingHistoryContext::Command { store, history_id } => {
@@ -145,7 +151,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
         // Check for pending IPC operations before entering the reedline input loop.
         // At this point reedline hasn't started, so there's no editor buffer to
         // conflict with — we can always accept.
-        if is_r_command_prompt(r_prompt)
+        if prompt_kind.is_command()
             && !state.prompt_config.is_shell_enabled()
             && let Some(op) = crate::ipc::take_pending_ipc_operation()
         {
@@ -222,12 +228,12 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
         loop {
             // Build prompt dynamically from config.
             // We detect the type of prompt R is asking for:
-            // - Continuation prompts start with '+' (multiline input)
-            // - Command prompts typically end with "> " (R's default prompt)
+            // - Continuation prompts are identified by PromptKind (multiline input)
+            // - Command prompts are identified by PromptKind at R's top level
             // - Non-standard prompts (menus, etc.) are passed through directly
-            let prompt = if r_prompt.starts_with('+') {
+            let prompt = if prompt_kind.is_continuation() {
                 state.prompt_config.build_cont_prompt(state.reprex.mode)
-            } else if is_r_command_prompt(r_prompt) {
+            } else if prompt_kind.is_command() {
                 state.prompt_config.build_main_prompt(state.reprex.mode)
             } else {
                 // Non-standard prompt from R (menu selection, etc.)
@@ -254,7 +260,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
             arf_libr::process_r_events();
 
             // Track whether we're in a non-standard prompt mode (menu selection, etc.)
-            let is_menu_prompt = !is_r_command_prompt(r_prompt) && !r_prompt.starts_with('+');
+            let is_menu_prompt = prompt_kind.is_other();
 
             match editor.read_line(&prompt) {
                 Ok(Signal::Success(line)) => {
@@ -354,7 +360,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                             // command. It must not finalize that command's
                             // history or sponge state merely because formatting
                             // this piece failed.
-                            if formatter_failure_updates_lifecycle(r_prompt) {
+                            if formatter_failure_updates_lifecycle(prompt_kind) {
                                 let history_id = match save_outcome {
                                     Some(crate::history::HistorySaveOutcome::Saved(id)) => Some(id),
                                     _ => None,
@@ -395,7 +401,7 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
                     // Only a top-level command starts a new Reedline history
                     // context. Continuation prompts remain part of the outer
                     // command, so preserve its context until evaluation ends.
-                    if is_r_command_prompt(r_prompt) && !code.trim().is_empty() {
+                    if prompt_kind.is_command() && !code.trim().is_empty() {
                         let history_id = match save_outcome {
                             Some(crate::history::HistorySaveOutcome::Saved(id)) => Some(id),
                             _ => None,
@@ -553,58 +559,77 @@ pub(super) fn read_console_callback(r_prompt: &str) -> Option<String> {
     })
 }
 
-/// Check if the prompt is R's standard command prompt (top-level).
-///
-/// Uses R's call stack depth (sys.nframe()) to determine if we're at the top-level
-/// or if user code is requesting input (e.g., via readline() or menu()).
-///
-/// This approach is more robust than heuristics like checking prompt endings,
-/// because it detects the actual R evaluation context.
-///
-/// Returns true if:
-/// - We're at the top-level (n_frame == 0) AND not a continuation prompt
-///
-/// Returns false if:
-/// - This is a continuation prompt (starts with '+')
-/// - User code is requesting input (n_frame > 0), e.g., readline(), menu()
-///
-/// Reference: This approach is used by ark (Positron's R kernel).
-fn is_r_command_prompt(prompt: &str) -> bool {
-    // Continuation prompts (starting with '+') are NOT command prompts
-    //
-    // TODO: R lets users change this prefix with options(continue = "..."),
-    // and a custom value is then misread as a command prompt. Compare against
-    // R's configured continuation string instead. Every caller of this
-    // function is affected, including IPC request admission.
-    if prompt.starts_with('+') {
-        return false;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptKind {
+    Command,
+    Continuation,
+    Other,
+}
+
+impl PromptKind {
+    fn is_command(self) -> bool {
+        matches!(self, Self::Command)
     }
 
-    // Use R's call stack depth to detect if we're at top-level
-    // n_frame == 0 means top-level prompt
-    // n_frame > 0 means user code is requesting input (readline, menu, etc.)
+    fn is_continuation(self) -> bool {
+        matches!(self, Self::Continuation)
+    }
+
+    fn is_other(self) -> bool {
+        matches!(self, Self::Other)
+    }
+}
+
+/// Classify a ReadConsole prompt once per callback.
+///
+/// Continuation status comes directly from R's low-level option lookup. For
+/// every other prompt, call sys.nframe() once to distinguish a top-level command
+/// prompt from input requested by user code (readline(), menu(), browser(), …).
+fn classify_prompt(prompt: &str, is_continuation: bool) -> PromptKind {
+    if is_continuation {
+        return PromptKind::Continuation;
+    }
+
     match arf_harp::r_n_frame() {
-        Ok(n_frame) => n_frame == 0,
+        Ok(0) => PromptKind::Command,
+        Ok(_) => PromptKind::Other,
         Err(_) => {
-            // If we can't get n_frame, fall back to heuristic
-            // R's default prompt ends with "> ", menu prompts end with ": "
-            prompt.ends_with("> ")
+            // If R's stack inspection fails, preserve the historical fallback
+            // for the standard prompt and treat other prompts conservatively.
+            if prompt.ends_with("> ") {
+                PromptKind::Command
+            } else {
+                PromptKind::Other
+            }
         }
     }
 }
 
 /// Formatter failures only finalize lifecycle state for top-level commands.
 /// Continuation prompts belong to the outer command and retain its context.
-fn formatter_failure_updates_lifecycle(prompt: &str) -> bool {
-    is_r_command_prompt(prompt)
+fn formatter_failure_updates_lifecycle(prompt_kind: PromptKind) -> bool {
+    prompt_kind.is_command()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::formatter_failure_updates_lifecycle;
+    use super::{PromptKind, classify_prompt, formatter_failure_updates_lifecycle};
 
     #[test]
     fn continuation_formatter_failure_keeps_outer_lifecycle_context() {
-        assert!(!formatter_failure_updates_lifecycle("+ "));
+        assert!(!formatter_failure_updates_lifecycle(
+            PromptKind::Continuation
+        ));
+    }
+
+    #[test]
+    fn prompt_classification_prioritizes_low_level_continuation_status() {
+        assert_eq!(classify_prompt("... ", true), PromptKind::Continuation,);
+    }
+
+    #[test]
+    fn prompt_classification_falls_back_for_uninitialized_r() {
+        assert_eq!(classify_prompt("> ", false), PromptKind::Command,);
+        assert_eq!(classify_prompt("Selection: ", false), PromptKind::Other,);
     }
 }

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -751,6 +751,117 @@ fn test_pty_menu_prompt() {
     terminal.quit().expect("Should quit cleanly");
 }
 
+/// A custom R continuation option must still be classified as a continuation
+/// by the console. The fake formatter makes the low-level R ReadConsole path
+/// observable despite reedline handling ordinary incomplete input itself.
+#[test]
+#[cfg(unix)]
+fn test_pty_custom_continuation_prompt_round_trip() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("create temporary test directory");
+    let bin_dir = temp_dir.path().join("bin");
+    std::fs::create_dir(&bin_dir).expect("create fake formatter directory");
+    let arity = bin_dir.join("arity");
+    std::fs::write(
+        &arity,
+        r##"#!/bin/sh
+case "$1" in
+  --version) echo 'arity 0.19.1'; exit 0 ;;
+  format)
+    input=$(cat)
+    if [ "$input" = 42 ]; then
+      printf '%s' '1 +'
+    else
+      printf '%s' "$input"
+    fi
+    exit 0
+    ;;
+  *) exit 18 ;;
+esac
+"##,
+    )
+    .expect("write fake formatter");
+    let mut permissions = std::fs::metadata(&arity)
+        .expect("stat fake formatter")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&arity, permissions).expect("make fake formatter executable");
+
+    let config_path = temp_dir.path().join("arf.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[startup]
+reprex = "format"
+
+[reprex]
+formatter = "arity"
+
+[prompt]
+format = "MAIN> "
+continuation = "CONT> "
+"#,
+    )
+    .expect("write test config");
+
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").expect("PATH should be set")
+    );
+    let config_path = config_path.to_string_lossy().into_owned();
+    let mut terminal = Terminal::spawn_with_args_and_env(
+        &["--no-auto-match", "--config", &config_path],
+        &[("PATH", &path)],
+    )
+    .expect("spawn arf with fake formatter");
+
+    terminal.expect("MAIN> ").expect("Should show main prompt");
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear initial prompt output");
+    terminal
+        .send_line("options(continue = '... ')")
+        .expect("Should configure continuation prompt");
+    terminal
+        .expect("MAIN> ")
+        .expect("Should return to the normal prompt after options()");
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear options output before incomplete expression");
+    terminal
+        .send_line("42")
+        .expect("Should send formatter sentinel");
+    terminal
+        .expect("CONT> ")
+        .expect("Should display the configured arf continuation prompt");
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear continuation prompt output");
+    terminal
+        .send_line("2")
+        .expect("Should complete the expression");
+    terminal
+        .expect("[1] 3")
+        .expect("Should evaluate the expression");
+    terminal
+        .expect("MAIN> ")
+        .expect("Should return to the normal prompt after completion");
+
+    terminal
+        .send_line("1 + 1")
+        .expect("Should send a subsequent top-level command");
+    terminal
+        .expect("[1] 2")
+        .expect("Subsequent top-level command should execute");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
 /// Test vi mode indicator is displayed correctly at the end of the prompt.
 ///
 /// The vi mode indicator is shown via `render_prompt_indicator()` which ensures

--- a/crates/arf-libr/src/functions.rs
+++ b/crates/arf-libr/src/functions.rs
@@ -85,6 +85,8 @@ pub struct RLibrary {
     pub rf_findvar: unsafe extern "C" fn(SEXP, SEXP) -> SEXP,
     pub rf_definevar: unsafe extern "C" fn(SEXP, SEXP, SEXP),
     pub rf_scalarlogical: unsafe extern "C" fn(c_int) -> SEXP,
+    /// Get an R option directly without evaluating R code.
+    pub rf_get_option1: unsafe extern "C" fn(SEXP) -> SEXP,
 
     // Stack limit (for embedded R)
     pub r_cstacklimit: *mut usize,
@@ -348,6 +350,7 @@ impl RLibrary {
             load_symbol!(rf_findvar, b"Rf_findVar\0");
             load_symbol!(rf_definevar, b"Rf_defineVar\0");
             load_symbol!(rf_scalarlogical, b"Rf_ScalarLogical\0");
+            load_symbol!(rf_get_option1, b"Rf_GetOption1\0");
 
             // Load stack limit pointer
             load_ptr!(r_cstacklimit, b"R_CStackLimit\0", usize);
@@ -612,6 +615,7 @@ impl RLibrary {
                 rf_findvar,
                 rf_definevar,
                 rf_scalarlogical,
+                rf_get_option1,
                 r_cstacklimit,
                 #[cfg(unix)]
                 ptr_r_readconsole,

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -44,14 +44,72 @@ use spinner::SPINNER_THREAD;
 #[cfg(test)]
 mod test_utils;
 
+use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
+
+use crate::SexpType;
 
 #[cfg(unix)]
 use askpass::{ASKPASS_PROMPT_PREFIX, read_password_from_tty, recover_pending_termios};
 use interrupt::AwaitConsoleInputGuard;
 use output::REPREX_SETTINGS;
 
-static mut READ_CONSOLE_CALLBACK: Option<fn(&str) -> Option<String>> = None;
+/// ReadConsole callback receives the raw R prompt and whether it exactly
+/// matches R's current `options(continue)` value.
+type ReadConsoleCallback = fn(&str, bool) -> Option<String>;
+
+static mut READ_CONSOLE_CALLBACK: Option<ReadConsoleCallback> = None;
+
+const DEFAULT_CONTINUATION_PROMPT: &str = "+ ";
+
+/// Read R's current continuation prompt without evaluating any R code.
+///
+/// This is intentionally performed for every ReadConsole invocation. R code may
+/// change `options(continue)` between prompts, so caching the value would make
+/// prompt classification stale. Any failure to inspect the option falls back to
+/// R's default continuation prompt.
+fn continuation_prompt() -> Option<String> {
+    let lib = crate::r_library().ok()?;
+    let option_name = b"continue\0";
+
+    // SAFETY: R is initialized while ReadConsole is invoked, and option_name is
+    // a valid NUL-terminated string. The returned SEXP is borrowed from R.
+    let option = unsafe {
+        let symbol = (lib.rf_install)(option_name.as_ptr() as *const c_char);
+        (lib.rf_get_option1)(symbol)
+    };
+
+    if option.is_null() {
+        return None;
+    }
+
+    // `options(continue = ...)` must be a character vector with exactly one
+    // element. Treat all other values as malformed and use the default.
+    let is_string = unsafe { (lib.rf_typeof)(option) == SexpType::StrSxp as c_int };
+    if !is_string || unsafe { (lib.rf_length)(option) } != 1 {
+        return None;
+    }
+
+    // SAFETY: The type and length were checked above. R's STRING_ELT and R_CHAR
+    // accessors return borrowed objects valid for this ReadConsole invocation.
+    let chars = unsafe {
+        let element = (lib.string_elt)(option, 0);
+        (lib.r_charsxp)(element)
+    };
+    if chars.is_null() {
+        return None;
+    }
+
+    // R strings are not necessarily valid UTF-8. The console callback accepts
+    // UTF-8, so malformed values use the default rather than panicking.
+    unsafe { CStr::from_ptr(chars).to_str().ok().map(str::to_owned) }
+}
+
+/// Determine whether an R prompt is the configured continuation prompt.
+fn is_continuation_prompt(prompt: &str) -> bool {
+    let configured = continuation_prompt().unwrap_or_else(|| DEFAULT_CONTINUATION_PROMPT.into());
+    prompt == configured
+}
 
 /// Buffer for input that exceeds R's buffer size.
 /// When input is longer than buflen, the remainder is stored here
@@ -88,6 +146,19 @@ pub(super) unsafe extern "C" fn r_read_console(
     #[cfg(unix)]
     recover_pending_termios();
 
+    // Read the option once per invocation and share this result with both the
+    // reprex bookkeeping below and the high-level console callback. This keeps
+    // all prompt classification consistent without evaluating R code.
+    let prompt_str: &str = if prompt.is_null() {
+        ""
+    } else {
+        // SAFETY: prompt is a valid C string from R.
+        unsafe { CStr::from_ptr(prompt) }
+            .to_str()
+            .unwrap_or_default()
+    };
+    let is_continuation = is_continuation_prompt(prompt_str);
+
     // Askpass mode: detect magic prefix, strip it, read from /dev/tty with echo disabled.
     // This runs before the input-wait guard on purpose: no Rust loop pumps R
     // events during the blocking tty read, so the longjmp hazard the guard
@@ -115,15 +186,9 @@ pub(super) unsafe extern "C" fn r_read_console(
         && settings.enabled
         && settings.had_output
     {
-        // Check if this is a main prompt (not continuation)
-        let is_main_prompt = if prompt.is_null() {
-            true
-        } else {
-            // SAFETY: prompt is a valid C string from R
-            let prompt_str = unsafe { std::ffi::CStr::from_ptr(prompt) }.to_string_lossy();
-            // Continuation prompts typically start with "+" or spaces
-            !prompt_str.starts_with('+') && !prompt_str.trim().is_empty()
-        };
+        // Check if this is a main prompt (not continuation). Use the same
+        // option-derived classification passed to the high-level callback.
+        let is_main_prompt = !is_continuation && !prompt_str.trim().is_empty();
 
         if is_main_prompt {
             println!();
@@ -141,23 +206,13 @@ pub(super) unsafe extern "C" fn r_read_console(
         } else {
             drop(pending); // Release lock before callback
 
-            // Get the prompt string
-            let prompt_str: &str = if prompt.is_null() {
-                ""
-            } else {
-                // SAFETY: prompt is a valid C string from R
-                unsafe { std::ffi::CStr::from_ptr(prompt) }
-                    .to_str()
-                    .unwrap_or_default()
-            };
-
             log::debug!("r_read_console: prompt={:?}", prompt_str);
 
             // Call the callback to get new input
             // SAFETY: READ_CONSOLE_CALLBACK is only accessed from this single-threaded context
             if let Some(callback) = unsafe { READ_CONSOLE_CALLBACK } {
                 log::debug!("r_read_console: calling callback");
-                match callback(prompt_str) {
+                match callback(prompt_str, is_continuation) {
                     Some(s) => {
                         log::debug!("r_read_console: got input len={}", s.len());
                         s
@@ -221,9 +276,11 @@ pub(super) unsafe extern "C" fn r_read_console(
 
 /// Set the console read callback.
 ///
-/// The callback receives the prompt and should return the user's input,
-/// or None to signal EOF (exit R).
-pub fn set_read_console_callback(callback: fn(&str) -> Option<String>) {
+/// The callback receives the raw R prompt and a boolean indicating whether it
+/// exactly matches the current `options(continue)` value. The option is read
+/// once for each ReadConsole invocation before the callback is called. The
+/// callback should return the user's input, or None to signal EOF (exit R).
+pub fn set_read_console_callback(callback: ReadConsoleCallback) {
     unsafe {
         READ_CONSOLE_CALLBACK = Some(callback);
     }


### PR DESCRIPTION
## Summary

- read the current R continuation option once per ReadConsole invocation without evaluating R code
- share one prompt classification across IPC, history, formatter lifecycle, display, and reprex handling
- add a PTY regression test that exercises a session-time custom continuation option through the real R continuation path

## Performance

Prompt classification previously called `sys.nframe()` up to six times during one top-level ReadConsole callback. A prior R 4.5.2 microbenchmark measured the existing `sys.nframe()` path at about 253–316 ns per call, while the direct `Rf_GetOption1` lookup and string comparison took about 17–23 ns.

The new path performs one continuation-option lookup per ReadConsole invocation and at most one `sys.nframe()` call. On the path that previously made six stack-depth checks, the estimated classification cost therefore drops from roughly 1.5–1.9 µs to roughly 0.27–0.34 µs, an approximately 80% reduction. Continuation prompts gain one direct option lookup compared with the old prefix check, so their expected added cost is only on the order of tens of nanoseconds. These figures are environment-specific microbenchmark estimates and exclude the rest of the console callback work.

The option is intentionally not cached so changes made by `options(continue = ...)` during a session take effect on the next ReadConsole invocation.

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-targets --all-features --workspace --locked