### PR TITLE
feat: add json-key R source override provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental:** Opt-in `json-key` R source override provider for reading a version from JSON files such as `renv.lock` (`{ type = "json-key", file = "renv.lock", key = "R.Version" }`) (#321).
+
 ### Fixed
 
 - Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).

--- a/artifacts/arf.schema.json
+++ b/artifacts/arf.schema.json
@@ -1959,6 +1959,27 @@
             "file",
             "key"
           ]
+        },
+        {
+          "description": "Read the R version from a JSON key.",
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "json-key"
+            }
+          },
+          "required": [
+            "type",
+            "file",
+            "key"
+          ]
         }
       ]
     },

--- a/crates/arf-console/src/app/resolve.rs
+++ b/crates/arf-console/src/app/resolve.rs
@@ -335,6 +335,7 @@ fn selected_by(
         let format = match resolution.provider.as_deref() {
             Some("version-file") => Some("text"),
             Some("toml-key") => Some("toml"),
+            Some("json-key") => Some("json"),
             _ => None,
         };
         return SelectedBy {

--- a/crates/arf-console/src/app/setup/overrides.rs
+++ b/crates/arf-console/src/app/setup/overrides.rs
@@ -194,6 +194,79 @@ where
                     }
                 }
             }
+            RSourceOverride::JsonKey { file, key } => {
+                if !is_bare_filename(file) {
+                    evaluated_provider = true;
+                    diagnostics.push(invalid_override_file_warning(provider, file));
+                    continue;
+                }
+                let path = match resolve_override_path(file, &mut base_dir) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(warning(
+                            "r_source_override.value_invalid",
+                            format!(
+                                "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
+                                file.display()
+                            ),
+                            Some(file.clone()),
+                        ));
+                        continue;
+                    }
+                };
+                match rversion::read_json_key(&path, key) {
+                    Ok(version) => {
+                        evaluated_provider = true;
+                        version
+                    }
+                    Err(error) if error.is_not_found() => {
+                        log::debug!("R source override file {} is not present", file.display());
+                        continue;
+                    }
+                    Err(
+                        rversion::JsonKeyError::MissingKey(_)
+                        | rversion::JsonKeyError::NotString(_),
+                    ) => {
+                        evaluated_provider = true;
+                        diagnostics.push(warning(
+                            "r_source_override.value_invalid",
+                            format!(
+                                "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
+                                file.display(),
+                                key
+                            ),
+                            Some(file.clone()),
+                        ));
+                        continue;
+                    }
+                    Err(rversion::JsonKeyError::Parse(_)) => {
+                        evaluated_provider = true;
+                        diagnostics.push(warning(
+                            "r_source_override.value_invalid",
+                            format!(
+                                "Warning: Failed to parse R source override file {}; trying the next R source override.",
+                                file.display()
+                            ),
+                            Some(file.clone()),
+                        ));
+                        continue;
+                    }
+                    Err(error) => {
+                        evaluated_provider = true;
+                        diagnostics.push(warning(
+                            "r_source_override.value_invalid",
+                            format!(
+                                "Warning: Failed to read R version from JSON key '{}' in {}: {error}; trying the next R source override.",
+                                key,
+                                file.display()
+                            ),
+                            Some(file.clone()),
+                        ));
+                        continue;
+                    }
+                }
+            }
         };
 
         let trimmed_version = version.trim().to_owned();
@@ -381,21 +454,24 @@ fn override_provider_name(source: &RSourceOverride) -> &'static str {
         RSourceOverride::Pixi => "pixi",
         RSourceOverride::VersionFile { .. } => "version-file",
         RSourceOverride::TomlKey { .. } => "toml-key",
+        RSourceOverride::JsonKey { .. } => "json-key",
     }
 }
 
 fn override_file(source: &RSourceOverride) -> Option<std::path::PathBuf> {
     match source {
         RSourceOverride::Pixi => None,
-        RSourceOverride::VersionFile { file } | RSourceOverride::TomlKey { file, .. } => {
-            Some(file.clone())
-        }
+        RSourceOverride::VersionFile { file }
+        | RSourceOverride::TomlKey { file, .. }
+        | RSourceOverride::JsonKey { file, .. } => Some(file.clone()),
     }
 }
 
 fn override_key(source: &RSourceOverride) -> Option<String> {
     match source {
-        RSourceOverride::TomlKey { key, .. } => Some(key.clone()),
+        RSourceOverride::TomlKey { key, .. } | RSourceOverride::JsonKey { key, .. } => {
+            Some(key.clone())
+        }
         RSourceOverride::Pixi | RSourceOverride::VersionFile { .. } => None,
     }
 }
@@ -405,6 +481,7 @@ fn override_location(source: &RSourceOverride) -> String {
         RSourceOverride::Pixi => "pixi".to_owned(),
         RSourceOverride::VersionFile { file } => file.display().to_string(),
         RSourceOverride::TomlKey { file, key } => format!("{}:{}", file.display(), key),
+        RSourceOverride::JsonKey { file, key } => format!("{}:{}", file.display(), key),
     }
 }
 
@@ -999,6 +1076,149 @@ mod r_source_override_tests {
     }
 
     #[test]
