### PR TITLE
style: fix Windows byte chunk clippy lint

### DIFF
--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -629,8 +629,10 @@ fn decode_os_string(encoded: &str) -> Result<OsString, String> {
             return Err("decoded value has an odd number of bytes".to_string());
         }
         let wide = bytes
-            .chunks_exact(2)
-            .map(|chunk| u16::from_ne_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_ne_bytes(*chunk))
             .collect::<Vec<_>>();
         Ok(OsString::from_wide(&wide))
     }


### PR DESCRIPTION
## Summary

- replace fixed-size byte chunk iteration with slice as_chunks in Windows startup environment decoding
- preserve odd-length validation and native-endian UTF-16 reconstruction

## Testing

- cargo fmt --all --check
- cargo clippy -p arf-console --all-targets --all-features --locked -- -D warnings
- cargo test -p arf-console --all-targets --all-features --locked

Windows-target Clippy was not run locally because the Windows Rust target is not installed; CI covers Windows.