### PR TITLE
fix: warn about ambiguous R prompt options

### DIFF
--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -622,6 +622,7 @@ impl Repl {
                     self.formatter_backend,
                 ),
                 should_exit: false,
+                r_prompt_options_ambiguous: false,
                 config_path: self.config_path.clone(),
                 config_status: self.config_status,
                 r_source_status: self.r_source_status.clone(),

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -13,9 +13,9 @@ use std::io::{self, Write};
 use super::history::{finalize_history, save_ipc_history};
 use super::state::{PendingHistoryContext, SpongeQueue};
 use super::{
-    MetaAction, REPL_STATE, RPrompt, SessionInfoContext, arf_println, clear_input_lines,
-    execute_shell_command, handle_meta_command_result, meta_command, process_meta_command,
-    strip_reprex_output,
+    MetaAction, REPL_STATE, RPrompt, SessionInfoContext, arf_eprintln, arf_println,
+    clear_input_lines, execute_shell_command, handle_meta_command_result, meta_command,
+    process_meta_command, strip_reprex_output,
 };
 
 struct ApprovedInteractiveIpcOperation {
@@ -83,7 +83,10 @@ fn approve_interactive_ipc_operation(
 /// With the Validator in place, reedline handles multiline input internally.
 /// The callback receives complete expressions (possibly with embedded newlines)
 /// from reedline and passes them to R.
-pub(super) fn read_console_callback(r_prompt: &str, is_continuation: bool) -> Option<String> {
+pub(super) fn read_console_callback(
+    r_prompt: &str,
+    prompt_info: arf_libr::ReadConsolePromptInfo,
+) -> Option<String> {
     REPL_STATE.with(|state| {
         // Use try_borrow_mut to detect re-entrant calls.
         // This is a defensive measure in case R unexpectedly calls ReadConsole
@@ -106,10 +109,20 @@ pub(super) fn read_console_callback(r_prompt: &str, is_continuation: bool) -> Op
             return None;
         }
 
-        // The low-level ReadConsole callback reads options(continue) once and
-        // supplies the result here. Classify the prompt once so every lifecycle,
-        // IPC, display, menu, formatter, and history decision shares one value.
-        let prompt_kind = classify_prompt(r_prompt, is_continuation);
+        if should_warn_prompt_ambiguity(
+            &mut state.r_prompt_options_ambiguous,
+            prompt_info.options_are_ambiguous,
+        ) {
+            arf_eprintln!(
+                "Warning: options(\"prompt\") and options(\"continue\") are identical; arf cannot distinguish top-level and continuation prompts."
+            );
+        }
+
+        // The low-level ReadConsole callback reads both prompt options once and
+        // supplies their metadata here. Classify the prompt once so every
+        // lifecycle, IPC, display, menu, formatter, and history decision shares
+        // one value.
+        let prompt_kind = classify_prompt(r_prompt, prompt_info.is_continuation);
 
         // Update exit_status for the previous command when a new prompt is shown.
         // This is called when R has finished evaluating and wants new input.
@@ -611,9 +624,19 @@ fn formatter_failure_updates_lifecycle(prompt_kind: PromptKind) -> bool {
     prompt_kind.is_command()
 }
 
+/// Warn once for each transition into an ambiguous prompt-option state.
+fn should_warn_prompt_ambiguity(was_ambiguous: &mut bool, is_ambiguous: bool) -> bool {
+    let should_warn = is_ambiguous && !*was_ambiguous;
+    *was_ambiguous = is_ambiguous;
+    should_warn
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{PromptKind, classify_prompt, formatter_failure_updates_lifecycle};
+    use super::{
+        PromptKind, classify_prompt, formatter_failure_updates_lifecycle,
+        should_warn_prompt_ambiguity,
+    };
 
     #[test]
     fn continuation_formatter_failure_keeps_outer_lifecycle_context() {
@@ -631,5 +654,15 @@ mod tests {
     fn prompt_classification_falls_back_for_uninitialized_r() {
         assert_eq!(classify_prompt("> ", false), PromptKind::Command,);
         assert_eq!(classify_prompt("Selection: ", false), PromptKind::Other,);
+    }
+
+    #[test]
+    fn prompt_ambiguity_warning_is_rearmed_after_distinct_options() {
+        let mut was_ambiguous = false;
+
+        assert!(should_warn_prompt_ambiguity(&mut was_ambiguous, true));
+        assert!(!should_warn_prompt_ambiguity(&mut was_ambiguous, true));
+        assert!(!should_warn_prompt_ambiguity(&mut was_ambiguous, false));
+        assert!(should_warn_prompt_ambiguity(&mut was_ambiguous, true));
     }
 }

--- a/crates/arf-console/src/repl/state.rs
+++ b/crates/arf-console/src/repl/state.rs
@@ -60,6 +60,8 @@ pub struct ReplState {
     pub prompt_config: PromptRuntimeConfig,
     pub reprex: ReprexRuntime,
     pub should_exit: bool,
+    /// Whether the previous ReadConsole invocation had identical R prompt options.
+    pub r_prompt_options_ambiguous: bool,
     /// Path to the config file (for :info command).
     pub config_path: Option<PathBuf>,
     /// Status of config file loading (for :info display).

--- a/crates/arf-console/tests/pty_advanced_tests.rs
+++ b/crates/arf-console/tests/pty_advanced_tests.rs
@@ -175,17 +175,10 @@ on_exit_only = false
     terminal
         .expect("R> ")
         .expect("successful command should reach the next prompt");
-    let screen = terminal
-        .screen()
-        .expect("read screen after successful command");
-    let current_line = screen
-        .lines
-        .get(screen.cursor_row as usize)
-        .expect("cursor row should exist");
-    assert!(
-        current_line.contains("ms"),
-        "successful command should leave a visible duration: {current_line:?}"
-    );
+    terminal
+        .current_line()
+        .assert_contains("ms")
+        .expect("successful command should leave a visible duration");
 
     terminal
         .clear_buffer()
@@ -200,6 +193,10 @@ on_exit_only = false
         .expect("R> ")
         .expect("formatter failure should reach the failed prompt");
 
+    terminal
+        .current_line()
+        .assert_contains("ERR ")
+        .expect("formatter failure should mark the next prompt failed");
     let screen = terminal
         .screen()
         .expect("read screen after formatter failure");
@@ -207,10 +204,6 @@ on_exit_only = false
         .lines
         .get(screen.cursor_row as usize)
         .expect("cursor row should exist");
-    assert!(
-        current_line.contains("ERR "),
-        "formatter failure should mark the next prompt failed: {current_line:?}"
-    );
     assert!(
         !current_line.contains("ms"),
         "formatter failure should clear the previous duration: {current_line:?}"
@@ -858,6 +851,70 @@ continuation = "CONT> "
     terminal
         .expect("[1] 2")
         .expect("Subsequent top-level command should execute");
+
+    terminal.quit().expect("Should quit cleanly");
+}
+
+/// An identical R main and continuation prompt is ambiguous to arf. Warn once
+/// when the session enters that state, suppress repeated warnings, and re-arm
+/// the warning after the options become distinct again.
+#[test]
+#[cfg(unix)]
+fn test_pty_identical_r_prompt_options_warn_once_per_transition() {
+    const WARNING: &str = "# [arf] Warning: options(\"prompt\") and options(\"continue\") are identical; arf cannot distinguish top-level and continuation prompts.";
+
+    let mut terminal =
+        Terminal::spawn_with_args(&["--no-auto-match"]).expect("Failed to spawn arf");
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    terminal.clear_buffer().expect("clear initial output");
+    terminal
+        .send_line("options(prompt = '> ', continue = '> ')")
+        .expect("set identical prompt options");
+    terminal.expect(WARNING).expect("warn on first ambiguity");
+    terminal
+        .expect("+  ")
+        .expect("show the continuation prompt while options are ambiguous");
+    let output = terminal.get_output().expect("read terminal output");
+    assert_eq!(output.matches(WARNING).count(), 1);
+
+    terminal.clear_buffer().expect("clear first warning output");
+    terminal.send_line("1 + 1").expect("send command");
+    terminal.expect("[1] 2").expect("evaluate command normally");
+    terminal
+        .expect("+  ")
+        .expect("retain continuation classification while ambiguity persists");
+    let output = terminal
+        .get_output()
+        .expect("read output while ambiguity persists");
+    assert_eq!(output.matches(WARNING).count(), 0);
+
+    terminal
+        .clear_buffer()
+        .expect("clear persistent ambiguity output");
+    terminal
+        .send_line("options(prompt = '> ', continue = '+ ')")
+        .expect("restore distinct prompt options");
+    terminal
+        .wait_for_prompt()
+        .expect("return to the normal prompt after restoring options");
+    let output = terminal.get_output().expect("read distinct options output");
+    assert_eq!(output.matches(WARNING).count(), 0);
+
+    terminal
+        .clear_buffer()
+        .expect("clear distinct options output");
+    terminal
+        .send_line("options(prompt = '> ', continue = '> ')")
+        .expect("re-enter identical prompt options");
+    terminal
+        .expect(WARNING)
+        .expect("warn again after the ambiguity is reintroduced");
+    terminal
+        .expect("+  ")
+        .expect("show the continuation prompt after second warning");
+    let output = terminal.get_output().expect("read second warning output");
+    assert_eq!(output.matches(WARNING).count(), 1);
 
     terminal.quit().expect("Should quit cleanly");
 }

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -29,13 +29,14 @@ pub use sys::askpass_handler_code;
 #[cfg(unix)]
 pub use sys::ensure_ld_library_path_with_pre_exec;
 pub use sys::{
-    clear_r_interrupt_pending, clear_write_console_callback, command_had_error,
-    ensure_ld_library_path, find_r_library, finish_ipc_capture, flush_reprex_buffer, get_r_home,
-    global_error_handler_code, initialize_r, initialize_r_with_args, is_r_auto_discovery_disabled,
-    is_r_awaiting_console_input, is_r_interrupt_flag_available, is_spinner_active,
-    mark_error_condition, mark_global_error_handler_initialized, process_r_events,
-    r_home_from_library_path, r_home_from_rhome_output, r_library_path, reset_command_error_state,
-    restore_stderr, run_r_mainloop, set_r_auto_discovery_disabled, set_r_interrupt_pending,
+    ReadConsolePromptInfo, clear_r_interrupt_pending, clear_write_console_callback,
+    command_had_error, ensure_ld_library_path, find_r_library, finish_ipc_capture,
+    flush_reprex_buffer, get_r_home, global_error_handler_code, initialize_r,
+    initialize_r_with_args, is_r_auto_discovery_disabled, is_r_awaiting_console_input,
+    is_r_interrupt_flag_available, is_spinner_active, mark_error_condition,
+    mark_global_error_handler_initialized, process_r_events, r_home_from_library_path,
+    r_home_from_rhome_output, r_library_path, reset_command_error_state, restore_stderr,
+    run_r_mainloop, set_r_auto_discovery_disabled, set_r_interrupt_pending,
     set_read_console_callback, set_reprex_mode, set_spinner_color, set_spinner_frames,
     set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
 };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -54,26 +54,28 @@ use askpass::{ASKPASS_PROMPT_PREFIX, read_password_from_tty, recover_pending_ter
 use interrupt::AwaitConsoleInputGuard;
 use output::REPREX_SETTINGS;
 
-/// ReadConsole callback receives the raw R prompt and whether it exactly
-/// matches R's current `options(continue)` value.
-type ReadConsoleCallback = fn(&str, bool) -> Option<String>;
+/// Option-derived metadata for one ReadConsole invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadConsolePromptInfo {
+    /// Whether the raw prompt exactly matches R's current `options(continue)` value.
+    pub is_continuation: bool,
+    /// Whether R's current `options(prompt)` and `options(continue)` values are identical.
+    pub options_are_ambiguous: bool,
+}
+
+/// ReadConsole callback receives the raw R prompt and option-derived metadata.
+type ReadConsoleCallback = fn(&str, ReadConsolePromptInfo) -> Option<String>;
 
 static mut READ_CONSOLE_CALLBACK: Option<ReadConsoleCallback> = None;
 
 const DEFAULT_CONTINUATION_PROMPT: &str = "+ ";
 
-/// Read R's current continuation prompt without evaluating any R code.
-///
-/// This is intentionally performed for every ReadConsole invocation. R code may
-/// change `options(continue)` between prompts, so caching the value would make
-/// prompt classification stale. Any failure to inspect the option falls back to
-/// R's default continuation prompt.
-fn continuation_prompt() -> Option<String> {
+/// Read a scalar string option without evaluating any R code.
+fn string_option(option_name: &'static [u8]) -> Option<String> {
     let lib = crate::r_library().ok()?;
-    let option_name = b"continue\0";
 
-    // SAFETY: R is initialized while ReadConsole is invoked, and option_name is
-    // a valid NUL-terminated string. The returned SEXP is borrowed from R.
+    // SAFETY: R is initialized while ReadConsole is invoked. Callers provide a
+    // static NUL-terminated option name. The returned SEXP is borrowed from R.
     let option = unsafe {
         let symbol = (lib.rf_install)(option_name.as_ptr() as *const c_char);
         (lib.rf_get_option1)(symbol)
@@ -83,8 +85,8 @@ fn continuation_prompt() -> Option<String> {
         return None;
     }
 
-    // `options(continue = ...)` must be a character vector with exactly one
-    // element. Treat all other values as malformed and use the default.
+    // Prompt options must be character vectors with exactly one element. Treat
+    // all other values as malformed.
     let is_string = unsafe { (lib.rf_typeof)(option) == SexpType::StrSxp as c_int };
     if !is_string || unsafe { (lib.rf_length)(option) } != 1 {
         return None;
@@ -101,14 +103,39 @@ fn continuation_prompt() -> Option<String> {
     }
 
     // R strings are not necessarily valid UTF-8. The console callback accepts
-    // UTF-8, so malformed values use the default rather than panicking.
+    // UTF-8, so reject malformed values rather than panicking.
     unsafe { CStr::from_ptr(chars).to_str().ok().map(str::to_owned) }
 }
 
-/// Determine whether an R prompt is the configured continuation prompt.
-fn is_continuation_prompt(prompt: &str) -> bool {
-    let configured = continuation_prompt().unwrap_or_else(|| DEFAULT_CONTINUATION_PROMPT.into());
-    prompt == configured
+fn prompt_info_from_options(
+    raw_prompt: &str,
+    main_prompt: Option<&str>,
+    continuation_prompt: Option<&str>,
+) -> ReadConsolePromptInfo {
+    let options_are_ambiguous = matches!(
+        (main_prompt, continuation_prompt),
+        (Some(main), Some(continuation)) if main == continuation
+    );
+    let continuation_prompt = continuation_prompt.unwrap_or(DEFAULT_CONTINUATION_PROMPT);
+
+    ReadConsolePromptInfo {
+        is_continuation: raw_prompt == continuation_prompt,
+        options_are_ambiguous,
+    }
+}
+
+/// Inspect the prompt options for one ReadConsole invocation.
+///
+/// This is intentionally performed for every invocation because R code may
+/// change either option during a session. Values are not cached.
+fn read_console_prompt_info(raw_prompt: &str) -> ReadConsolePromptInfo {
+    let main_prompt = string_option(b"prompt\0");
+    let continuation_prompt = string_option(b"continue\0");
+    prompt_info_from_options(
+        raw_prompt,
+        main_prompt.as_deref(),
+        continuation_prompt.as_deref(),
+    )
 }
 
 /// Buffer for input that exceeds R's buffer size.
@@ -146,9 +173,8 @@ pub(super) unsafe extern "C" fn r_read_console(
     #[cfg(unix)]
     recover_pending_termios();
 
-    // Read the option once per invocation and share this result with both the
-    // reprex bookkeeping below and the high-level console callback. This keeps
-    // all prompt classification consistent without evaluating R code.
+    // Read the prompt options once per invocation and share the resulting
+    // metadata with both the reprex bookkeeping and high-level callback.
     let prompt_str: &str = if prompt.is_null() {
         ""
     } else {
@@ -157,7 +183,7 @@ pub(super) unsafe extern "C" fn r_read_console(
             .to_str()
             .unwrap_or_default()
     };
-    let is_continuation = is_continuation_prompt(prompt_str);
+    let prompt_info = read_console_prompt_info(prompt_str);
 
     // Askpass mode: detect magic prefix, strip it, read from /dev/tty with echo disabled.
     // This runs before the input-wait guard on purpose: no Rust loop pumps R
@@ -188,7 +214,7 @@ pub(super) unsafe extern "C" fn r_read_console(
     {
         // Check if this is a main prompt (not continuation). Use the same
         // option-derived classification passed to the high-level callback.
-        let is_main_prompt = !is_continuation && !prompt_str.trim().is_empty();
+        let is_main_prompt = !prompt_info.is_continuation && !prompt_str.trim().is_empty();
 
         if is_main_prompt {
             println!();
@@ -212,7 +238,7 @@ pub(super) unsafe extern "C" fn r_read_console(
             // SAFETY: READ_CONSOLE_CALLBACK is only accessed from this single-threaded context
             if let Some(callback) = unsafe { READ_CONSOLE_CALLBACK } {
                 log::debug!("r_read_console: calling callback");
-                match callback(prompt_str, is_continuation) {
+                match callback(prompt_str, prompt_info) {
                     Some(s) => {
                         log::debug!("r_read_console: got input len={}", s.len());
                         s
@@ -276,10 +302,10 @@ pub(super) unsafe extern "C" fn r_read_console(
 
 /// Set the console read callback.
 ///
-/// The callback receives the raw R prompt and a boolean indicating whether it
-/// exactly matches the current `options(continue)` value. The option is read
-/// once for each ReadConsole invocation before the callback is called. The
-/// callback should return the user's input, or None to signal EOF (exit R).
+/// The callback receives the raw R prompt and option-derived metadata. The
+/// current `options(prompt)` and `options(continue)` values are read once for
+/// each ReadConsole invocation before the callback is called. The callback
+/// should return the user's input, or None to signal EOF (exit R).
 pub fn set_read_console_callback(callback: ReadConsoleCallback) {
     unsafe {
         READ_CONSOLE_CALLBACK = Some(callback);

--- a/crates/arf-libr/src/sys/tests.rs
+++ b/crates/arf-libr/src/sys/tests.rs
@@ -1,6 +1,45 @@
 use super::*;
 use std::path::Path;
 
+#[test]
+fn prompt_info_detects_ambiguity_without_changing_exact_classification() {
+    let info = prompt_info_from_options("same> ", Some("same> "), Some("same> "));
+
+    assert!(info.is_continuation);
+    assert!(info.options_are_ambiguous);
+}
+
+#[test]
+fn prompt_info_matches_only_the_current_continuation_option() {
+    let info = prompt_info_from_options("... ", Some("> "), Some("... "));
+
+    assert!(info.is_continuation);
+    assert!(!info.options_are_ambiguous);
+
+    let main_prompt = prompt_info_from_options("> ", Some("> "), Some("... "));
+    assert!(!main_prompt.is_continuation);
+    assert!(!main_prompt.options_are_ambiguous);
+}
+
+#[test]
+fn prompt_info_uses_default_continuation_only_when_option_is_unavailable() {
+    let fallback = prompt_info_from_options("+ ", Some("> "), None);
+    let custom = prompt_info_from_options("+ ", Some("> "), Some("... "));
+
+    assert!(fallback.is_continuation);
+    assert!(!fallback.options_are_ambiguous);
+    assert!(!custom.is_continuation);
+}
+
+#[test]
+fn prompt_info_does_not_mark_malformed_options_as_ambiguous() {
+    let missing_main = prompt_info_from_options("+ ", None, Some("+ "));
+    let missing_continue = prompt_info_from_options("+ ", Some("+ "), None);
+
+    assert!(!missing_main.options_are_ambiguous);
+    assert!(!missing_continue.options_are_ambiguous);
+}
+
 /// Combined spinner test to avoid race conditions from parallel tests sharing global state.
 /// Tests spinner lifecycle: config, start, stop, double-start, double-stop, and color.
 #[test]


### PR DESCRIPTION
## Summary

- read R main and continuation prompt options for every ReadConsole invocation
- warn once when the options become identical and re-arm after they become distinct
- add unit and PTY coverage for ambiguity detection and warning suppression
- make formatter lifecycle PTY assertions wait for terminal screen updates

## Behavior

arf reports the ambiguity but does not rewrite either option or attempt to resolve the prompt type. Session-time option changes are detected without caching.

## Performance

Each ReadConsole invocation adds one direct R option lookup for the main prompt; the continuation option was already read by the preceding fix. There is no R expression evaluation, and warning state is a boolean comparison/update, so the expected overhead is negligible relative to interactive console I/O.

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo test --all-targets --all-features --workspace --locked