+    fn json_key_resolution_uses_nested_string_and_reports_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("renv.lock"), r#"{"R":{"Version":"4.4"}}"#).unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::JsonKey {
+                file: "renv.lock".into(),
+                key: "R.Version".to_string(),
+            }],
+            Some(temp.path()),
+            || Ok(()),
+            || Ok(vec![rig_version("4.4.2")]),
+            |selected, versions| {
+                assert_eq!(selected, &semver::Version::new(4, 4, 2));
+                Ok(ResolvedRSource {
+                    status: RSourceStatus::Rig {
+                        version: versions[0].version.clone(),
+                        override_info: None,
+                    },
+                    r_home: Some(PathBuf::from("/tmp/r-home")),
+                })
+            },
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Applied { info, .. } => {
+                assert_eq!(info.provider, "json-key");
+                assert_eq!(info.file, Some(PathBuf::from("renv.lock")));
+                assert_eq!(info.key.as_deref(), Some("R.Version"));
+                assert_eq!(info.requested_version, "4.4");
+            }
+            OverrideResolution::Fallback { .. } => {
+                panic!("the JSON key provider should be applied")
+            }
+        }
+    }
+
+    #[test]
+    fn json_key_missing_value_falls_through_to_next_provider() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("renv.lock"), r#"{"R":{}}"#).unwrap();
+        let second_file = Path::new("fallback.r-version").to_path_buf();
+        std::fs::write(temp.path().join(&second_file), "4.4.2\n").unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[
+                RSourceOverride::JsonKey {
+                    file: "renv.lock".into(),
+                    key: "R.Version".to_string(),
+                },
+                RSourceOverride::VersionFile {
+                    file: second_file.clone(),
+                },
+            ],
+            Some(temp.path()),
+            || Ok(()),
+            || Ok(vec![rig_version("4.4.2")]),
+            |selected, versions| {
+                assert_eq!(selected, &semver::Version::new(4, 4, 2));
+                Ok(ResolvedRSource {
+                    status: RSourceStatus::Rig {
+                        version: versions[0].version.clone(),
+                        override_info: None,
+                    },
+                    r_home: Some(PathBuf::from("/tmp/r-home")),
+                })
+            },
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Applied {
+                info, diagnostics, ..
+            } => {
+                assert_eq!(info.provider, "version-file");
+                assert_eq!(info.file, Some(second_file));
+                assert_eq!(diagnostics.len(), 1);
+                assert!(diagnostics[0].message.contains("renv.lock:R.Version"));
+            }
+            OverrideResolution::Fallback { .. } => {
+                panic!("the fallback provider should be applied")
+            }
+        }
+    }
+
+    #[test]
+    fn json_key_value_errors_fall_through_to_next_provider() {
+        for (name, contents) in [
+            ("missing", r#"{"R":{}}"#),
+            ("non-string", r#"{"R":{"Version":4.4}}"#),
+            ("parse", r#"{"R":{"Version":"4.4"}"#),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            std::fs::write(temp.path().join("renv.lock"), contents).unwrap();
+            std::fs::write(temp.path().join("fallback.r-version"), "4.4.2\n").unwrap();
+
+            let result = setup_r_via_overrides_with(
+                &[
+                    RSourceOverride::JsonKey {
+                        file: "renv.lock".into(),
+                        key: "R.Version".to_string(),
+                    },
+                    RSourceOverride::VersionFile {
+                        file: "fallback.r-version".into(),
+                    },
+                ],
+                Some(temp.path()),
+                || Ok(()),
+                || Ok(vec![rig_version("4.4.2")]),
+                |selected, versions| {
+                    assert_eq!(selected, &semver::Version::new(4, 4, 2));
+                    Ok(ResolvedRSource {
+                        status: RSourceStatus::Rig {
+                            version: versions[0].version.clone(),
+                            override_info: None,
+                        },
+                        r_home: Some(PathBuf::from("/tmp/r-home")),
+                    })
+                },
+            )
+            .unwrap();
+
+            match result {
+                OverrideResolution::Applied {
+                    info, diagnostics, ..
+                } => {
+                    assert_eq!(info.provider, "version-file", "case: {name}");
+                    assert_eq!(diagnostics.len(), 1, "case: {name}");
+                    if name == "parse" {
+                        assert!(diagnostics[0].message.contains("Failed to parse"));
+                    } else {
+                        assert!(diagnostics[0].message.contains("renv.lock:R.Version"));
+                    }
+                }
+                OverrideResolution::Fallback { .. } => {
+                    panic!("the fallback provider should be applied for {name}")
+                }
+            }
+        }
+    }
+
+    #[test]
     fn overlong_version_file_value_is_not_disclosed_in_diagnostic() {
         let temp = tempfile::tempdir().unwrap();
         let marker = "4".repeat(300);
@@ -1063,14 +1283,14 @@ mod r_source_override_tests {
     fn invalid_version_markers_are_not_disclosed_for_file_providers() {
         let marker = "SUPER-SECRET-TOKEN-abc123";
 
-        for provider in ["version-file", "toml-key"] {
+        for provider in ["version-file", "toml-key", "json-key"] {
             let temp = tempfile::tempdir().unwrap();
             let overrides = if provider == "version-file" {
                 std::fs::write(temp.path().join("project.r-version"), marker).unwrap();
                 vec![RSourceOverride::VersionFile {
                     file: "project.r-version".into(),
                 }]
-            } else {
+            } else if provider == "toml-key" {
                 std::fs::write(
                     temp.path().join("rproject.toml"),
                     format!("[project]\nr_version = \"{marker}\"\n"),
@@ -1079,6 +1299,16 @@ mod r_source_override_tests {
                 vec![RSourceOverride::TomlKey {
                     file: "rproject.toml".into(),
                     key: "project.r_version".to_string(),
+                }]
+            } else {
+                std::fs::write(
+                    temp.path().join("renv.lock"),
+                    format!(r#"{{"R":{{"Version":"{marker}"}}}}"#),
+                )
+                .unwrap();
+                vec![RSourceOverride::JsonKey {
+                    file: "renv.lock".into(),
+                    key: "R.Version".to_string(),
                 }]
             };
 
@@ -1141,22 +1371,62 @@ mod r_source_override_tests {
     }
 
     #[test]
+    fn malformed_json_does_not_disclose_file_contents_in_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = "SUPER-SECRET-JSON-CONTENTS";
+        std::fs::write(
+            temp.path().join("renv.lock"),
+            format!(r#"{{"R":{{"Version":"{marker}"}}"#),
+        )
+        .unwrap();
+
+        let result = setup_r_via_overrides_with(
+            &[RSourceOverride::JsonKey {
+                file: "renv.lock".into(),
+                key: "R.Version".to_string(),
+            }],
+            Some(temp.path()),
+            || panic!("rig should not be queried for malformed JSON"),
+            || panic!("installed versions should not be queried for malformed JSON"),
+            |_, _| panic!("version resolution should not be attempted"),
+        )
+        .unwrap();
+
+        match result {
+            OverrideResolution::Fallback { diagnostics } => {
+                let diagnostics = diagnostic_text(&diagnostics);
+                assert!(diagnostics.contains(
+                    "Warning: Failed to parse R source override file renv.lock; trying the next R source override."
+                ));
+                assert!(!diagnostics.contains(marker));
+            }
+            OverrideResolution::Applied { .. } => {
+                panic!("malformed JSON must not be applied")
+            }
+        }
+    }
+
+    #[test]
     fn invalid_override_filenames_are_skipped_with_diagnostics() {
         let invalid_files = ["../x", "sub/x", r"a\b", "/absolute", "C:foo", ".", "..", ""];
 
-        for provider in ["version-file", "toml-key"] {
+        for provider in ["version-file", "toml-key", "json-key"] {
             for invalid_file in invalid_files {
                 let temp = tempfile::tempdir().unwrap();
                 let valid_file = if provider == "version-file" {
                     PathBuf::from("valid.r-version")
-                } else {
+                } else if provider == "toml-key" {
                     PathBuf::from("valid.toml")
+                } else {
+                    PathBuf::from("valid.json")
                 };
                 let valid_path = temp.path().join(&valid_file);
                 if provider == "version-file" {
                     std::fs::write(valid_path, "4.4.2\n").unwrap();
-                } else {
+                } else if provider == "toml-key" {
                     std::fs::write(valid_path, "[project]\nr_version = \"4.4.2\"\n").unwrap();
+                } else {
+                    std::fs::write(valid_path, r#"{"R":{"Version":"4.4.2"}}"#).unwrap();
                 }
 
                 let invalid = PathBuf::from(invalid_file);
@@ -1167,7 +1437,7 @@ mod r_source_override_tests {
                             file: valid_file.clone(),
                         },
                     ]
-                } else {
+                } else if provider == "toml-key" {
                     vec![
                         RSourceOverride::TomlKey {
                             file: invalid,
@@ -1176,6 +1446,17 @@ mod r_source_override_tests {
                         RSourceOverride::TomlKey {
                             file: valid_file.clone(),
                             key: "project.r_version".to_string(),
+                        },
+                    ]
+                } else {
+                    vec![
+                        RSourceOverride::JsonKey {
+                            file: invalid,
+                            key: "R.Version".to_string(),
+                        },
+                        RSourceOverride::JsonKey {
+                            file: valid_file.clone(),
+                            key: "R.Version".to_string(),
                         },
                     ]
                 };

--- a/crates/arf-console/src/app/setup/overrides.rs
+++ b/crates/arf-console/src/app/setup/overrides.rs
@@ -45,6 +45,228 @@ fn resolve_override_path(file: &Path, base_dir: &mut Option<PathBuf>) -> std::io
     Ok(path)
 }
 
+#[derive(Debug, Clone, Copy)]
+enum FileReader<'a> {
+    VersionFile,
+    TomlKey { key: &'a str },
+    JsonKey { key: &'a str },
+}
+
+enum ProviderKind<'a> {
+    Unsupported,
+    File {
+        file: &'a Path,
+        reader: FileReader<'a>,
+    },
+}
+
+/// Borrowed provider metadata used while resolving one configured override.
+///
+/// Keeping this separate from `RSourceOverride` centralizes the metadata and
+/// file-reading behavior without changing the serde-facing configuration enum.
+struct ProviderSpec<'a> {
+    name: &'static str,
+    kind: ProviderKind<'a>,
+}
+
+impl<'a> From<&'a RSourceOverride> for ProviderSpec<'a> {
+    fn from(source: &'a RSourceOverride) -> Self {
+        match source {
+            RSourceOverride::Pixi => Self {
+                name: "pixi",
+                kind: ProviderKind::Unsupported,
+            },
+            RSourceOverride::VersionFile { file } => Self {
+                name: "version-file",
+                kind: ProviderKind::File {
+                    file,
+                    reader: FileReader::VersionFile,
+                },
+            },
+            RSourceOverride::TomlKey { file, key } => Self {
+                name: "toml-key",
+                kind: ProviderKind::File {
+                    file,
+                    reader: FileReader::TomlKey { key },
+                },
+            },
+            RSourceOverride::JsonKey { file, key } => Self {
+                name: "json-key",
+                kind: ProviderKind::File {
+                    file,
+                    reader: FileReader::JsonKey { key },
+                },
+            },
+        }
+    }
+}
+
+impl ProviderSpec<'_> {
+    fn file_path(&self) -> Option<PathBuf> {
+        match &self.kind {
+            ProviderKind::Unsupported => None,
+            ProviderKind::File { file, .. } => Some((*file).to_path_buf()),
+        }
+    }
+
+    fn key(&self) -> Option<&str> {
+        match &self.kind {
+            ProviderKind::Unsupported => None,
+            ProviderKind::File { reader, .. } => match reader {
+                FileReader::VersionFile => None,
+                FileReader::TomlKey { key } | FileReader::JsonKey { key } => Some(key),
+            },
+        }
+    }
+
+    fn location(&self) -> String {
+        match &self.kind {
+            ProviderKind::Unsupported => self.name.to_owned(),
+            ProviderKind::File { file, reader } => match reader {
+                FileReader::VersionFile => file.display().to_string(),
+                FileReader::TomlKey { key } | FileReader::JsonKey { key } => {
+                    format!("{}:{key}", file.display())
+                }
+            },
+        }
+    }
+}
+
+enum ReadOverride {
+    Missing,
+    Value(String),
+    Rejected(RSourceDiagnostic),
+}
+
+/// Read one provider's value and normalize its result for the resolution loop.
+fn read_override(spec: &ProviderSpec<'_>, base_dir: &mut Option<PathBuf>) -> ReadOverride {
+    let ProviderKind::File { file, reader } = &spec.kind else {
+        return ReadOverride::Rejected(warning(
+            "r_source_override.provider_unsupported",
+            format!(
+                "Warning: R source override provider '{}' is not implemented; trying the next R source override.",
+                spec.name
+            ),
+            None,
+        ));
+    };
+    if !is_bare_filename(file) {
+        return ReadOverride::Rejected(invalid_override_file_warning(spec.name, file));
+    }
+
+    let path = match resolve_override_path(file, base_dir) {
+        Ok(path) => path,
+        Err(error) => {
+            return ReadOverride::Rejected(warning(
+                "r_source_override.value_invalid",
+                format!(
+                    "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
+                    file.display()
+                ),
+                Some(file.to_path_buf()),
+            ));
+        }
+    };
+
+    match reader {
+        FileReader::VersionFile => read_version_file_override(file, &path),
+        FileReader::TomlKey { key } => read_toml_key_override(file, &path, key),
+        FileReader::JsonKey { key } => read_json_key_override(file, &path, key),
+    }
+}
+
+fn read_version_file_override(file: &Path, path: &Path) -> ReadOverride {
+    match rversion::read_version_file(path) {
+        Ok(version) => ReadOverride::Value(version),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            log::debug!("R source override file {} is not present", file.display());
+            ReadOverride::Missing
+        }
+        Err(error) => ReadOverride::Rejected(warning(
+            "r_source_override.value_invalid",
+            format!(
+                "Warning: Failed to read R version override file {}: {error}; trying the next R source override.",
+                file.display()
+            ),
+            Some(file.to_path_buf()),
+        )),
+    }
+}
+
+fn read_toml_key_override(file: &Path, path: &Path, key: &str) -> ReadOverride {
+    match rversion::read_toml_key(path, key) {
+        Ok(version) => ReadOverride::Value(version),
+        Err(error) if error.is_not_found() => {
+            log::debug!("R source override file {} is not present", file.display());
+            ReadOverride::Missing
+        }
+        Err(rversion::TomlKeyError::MissingKey(_) | rversion::TomlKeyError::NotString(_)) => {
+            ReadOverride::Rejected(warning(
+                "r_source_override.value_invalid",
+                format!(
+                    "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
+                    file.display(),
+                    key
+                ),
+                Some(file.to_path_buf()),
+            ))
+        }
+        Err(rversion::TomlKeyError::Parse(_)) => ReadOverride::Rejected(warning(
+            "r_source_override.value_invalid",
+            format!(
+                "Warning: Failed to parse R source override file {}; trying the next R source override.",
+                file.display()
+            ),
+            Some(file.to_path_buf()),
+        )),
+        Err(error) => ReadOverride::Rejected(warning(
+            "r_source_override.value_invalid",
+            format!(
+                "Warning: Failed to read R version from TOML key '{key}' in {}: {error}; trying the next R source override.",
+                file.display()
+            ),
+            Some(file.to_path_buf()),
+        )),
+    }
+}
+
+fn read_json_key_override(file: &Path, path: &Path, key: &str) -> ReadOverride {
+    match rversion::read_json_key(path, key) {
+        Ok(version) => ReadOverride::Value(version),
+        Err(error) if error.is_not_found() => {
+            log::debug!("R source override file {} is not present", file.display());
+            ReadOverride::Missing
+        }
+        Err(rversion::JsonKeyError::MissingKey(_) | rversion::JsonKeyError::NotString(_)) => {
+            ReadOverride::Rejected(warning(
+                "r_source_override.value_invalid",
+                format!(
+                    "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
+                    file.display(),
+                    key
+                ),
+                Some(file.to_path_buf()),
+            ))
+        }
+        Err(rversion::JsonKeyError::Parse(_)) => ReadOverride::Rejected(warning(
+            "r_source_override.value_invalid",
+            format!(
+                "Warning: Failed to parse R source override file {}; trying the next R source override.",
+                file.display()
+            ),
+            Some(file.to_path_buf()),
+        )),
+        Err(error) => ReadOverride::Rejected(warning(
+            "r_source_override.value_invalid",
+            format!(
+                "Warning: Failed to read R version from JSON key '{key}' in {}: {error}; trying the next R source override.",
+                file.display()
+            ),
+            Some(file.to_path_buf()),
+        )),
+    }
+}
+
 fn setup_r_via_overrides_with<FAvailable, FList, FResolve>(
     overrides: &[RSourceOverride],
     base_dir: Option<&Path>,
@@ -64,208 +286,17 @@ where
     let mut base_dir = base_dir.map(Path::to_path_buf);
 
     for source in overrides {
-        let provider = override_provider_name(source);
-        let version = match source {
-            RSourceOverride::Pixi => {
+        let provider = ProviderSpec::from(source);
+        let version = match read_override(&provider, &mut base_dir) {
+            ReadOverride::Missing => continue,
+            ReadOverride::Value(version) => {
                 evaluated_provider = true;
-                diagnostics.push(warning(
-                    "r_source_override.provider_unsupported",
-                    format!(
-                        "Warning: R source override provider '{provider}' is not implemented; trying the next R source override."
-                    ),
-                    None,
-                ));
+                version
+            }
+            ReadOverride::Rejected(diagnostic) => {
+                evaluated_provider = true;
+                diagnostics.push(diagnostic);
                 continue;
-            }
-            RSourceOverride::VersionFile { file } => {
-                if !is_bare_filename(file) {
-                    evaluated_provider = true;
-                    diagnostics.push(invalid_override_file_warning(provider, file));
-                    continue;
-                }
-                let path = match resolve_override_path(file, &mut base_dir) {
-                    Ok(path) => path,
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                };
-                match rversion::read_version_file(&path) {
-                    Ok(version) => {
-                        evaluated_provider = true;
-                        version
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        log::debug!("R source override file {} is not present", file.display());
-                        continue;
-                    }
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to read R version override file {}: {error}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                }
-            }
-            RSourceOverride::TomlKey { file, key } => {
-                if !is_bare_filename(file) {
-                    evaluated_provider = true;
-                    diagnostics.push(invalid_override_file_warning(provider, file));
-                    continue;
-                }
-                let path = match resolve_override_path(file, &mut base_dir) {
-                    Ok(path) => path,
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                };
-                match rversion::read_toml_key(&path, key) {
-                    Ok(version) => {
-                        evaluated_provider = true;
-                        version
-                    }
-                    Err(error) if error.is_not_found() => {
-                        log::debug!("R source override file {} is not present", file.display());
-                        continue;
-                    }
-                    Err(
-                        rversion::TomlKeyError::MissingKey(_)
-                        | rversion::TomlKeyError::NotString(_),
-                    ) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
-                                file.display(),
-                                key
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                    Err(rversion::TomlKeyError::Parse(_)) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to parse R source override file {}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to read R version from TOML key '{}' in {}: {error}; trying the next R source override.",
-                                key,
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                }
-            }
-            RSourceOverride::JsonKey { file, key } => {
-                if !is_bare_filename(file) {
-                    evaluated_provider = true;
-                    diagnostics.push(invalid_override_file_warning(provider, file));
-                    continue;
-                }
-                let path = match resolve_override_path(file, &mut base_dir) {
-                    Ok(path) => path,
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to determine the current directory for R source override file {}: {error}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                };
-                match rversion::read_json_key(&path, key) {
-                    Ok(version) => {
-                        evaluated_provider = true;
-                        version
-                    }
-                    Err(error) if error.is_not_found() => {
-                        log::debug!("R source override file {} is not present", file.display());
-                        continue;
-                    }
-                    Err(
-                        rversion::JsonKeyError::MissingKey(_)
-                        | rversion::JsonKeyError::NotString(_),
-                    ) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: {}:{} does not contain the configured R version key; trying the next R source override.",
-                                file.display(),
-                                key
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                    Err(rversion::JsonKeyError::Parse(_)) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to parse R source override file {}; trying the next R source override.",
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                    Err(error) => {
-                        evaluated_provider = true;
-                        diagnostics.push(warning(
-                            "r_source_override.value_invalid",
-                            format!(
-                                "Warning: Failed to read R version from JSON key '{}' in {}: {error}; trying the next R source override.",
-                                key,
-                                file.display()
-                            ),
-                            Some(file.clone()),
-                        ));
-                        continue;
-                    }
-                }
             }
         };
 
@@ -277,9 +308,9 @@ where
                     "r_source_override.value_invalid",
                     format!(
                         "Warning: {} contains an empty R version specification; trying the next R source override.",
-                        override_location(source)
+                        provider.location()
                     ),
-                    override_file(source),
+                    provider.file_path(),
                 ));
                 continue;
             }
@@ -288,9 +319,9 @@ where
                     "r_source_override.value_invalid",
                     format!(
                         "Warning: {} contains an R version specification that could not be parsed; trying the next R source override.",
-                        override_location(source)
+                        provider.location()
                     ),
-                    override_file(source),
+                    provider.file_path(),
                 ));
                 continue;
             }
@@ -301,9 +332,9 @@ where
                 "r_source_override.provider_unsupported",
                 format!(
                     "Warning: R version \"{name}\" from {} is unsupported in the R source override path; trying the next R source override.",
-                    override_location(source)
+                    provider.location()
                 ),
-                override_file(source),
+                provider.file_path(),
             ));
             continue;
         }
@@ -324,9 +355,9 @@ where
                         "r_source_override.fallback",
                         format!(
                             "Warning: Could not inspect installed R versions for {}: {error}; falling back to startup.r_source.",
-                            override_location(source)
+                            provider.location()
                         ),
-                        override_file(source),
+                        provider.file_path(),
                     ));
                     return Some(OverrideResolution::Fallback { diagnostics });
                 }
@@ -339,11 +370,11 @@ where
 
         let Some(selected) = rversion::resolve_version(&spec, &installed_versions) else {
             diagnostics.push(not_installed_warning(
-                provider,
-                &override_location(source),
+                provider.name,
+                &provider.location(),
                 &trimmed_version,
                 &spec,
-                override_file(source),
+                provider.file_path(),
             ));
             continue;
         };
@@ -354,9 +385,9 @@ where
                 r_home,
             }) => {
                 let info = RSourceOverrideInfo {
-                    provider: provider.to_owned(),
-                    file: override_file(source),
-                    key: override_key(source),
+                    provider: provider.name.to_owned(),
+                    file: provider.file_path(),
+                    key: provider.key().map(str::to_owned),
                     requested_version: trimmed_version,
                     resolved_version: version.clone(),
                 };
@@ -364,7 +395,7 @@ where
                     diagnostics.push(warning(
                         "r_source_override.fallback",
                         "Warning: R source override resolved without an R_HOME; falling back to startup.r_source.",
-                        override_file(source),
+                        provider.file_path(),
                     ));
                     return Some(OverrideResolution::Fallback { diagnostics });
                 };
@@ -384,9 +415,9 @@ where
                     "r_source_override.provider_unsupported",
                     format!(
                         "Warning: R source override {} resolved to an unsupported R source status ({status:?}); falling back to startup.r_source.",
-                        override_location(source)
+                        provider.location()
                     ),
-                    override_file(source),
+                    provider.file_path(),
                 ));
                 return Some(OverrideResolution::Fallback { diagnostics });
             }
