### PR TITLE
chore: upgrade reedline to 0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode.
+- Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).
 
 ## [0.5.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode.
+
 ## [0.5.0] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -662,7 +662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753088c970c4e63f91114d0dbef96c84fbaf3fde8943877f4254d33e97ce2193"
+checksum = "d010acf9ed312cbc737e5f9064c375a7093975b0c25568337f0c24148f46540d"
 dependencies = [
  "chrono",
  "crossterm",
@@ -1849,7 +1849,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -2235,7 +2235,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm"]
 # NOTE: reedline and rusqlite share the `links = "sqlite3"` native library (via
 # libsqlite3-sys) and must be upgraded together in lockstep, or Cargo's
 # dependency resolution fails.
-reedline = { version = "0.50", features = ["sqlite", "idle_callback"] }
+reedline = { version = "0.51", features = ["sqlite", "idle_callback"] }
 
 # Configuration
 dirs = "6.0"


### PR DESCRIPTION
Upgrades reedline from 0.50 to 0.51. No arf code changes were required; the only source change is a CHANGELOG entry for a user-visible vi fix that comes with the upgrade.

`rusqlite` stays at 0.40.x: reedline 0.51 still depends on 0.40.1, so the `links = "sqlite3"` lockstep noted in `Cargo.toml` does not come into play.

## Upstream changes and their effect on arf

**Vi pending motions completed with `v`.** Upstream guards the "enter visual mode" arm on the pending cache being empty, so `rv`, `fv` and `tv` now take `v` as the motion character instead of switching to visual mode. arf uses reedline's `Vi` edit mode directly, so this is user-visible and gets a CHANGELOG entry.

One known upstream side effect rides along: a count-prefixed `2v` no longer enters visual mode, because the pending count keeps the cache non-empty. Upstream marks this as deliberate-for-now while it decides how count-prefixed visual entry should behave. It is left out of the CHANGELOG as too marginal to be worth a user's attention.

**New `ReedlineEvent::HelixChangeMode` variant.** `ReedlineEvent` is not `#[non_exhaustive]`, so a new variant breaks any exhaustive match. arf matches over `ReedlineEvent` in three places in `crates/arf-console/src/editor/mode.rs`, and all three already have wildcard arms, so nothing changes. arf does not expose helix mode, so no arm is warranted for it either.

**Cursor repair around `change_edit_mode`.** arf never calls `Reedline::change_edit_mode`; it builds one edit mode at startup from `[editor] mode`. No effect.

## Cargo.lock

Besides reedline itself, `cargo update -p reedline` re-pointed some edges between versions that were already locked: `dirs`, `rustix` and `tempfile` move from `windows-sys` 0.59.0 to 0.61.2, and `fd-lock` from `errno` 0.2.8 to 0.3.14. Both older versions stay in the lockfile — `fd-lock`, `rtoolbox`, `winreg` and `exec` still reference them. This is deduplication rather than a version bump, and it comes back on any later `cargo update`, so it is kept.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [x] `cargo test --all-targets --all-features --workspace` — 1314 tests pass across 20 test binaries, including the PTY integration suites