@@ -396,9 +427,9 @@ where
                     format!(
                         "Warning: Failed to use R version \"{}\" from {}: {error}; trying the next R source override.",
                         trimmed_version,
-                        override_location(source)
+                        provider.location()
                     ),
-                    override_file(source),
+                    provider.file_path(),
                 ));
                 continue;
             }
@@ -447,42 +478,6 @@ pub(super) fn script_override_notice(resolution: &RSourceResolutionReport) -> Op
     resolution
         .override_info()
         .map(|info| format!("# R source override: {}", info.display()))
-}
-
-fn override_provider_name(source: &RSourceOverride) -> &'static str {
-    match source {
-        RSourceOverride::Pixi => "pixi",
-        RSourceOverride::VersionFile { .. } => "version-file",
-        RSourceOverride::TomlKey { .. } => "toml-key",
-        RSourceOverride::JsonKey { .. } => "json-key",
-    }
-}
-
-fn override_file(source: &RSourceOverride) -> Option<std::path::PathBuf> {
-    match source {
-        RSourceOverride::Pixi => None,
-        RSourceOverride::VersionFile { file }
-        | RSourceOverride::TomlKey { file, .. }
-        | RSourceOverride::JsonKey { file, .. } => Some(file.clone()),
-    }
-}
-
-fn override_key(source: &RSourceOverride) -> Option<String> {
-    match source {
-        RSourceOverride::TomlKey { key, .. } | RSourceOverride::JsonKey { key, .. } => {
-            Some(key.clone())
-        }
-        RSourceOverride::Pixi | RSourceOverride::VersionFile { .. } => None,
-    }
-}
-
-fn override_location(source: &RSourceOverride) -> String {
-    match source {
-        RSourceOverride::Pixi => "pixi".to_owned(),
-        RSourceOverride::VersionFile { file } => file.display().to_string(),
-        RSourceOverride::TomlKey { file, key } => format!("{}:{}", file.display(), key),
-        RSourceOverride::JsonKey { file, key } => format!("{}:{}", file.display(), key),
-    }
 }
 
 fn rig_unavailable_warning(error: &external::rig::RigError) -> RSourceDiagnostic {

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -16,6 +16,8 @@ pub enum RSourceOverride {
     VersionFile { file: PathBuf },
     /// Read the R version from a TOML key.
     TomlKey { file: PathBuf, key: String },
+    /// Read the R version from a JSON key.
+    JsonKey { file: PathBuf, key: String },
 }
 
 /// Experimental features configuration.
@@ -519,6 +521,7 @@ shell_semicolon_shortcut = true
 [experimental]
 r_source_overrides = [
   { type = "toml-key", file = "rproject.toml", key = "project.r_version" },
+  { type = "json-key", file = "renv.lock", key = "R.Version" },
   { type = "version-file", file = ".r-version" },
   { type = "pixi" },
 ]
@@ -532,10 +535,15 @@ r_source_overrides = [
         ));
         assert!(matches!(
             &config.experimental.r_source_overrides[1],
+            RSourceOverride::JsonKey { file, key }
+                if file == &PathBuf::from("renv.lock") && key == "R.Version"
+        ));
+        assert!(matches!(
+            &config.experimental.r_source_overrides[2],
             RSourceOverride::VersionFile { file } if file == &PathBuf::from(".r-version")
         ));
         assert!(matches!(
-            config.experimental.r_source_overrides[2],
+            config.experimental.r_source_overrides[3],
             RSourceOverride::Pixi
         ));
     }

--- a/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
+++ b/crates/arf-console/src/config/snapshots/arf__config__tests__schema_tests__config_schema.snap
@@ -1963,6 +1963,27 @@ expression: schema
             "file",
             "key"
           ]
+        },
+        {
+          "description": "Read the R version from a JSON key.",
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "json-key"
+            }
+          },
+          "required": [
+            "type",
+            "file",
+            "key"
+          ]
         }
       ]
     },

--- a/crates/arf-console/src/config/startup.rs
+++ b/crates/arf-console/src/config/startup.rs
@@ -92,7 +92,7 @@ pub struct RSourceOverrideInfo {
     pub provider: String,
     /// The file read by the provider, if any.
     pub file: Option<PathBuf>,
-    /// The TOML key read by the provider, if any.
+    /// The key read by the provider, if any.
     pub key: Option<String>,
     /// The version specification read from the provider.
     pub requested_version: String,

--- a/crates/arf-console/src/rversion/mod.rs
+++ b/crates/arf-console/src/rversion/mod.rs
@@ -43,6 +43,47 @@ pub enum TomlKeyError {
     NotString(String),
 }
 
+/// An error returned when reading an R version from a JSON key.
+#[derive(Debug)]
+pub enum JsonKeyError {
+    /// The JSON file could not be read.
+    Read(io::Error),
+    /// The JSON document could not be parsed.
+    Parse(serde_json::Error),
+    /// The requested key path does not exist.
+    MissingKey(String),
+    /// The requested key does not contain a string.
+    NotString(String),
+}
+
+impl fmt::Display for JsonKeyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read(error) => write!(formatter, "failed to read JSON file: {error}"),
+            Self::Parse(_) => formatter.write_str("failed to parse JSON"),
+            Self::MissingKey(key) => write!(formatter, "JSON key not found: {key}"),
+            Self::NotString(key) => write!(formatter, "JSON key is not a string: {key}"),
+        }
+    }
+}
+
+impl std::error::Error for JsonKeyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read(error) => Some(error),
+            Self::Parse(error) => Some(error),
+            Self::MissingKey(_) | Self::NotString(_) => None,
+        }
+    }
+}
+
+impl JsonKeyError {
+    /// Return whether this error means that the configured file is absent.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::Read(error) if error.kind() == io::ErrorKind::NotFound)
+    }
+}
+
 impl fmt::Display for TomlKeyError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -134,6 +175,29 @@ pub fn read_toml_key(path: &Path, key: &str) -> Result<String, TomlKeyError> {
         .as_str()
         .map(|version| version.trim().to_owned())
         .ok_or_else(|| TomlKeyError::NotString(key.to_owned()))
+}
+
+/// Read a string value from a dot-separated key path in a JSON file.
+pub fn read_json_key(path: &Path, key: &str) -> Result<String, JsonKeyError> {
+    let contents = fs::read_to_string(path).map_err(JsonKeyError::Read)?;
+    let document =
+        serde_json::from_str::<serde_json::Value>(&contents).map_err(JsonKeyError::Parse)?;
+
+    let mut value = &document;
+    for component in key.split('.') {
+        if component.is_empty() {
+            return Err(JsonKeyError::MissingKey(key.to_owned()));
+        }
+        value = value
+            .as_object()
+            .and_then(|object| object.get(component))
+            .ok_or_else(|| JsonKeyError::MissingKey(key.to_owned()))?;
+    }
+
+    value
+        .as_str()
+        .map(|version| version.trim().to_owned())
+        .ok_or_else(|| JsonKeyError::NotString(key.to_owned()))
 }
 
 impl fmt::Display for VersionSpecParseError {
@@ -515,6 +579,79 @@ mod tests {
         assert!(matches!(
             read_toml_key(file.path(), "project.r_version"),
             Err(TomlKeyError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn json_key_reads_nested_string() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"R":{"Version":"4.4"}}"#).unwrap();
+
+        assert_eq!(read_json_key(file.path(), "R.Version").unwrap(), "4.4");
+    }
+
+    #[test]
+    fn json_key_reports_missing_key() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"R":{"Platform":"x86_64"}}"#).unwrap();
+
+        assert!(matches!(
+            read_json_key(file.path(), "R.Version"),
+            Err(JsonKeyError::MissingKey(_))
+        ));
+    }
+
+    #[test]
+    fn json_key_reports_non_string_value() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"R":{"Version":4.4}}"#).unwrap();
+
+        assert!(matches!(
+            read_json_key(file.path(), "R.Version"),
+            Err(JsonKeyError::NotString(_))
+        ));
+    }
+
+    #[test]
+    fn json_key_reports_parse_errors_without_disclosing_contents() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let contents = r#"{"private":"SUPER-SECRET-JSON-CONTENTS""#;
+        std::fs::write(file.path(), contents).unwrap();
+
+        let error = read_json_key(file.path(), "R.Version").unwrap_err();
+        assert!(matches!(&error, JsonKeyError::Parse(_)));
+        assert_eq!(error.to_string(), "failed to parse JSON");
+        assert!(!error.to_string().contains("SUPER-SECRET-JSON-CONTENTS"));
+    }
+
+    #[test]
+    fn json_key_reports_read_errors_and_not_found() {
+        let path = Path::new("file-that-does-not-exist.json");
+
+        let error = read_json_key(path, "R.Version").unwrap_err();
+        assert!(error.is_not_found());
+        assert!(matches!(error, JsonKeyError::Read(_)));
+    }
+
+    #[test]
+    fn json_key_empty_component_is_missing_key() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"R":{"Version":"4.4"}}"#).unwrap();
+
+        assert!(matches!(
+            read_json_key(file.path(), "R..Version"),
+            Err(JsonKeyError::MissingKey(_))
+        ));
+    }
+
+    #[test]
+    fn json_key_does_not_support_array_indexes() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"R":[{"Version":"4.4"}]}"#).unwrap();
+
+        assert!(matches!(
+            read_json_key(file.path(), "R.0.Version"),
+            Err(JsonKeyError::MissingKey(_))
         ));
     }
 }

--- a/crates/arf-console/tests/resolve_tests.rs
+++ b/crates/arf-console/tests/resolve_tests.rs
@@ -368,6 +368,53 @@ r_version = "4.4.2"
 
 #[test]
 #[cfg(unix)]
+fn resolve_project_file_version_request_reports_json_source() {
+    let temp = write_uninstalled_project_override_fixture();
+    std::fs::write(
+        temp.path().join("arf.toml"),
+        r#"[experimental]
+r_source_overrides = [
+  { type = "json-key", file = "renv.lock", key = "R.Version" },
+]
+
+[startup]
+r_source = { path = "fallback-r-home" }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("renv.lock"),
+        r#"{"R":{"Version":"4.4.2"}}"#,
+    )
+    .unwrap();
+    let environment = FakeRigEnvironment::new();
+
+    let output = environment
+        .command()
+        .args(["r", "resolve", "--config", "arf.toml"])
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["selected_by"]["kind"], "version_request");
+    assert_selected_by_nullable_fields_are_present(&value);
+    assert!(value["selected_by"]["requested_r_home"].is_null());
+    assert_eq!(value["selected_by"]["requested_version"], "4.4.2");
+    assert_eq!(value["selected_by"]["source"]["kind"], "project_file");
+    assert!(value["selected_by"]["source"]["name"].is_null());
+    assert_descriptor_path(&value, &value["selected_by"]["source"]["path"], "renv.lock");
+    assert_eq!(value["selected_by"]["source"]["format"], "json");
+    assert_eq!(value["selected_by"]["source"]["key"], "R.Version");
+    insta::assert_snapshot!(
+        "resolve_project_file_version_request_reports_json_source",
+        normalize_descriptor(&value)
+    );
+}
+
+#[test]
+#[cfg(unix)]
 fn resolve_project_file_version_request_reports_text_source() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_json_source.snap
+++ b/crates/arf-console/tests/snapshots/resolve_tests__resolve_project_file_version_request_reports_json_source.snap
@@ -1,0 +1,32 @@
+---
+source: crates/arf-console/tests/resolve_tests.rs
+expression: normalize_descriptor(&value)
+---
+{
+  "cwd": "<cwd>",
+  "diagnostics": [],
+  "provider": "rig",
+  "resolved": true,
+  "resolver": {
+    "name": "arf",
+    "version": "<arf-version>"
+  },
+  "schema_version": 1,
+  "selected_by": {
+    "kind": "version_request",
+    "requested_r_home": null,
+    "requested_version": "4.4.2",
+    "source": {
+      "format": "json",
+      "key": "R.Version",
+      "kind": "project_file",
+      "name": null,
+      "path": "<source-path>"
+    }
+  },
+  "target": {
+    "r_binary": null,
+    "r_home": "<r-home>",
+    "resolved_version": "4.4.2"
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -843,7 +843,7 @@ Abbreviations are matched against the word immediately to the left of the cursor
 Automatically select an installed R version from project tooling. This feature is fully opt-in: `r_source_overrides` defaults to an empty array. If it is unset or empty, arf falls back entirely to `startup.r_source`, exactly as before.
 
 > [!IMPORTANT]
-> A version read from a file is only ever matched against the R installations that rig knows about — arf takes the candidate list from `rig list --json`. **The `version-file` and `toml-key` providers therefore require rig**, and can only select an R version that rig has already installed. Without rig, or when no installed version matches, arf warns and falls back to `startup.r_source` rather than failing to start.
+> A version read from a file is only ever matched against the R installations that rig knows about — arf takes the candidate list from `rig list --json`. **The `version-file`, `toml-key`, and `json-key` providers therefore require rig**, and can only select an R version that rig has already installed. Without rig, or when no installed version matches, arf warns and falls back to `startup.r_source` rather than failing to start.
 
 Override files are resolved as `<current directory>/<file>`. `file` must be a bare filename: it cannot be empty, `.`, `..`, contain subdirectories, or be an absolute path. arf does **not** walk up parent directories, even though the tools that write these files often do.
 
@@ -858,6 +858,7 @@ Entries are evaluated in array order, which is the priority order. The first ent
 | `r_source_overrides` | `[]` (disabled) | Ordered list of R source providers. |
 | `type = "version-file"` | — | Reads the first non-empty line as the version specification from the `file` field. |
 | `type = "toml-key"` | — | Reads a string version specification from the dot-separated TOML key in the `file` and `key` fields. |
+| `type = "json-key"` | — | Reads a string version specification from the dot-separated JSON key in the `file` and `key` fields. |
 | `type = "pixi"` | — | Uses the active pixi environment. This provider is not implemented yet and has no additional fields. |
 
 For example, [rv](https://a2-ai.github.io/rv-docs/) stores its R version in `rproject.toml`. This configuration reads the `project.r_version` string and tries to select the matching installed R version:
@@ -896,7 +897,27 @@ r_version = "4.4"
 
 With `key = "project.r_version"`, arf looks up the `project` table and reads its `r_version` field. The value must be a TOML string; any other type is treated as an error.
 
-**Version strings read by `version-file` and `toml-key` use the version specifications above.** These providers accept exact or partial numbers and ranges, and select the newest installed version that matches. `devel` and `release` are recognised names, but named selectors are not supported by the R source override path.
+`json-key` parses `file` as JSON and follows `key` as a dot-separated path through its objects. For example, an `renv.lock` file contains the recorded R version near its top level:
+
+```json
+{
+  "R": {
+    "Version": "4.4.1",
+    "Repositories": []
+  }
+}
+```
+
+With `key = "R.Version"`, arf reads the string under `R.Version`. The value must be a JSON string; arrays, array indexes, and escaped literal dots are not supported. This provider is fully opt-in; arf does not detect `renv.lock` automatically. A recorded `R.Version` is the version captured at the time of the snapshot, so updating the lockfile can change which R arf selects. Use this configuration only when that behavior is desired (and, when appropriate, use `renv::settings$r.version("4.4.1")` to intentionally control the recorded value):
+
+```toml
+[experimental]
+r_source_overrides = [
+  { type = "json-key", file = "renv.lock", key = "R.Version" },
+]
+```
+
+**Version strings read by `version-file`, `toml-key`, and `json-key` use the version specifications above.** These providers accept exact or partial numbers and ranges, and select the newest installed version that matches. `devel` and `release` are recognised names, but named selectors are not supported by the R source override path.
 
 **Who performs the matching:** arf runs rig only to check that it is there (`rig --version`) and to list what is installed (`rig list --json`). It then matches the specification against that list itself and asks the selected installation's R binary for its `R_HOME`. rig never sees the specification, so it is arf that decides what `4.4` means.
 


### PR DESCRIPTION
## Summary

- add a generic `json-key` R source override provider with the same fallback and diagnostic behavior as `toml-key`
- read string versions from dot-separated JSON object paths while keeping raw parse input out of diagnostics
- document the explicit opt-in configuration for reading `R.Version` from `renv.lock`, including its snapshot semantics
- update the configuration schema and `arf r resolve` source metadata
- separate provider metadata, file reading, and common version resolution so adding providers does not grow the main resolution loop

## Design

- keep `RSourceOverride` as the serde/schemars tagged enum
- normalize provider reads as missing, resolved values, or rejected diagnostics
- encode unsupported and file-backed providers with typed reader variants, so invalid file/key combinations are not representable
- preserve provider priority, fallback behavior, diagnostic wording, parse-input redaction, and lazy rig caching

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --all-features --workspace --locked`

Closes #321
