### PR TITLE
fix: preserve IPC PID ownership across restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).
+- **Experimental:** IPC PID file ownership and handoff now preserve tracking across interactive `:restart` and `:switch`; relative paths and loader re-exec are preserved across the replacement (#342).
 
 ## [0.5.0] - 2026-08-19
 

--- a/crates/arf-console/src/app/headless.rs
+++ b/crates/arf-console/src/app/headless.rs
@@ -143,6 +143,11 @@ pub(crate) fn run_headless(
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    if let Some(path) = pid_file {
+        // Resolve before R startup can change the working directory.
+        crate::pid_file::set_initial_pid_file_path(path);
+    }
+
     // --json implies --quiet: suppress status messages on stderr since
     // all relevant info is in the JSON output on stdout.
     let quiet = quiet || json;

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -545,6 +545,7 @@ fn run() -> Result<()> {
 }
 
 /// Resolve a CLI bind path while the process still has its original cwd.
+#[cfg(unix)]
 fn absolute_ipc_bind_path(path: &OsStr) -> OsString {
     let path = PathBuf::from(path);
     if is_effective_ipc_bind_path(&path) {
@@ -554,11 +555,8 @@ fn absolute_ipc_bind_path(path: &OsStr) -> OsString {
     }
 }
 
+#[cfg(unix)]
 fn is_effective_ipc_bind_path(path: &std::path::Path) -> bool {
-    #[cfg(windows)]
-    if path.as_os_str().to_string_lossy().starts_with(r"\\.\pipe\") {
-        return true;
-    }
     path.is_absolute()
 }
 

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -73,8 +73,15 @@ const STARTUP_ENV_VARS: &[&str] = &[
 /// be set directly.
 const STARTUP_ENV_CARRIER: &str = "_ARF_INTERNAL_STARTUP_ENV";
 const STARTUP_ENV_CARRIER_VERSION: u32 = 1;
+/// Carries the effective IPC bind path through a restart or loader re-exec.
+///
+/// The value is consumed during startup before R is initialized, so it cannot
+/// leak into R or a child process. It is an OsString because Unix paths are not
+/// required to be valid UTF-8.
+pub(crate) const IPC_BIND_CARRIER: &str = "_ARF_INTERNAL_IPC_BIND";
 
 static STARTUP_ENV: OnceLock<HashMap<String, OsString>> = OnceLock::new();
+static IPC_BIND_PATH: OnceLock<Option<OsString>> = OnceLock::new();
 
 fn main() -> ExitCode {
     match run() {
@@ -92,6 +99,7 @@ fn main() -> ExitCode {
 
 fn run() -> Result<()> {
     capture_startup_env();
+    let carried_ipc_bind = capture_ipc_bind_carrier();
 
     // Parse command-line arguments first, then initialize the logger exactly
     // once based on the parsed command. This avoids the fragile pre-parse
@@ -100,6 +108,11 @@ fn run() -> Result<()> {
     let matches = command.clone().get_matches();
     validate_top_level_scope(&command, &matches);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    // Resolve this before R initialization: profiles may change cwd, but a
+    // relative IPC bind path must continue to identify its initial endpoint.
+    let effective_ipc_bind =
+        effective_ipc_bind_path(cli.ipc_bind.as_deref().map(OsStr::new), carried_ipc_bind);
+    let _ = IPC_BIND_PATH.set(effective_ipc_bind);
     if let Some(path) = cli.ipc_pid_file.as_deref() {
         // Resolve this before R initialization: profiles may change cwd, but
         // a relative PID path must continue to identify its initial file.
@@ -351,6 +364,11 @@ fn run() -> Result<()> {
         // threads are spawned and before R is initialized, so mutating the
         // process environment here cannot race with a concurrent read.
         unsafe { std::env::set_var(STARTUP_ENV_CARRIER, startup_env_carrier()) };
+        if let Some(path) = ipc_bind_path() {
+            // Forward the fixed bind path through this possible loader
+            // re-exec. The replacement consumes it before R initialization.
+            unsafe { std::env::set_var(IPC_BIND_CARRIER, path) };
+        }
         if let Some((path, pid)) = pid_file::restart_context_carrier() {
             // Forward the restart ownership context through this possible
             // loader re-exec. capture_startup_env removes it in the image
@@ -378,6 +396,7 @@ fn run() -> Result<()> {
         unsafe {
             std::env::remove_var(pid_file::RESTART_PID_PATH_ENV);
             std::env::remove_var(pid_file::RESTART_PID_ENV);
+            std::env::remove_var(IPC_BIND_CARRIER);
         }
     }
     #[cfg(not(unix))]
@@ -479,8 +498,17 @@ fn run() -> Result<()> {
     // server advertises a session ID only after the R runtime is confirmed
     // available. The REPL later attaches those same owners to its editors.
     if cli.with_ipc {
+        let ipc_bind = ipc_bind_path()
+            .map(|path| {
+                path.into_string().map_err(|_| {
+                    anyhow::anyhow!(
+                        "IPC bind path is not valid UTF-8 and cannot be advertised by the IPC protocol"
+                    )
+                })
+            })
+            .transpose()?;
         match ipc::start_server(
-            cli.ipc_bind.as_deref(),
+            ipc_bind.as_deref(),
             repl.r_home_for_ipc(),
             None,
             repl.history_session_id_raw(),
@@ -516,6 +544,61 @@ fn run() -> Result<()> {
     }
 
     repl_result
+}
+
+/// Consume the bind-path carrier before R or any child process can observe it.
+/// Invalid carriers are ignored; the command-line path is then used normally.
+fn capture_ipc_bind_carrier() -> Option<OsString> {
+    // SAFETY: run() calls this during single-threaded process initialization,
+    // before R or any child process is started.
+    let value = unsafe {
+        let value = std::env::var_os(IPC_BIND_CARRIER);
+        std::env::remove_var(IPC_BIND_CARRIER);
+        value
+    }?;
+    let path = PathBuf::from(value);
+    if is_effective_ipc_bind_path(&path) {
+        Some(path.into_os_string())
+    } else {
+        None
+    }
+}
+
+/// Resolve a CLI bind path while the process still has its original cwd.
+fn absolute_ipc_bind_path(path: &OsStr) -> OsString {
+    let path = PathBuf::from(path);
+    if is_effective_ipc_bind_path(&path) {
+        path.into_os_string()
+    } else {
+        std::path::absolute(&path).unwrap_or(path).into_os_string()
+    }
+}
+
+/// Select the startup bind path only when the command line requested IPC
+/// binding. This prevents an untrusted or stale carrier from enabling a
+/// custom endpoint during an otherwise ordinary startup.
+fn effective_ipc_bind_path(
+    cli_path: Option<&OsStr>,
+    carried_path: Option<OsString>,
+) -> Option<OsString> {
+    cli_path.map(|path| {
+        carried_path
+            .filter(|path| is_effective_ipc_bind_path(std::path::Path::new(path)))
+            .unwrap_or_else(|| absolute_ipc_bind_path(path))
+    })
+}
+
+fn is_effective_ipc_bind_path(path: &std::path::Path) -> bool {
+    #[cfg(windows)]
+    if path.as_os_str().to_string_lossy().starts_with(r"\\.\pipe\") {
+        return true;
+    }
+    path.is_absolute()
+}
+
+/// Return the bind path fixed at process startup, if one was configured.
+pub(crate) fn ipc_bind_path() -> Option<OsString> {
+    IPC_BIND_PATH.get().cloned().flatten()
 }
 
 /// Read the startup environment snapshot before R initialization can add any
@@ -857,7 +940,7 @@ fn is_history_option_allowed(path: &[String], long: &str) -> bool {
 mod tests {
     use super::{
         STARTUP_ENV_CARRIER_VERSION, absolutize_runtime_r_home, deserialize_startup_env,
-        serialize_startup_env,
+        effective_ipc_bind_path, serialize_startup_env,
     };
     use std::collections::HashMap;
     use std::ffi::OsString;
@@ -892,6 +975,23 @@ mod tests {
             absolutize_runtime_r_home(PathBuf::from("lib/R"), None),
             None
         );
+    }
+
+    #[test]
+    fn ipc_bind_carrier_cannot_enable_binding_without_cli_option() {
+        let carried = Some(PathBuf::from("/tmp/carried.sock").into_os_string());
+        assert_eq!(effective_ipc_bind_path(None, carried), None);
+    }
+
+    #[test]
+    fn invalid_ipc_bind_carrier_falls_back_to_cli_path() {
+        let carried = Some(PathBuf::from("relative/carried.sock").into_os_string());
+        let effective = effective_ipc_bind_path(
+            Some(OsString::from("relative/cli.sock").as_os_str()),
+            carried,
+        )
+        .expect("CLI bind path should be selected");
+        assert!(PathBuf::from(effective).is_absolute());
     }
 
     #[test]

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -73,15 +73,8 @@ const STARTUP_ENV_VARS: &[&str] = &[
 /// be set directly.
 const STARTUP_ENV_CARRIER: &str = "_ARF_INTERNAL_STARTUP_ENV";
 const STARTUP_ENV_CARRIER_VERSION: u32 = 1;
-/// Carries the effective IPC bind path through a restart or loader re-exec.
-///
-/// The value is consumed during startup before R is initialized, so it cannot
-/// leak into R or a child process. It is an OsString because Unix paths are not
-/// required to be valid UTF-8.
-pub(crate) const IPC_BIND_CARRIER: &str = "_ARF_INTERNAL_IPC_BIND";
-
 static STARTUP_ENV: OnceLock<HashMap<String, OsString>> = OnceLock::new();
-static IPC_BIND_PATH: OnceLock<Option<OsString>> = OnceLock::new();
+static NORMALIZED_ARGS: OnceLock<Vec<OsString>> = OnceLock::new();
 
 fn main() -> ExitCode {
     match run() {
@@ -99,7 +92,6 @@ fn main() -> ExitCode {
 
 fn run() -> Result<()> {
     capture_startup_env();
-    let carried_ipc_bind = capture_ipc_bind_carrier();
 
     // Parse command-line arguments first, then initialize the logger exactly
     // once based on the parsed command. This avoids the fragile pre-parse
@@ -108,16 +100,32 @@ fn run() -> Result<()> {
     let matches = command.clone().get_matches();
     validate_top_level_scope(&command, &matches);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
-    // Resolve this before R initialization: profiles may change cwd, but a
-    // relative IPC bind path must continue to identify its initial endpoint.
-    let effective_ipc_bind =
-        effective_ipc_bind_path(cli.ipc_bind.as_deref().map(OsStr::new), carried_ipc_bind);
-    let _ = IPC_BIND_PATH.set(effective_ipc_bind);
     if let Some(path) = cli.ipc_pid_file.as_deref() {
         // Resolve this before R initialization: profiles may change cwd, but
         // a relative PID path must continue to identify its initial file.
         pid_file::set_initial_pid_file_path(path);
+        #[cfg(unix)]
+        pid_file::authorize_inherited_pid_fd(&pid_file::absolute_pid_file_path(path));
     }
+    let bind_path = cli.ipc_bind.as_deref().map(|path| {
+        #[cfg(unix)]
+        {
+            absolute_ipc_bind_path(OsStr::new(path))
+        }
+        #[cfg(not(unix))]
+        {
+            OsString::from(path)
+        }
+    });
+    let pid_path = cli
+        .ipc_pid_file
+        .as_deref()
+        .map(|path| pid_file::absolute_pid_file_path(path).into_os_string());
+    let _ = NORMALIZED_ARGS.set(normalize_interactive_args(
+        std::env::args_os().skip(1).collect(),
+        bind_path.as_deref(),
+        pid_path.as_deref(),
+    ));
     let no_r_auto_discovery = match &cli.command {
         Some(Commands::Headless(args)) => args.r_source.no_r_auto_discovery,
         Some(Commands::R(args)) => {
@@ -364,21 +372,13 @@ fn run() -> Result<()> {
         // threads are spawned and before R is initialized, so mutating the
         // process environment here cannot race with a concurrent read.
         unsafe { std::env::set_var(STARTUP_ENV_CARRIER, startup_env_carrier()) };
-        if let Some(path) = ipc_bind_path() {
-            // Forward the fixed bind path through this possible loader
-            // re-exec. The replacement consumes it before R initialization.
-            unsafe { std::env::set_var(IPC_BIND_CARRIER, path) };
+        if let Some(fd) = pid_file::restart_fd_carrier() {
+            // The descriptor itself is the only PID handoff capability. Keep
+            // its number in the environment solely across this loader exec.
+            unsafe { std::env::set_var(pid_file::RESTART_PID_FD_ENV, fd) };
         }
-        if let Some((path, pid)) = pid_file::restart_context_carrier() {
-            // Forward the restart ownership context through this possible
-            // loader re-exec. capture_startup_env removes it in the image
-            // that finally starts R.
-            unsafe {
-                std::env::set_var(pid_file::RESTART_PID_PATH_ENV, path);
-                std::env::set_var(pid_file::RESTART_PID_ENV, pid);
-            }
-        }
-        if let Err(e) = arf_libr::ensure_ld_library_path_with_pre_exec(
+        if let Err(e) = arf_libr::ensure_ld_library_path_with_pre_exec_and_args(
+            &normalized_args(),
             console_mode::restore_original_input_mode,
         ) {
             log::warn!("Could not set LD_LIBRARY_PATH: {}", e);
@@ -393,11 +393,8 @@ fn run() -> Result<()> {
         //
         // SAFETY: same single-threaded, pre-R-init context as above.
         unsafe { std::env::remove_var(STARTUP_ENV_CARRIER) };
-        unsafe {
-            std::env::remove_var(pid_file::RESTART_PID_PATH_ENV);
-            std::env::remove_var(pid_file::RESTART_PID_ENV);
-            std::env::remove_var(IPC_BIND_CARRIER);
-        }
+        unsafe { std::env::remove_var(pid_file::RESTART_PID_FD_ENV) };
+        pid_file::finish_loader_reexec();
     }
     #[cfg(not(unix))]
     if let Err(e) = arf_libr::ensure_ld_library_path() {
@@ -498,9 +495,10 @@ fn run() -> Result<()> {
     // server advertises a session ID only after the R runtime is confirmed
     // available. The REPL later attaches those same owners to its editors.
     if cli.with_ipc {
-        let ipc_bind = ipc_bind_path()
+        let ipc_bind = bind_path
+            .as_deref()
             .map(|path| {
-                path.into_string().map_err(|_| {
+                path.to_str().ok_or_else(|| {
                     anyhow::anyhow!(
                         "IPC bind path is not valid UTF-8 and cannot be advertised by the IPC protocol"
                     )
@@ -508,7 +506,7 @@ fn run() -> Result<()> {
             })
             .transpose()?;
         match ipc::start_server(
-            ipc_bind.as_deref(),
+            ipc_bind,
             repl.r_home_for_ipc(),
             None,
             repl.history_session_id_raw(),
@@ -546,24 +544,6 @@ fn run() -> Result<()> {
     repl_result
 }
 
-/// Consume the bind-path carrier before R or any child process can observe it.
-/// Invalid carriers are ignored; the command-line path is then used normally.
-fn capture_ipc_bind_carrier() -> Option<OsString> {
-    // SAFETY: run() calls this during single-threaded process initialization,
-    // before R or any child process is started.
-    let value = unsafe {
-        let value = std::env::var_os(IPC_BIND_CARRIER);
-        std::env::remove_var(IPC_BIND_CARRIER);
-        value
-    }?;
-    let path = PathBuf::from(value);
-    if is_effective_ipc_bind_path(&path) {
-        Some(path.into_os_string())
-    } else {
-        None
-    }
-}
-
 /// Resolve a CLI bind path while the process still has its original cwd.
 fn absolute_ipc_bind_path(path: &OsStr) -> OsString {
     let path = PathBuf::from(path);
@@ -574,20 +554,6 @@ fn absolute_ipc_bind_path(path: &OsStr) -> OsString {
     }
 }
 
-/// Select the startup bind path only when the command line requested IPC
-/// binding. This prevents an untrusted or stale carrier from enabling a
-/// custom endpoint during an otherwise ordinary startup.
-fn effective_ipc_bind_path(
-    cli_path: Option<&OsStr>,
-    carried_path: Option<OsString>,
-) -> Option<OsString> {
-    cli_path.map(|path| {
-        carried_path
-            .filter(|path| is_effective_ipc_bind_path(std::path::Path::new(path)))
-            .unwrap_or_else(|| absolute_ipc_bind_path(path))
-    })
-}
-
 fn is_effective_ipc_bind_path(path: &std::path::Path) -> bool {
     #[cfg(windows)]
     if path.as_os_str().to_string_lossy().starts_with(r"\\.\pipe\") {
@@ -596,9 +562,75 @@ fn is_effective_ipc_bind_path(path: &std::path::Path) -> bool {
     path.is_absolute()
 }
 
-/// Return the bind path fixed at process startup, if one was configured.
-pub(crate) fn ipc_bind_path() -> Option<OsString> {
-    IPC_BIND_PATH.get().cloned().flatten()
+/// Return argv with interactive IPC paths fixed against the initial cwd.
+pub(crate) fn normalized_args() -> Vec<OsString> {
+    NORMALIZED_ARGS
+        .get()
+        .cloned()
+        .unwrap_or_else(|| std::env::args_os().skip(1).collect())
+}
+
+fn normalize_interactive_args(
+    args: Vec<OsString>,
+    bind_path: Option<&OsStr>,
+    pid_path: Option<&OsStr>,
+) -> Vec<OsString> {
+    let mut normalized = Vec::with_capacity(args.len());
+    let bind_path = bind_path.map(OsStr::to_os_string);
+    let pid_path = pid_path.map(OsStr::to_os_string);
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            normalized.extend(args[index..].iter().cloned());
+            break;
+        }
+        if arg == "--ipc-bind" {
+            if let Some(bind) = bind_path.as_ref()
+                && index + 1 < args.len()
+            {
+                normalized.push(arg.clone());
+                normalized.push(bind.clone());
+                index += 2;
+                continue;
+            }
+        } else if arg == "--ipc-pid-file"
+            && let Some(pid) = pid_path.as_ref()
+            && index + 1 < args.len()
+        {
+            normalized.push(arg.clone());
+            normalized.push(pid.clone());
+            index += 2;
+            continue;
+        }
+        if let Some(bind) = bind_path.as_ref()
+            && arg
+                .to_str()
+                .and_then(|s| s.strip_prefix("--ipc-bind="))
+                .is_some()
+        {
+            let mut rewritten = OsString::from("--ipc-bind=");
+            rewritten.push(bind);
+            normalized.push(rewritten);
+            index += 1;
+            continue;
+        }
+        if let Some(pid) = pid_path.as_ref()
+            && arg
+                .to_str()
+                .and_then(|s| s.strip_prefix("--ipc-pid-file="))
+                .is_some()
+        {
+            let mut rewritten = OsString::from("--ipc-pid-file=");
+            rewritten.push(pid);
+            normalized.push(rewritten);
+            index += 1;
+            continue;
+        }
+        normalized.push(arg.clone());
+        index += 1;
+    }
+    normalized
 }
 
 /// Read the startup environment snapshot before R initialization can add any
@@ -940,7 +972,7 @@ fn is_history_option_allowed(path: &[String], long: &str) -> bool {
 mod tests {
     use super::{
         STARTUP_ENV_CARRIER_VERSION, absolutize_runtime_r_home, deserialize_startup_env,
-        effective_ipc_bind_path, serialize_startup_env,
+        normalize_interactive_args, serialize_startup_env,
     };
     use std::collections::HashMap;
     use std::ffi::OsString;
@@ -978,20 +1010,74 @@ mod tests {
     }
 
     #[test]
-    fn ipc_bind_carrier_cannot_enable_binding_without_cli_option() {
-        let carried = Some(PathBuf::from("/tmp/carried.sock").into_os_string());
-        assert_eq!(effective_ipc_bind_path(None, carried), None);
+    fn normalize_args_rewrites_separated_options() {
+        let args = vec![
+            OsString::from("--ipc-bind"),
+            OsString::from("relative.sock"),
+            OsString::from("--ipc-pid-file"),
+            OsString::from("relative.pid"),
+        ];
+        let normalized = normalize_interactive_args(
+            args,
+            Some(OsString::from("/tmp/effective.sock").as_os_str()),
+            Some(OsString::from("/tmp/effective.pid").as_os_str()),
+        );
+        assert_eq!(normalized[1], "/tmp/effective.sock");
+        assert_eq!(normalized[3], "/tmp/effective.pid");
     }
 
     #[test]
-    fn invalid_ipc_bind_carrier_falls_back_to_cli_path() {
-        let carried = Some(PathBuf::from("relative/carried.sock").into_os_string());
-        let effective = effective_ipc_bind_path(
-            Some(OsString::from("relative/cli.sock").as_os_str()),
-            carried,
-        )
-        .expect("CLI bind path should be selected");
-        assert!(PathBuf::from(effective).is_absolute());
+    fn normalize_args_rewrites_equal_options_and_preserves_non_utf8_arg() {
+        #[cfg(unix)]
+        use std::os::unix::ffi::OsStringExt;
+        let unrelated = {
+            #[cfg(unix)]
+            {
+                OsString::from_vec(vec![b'X', 0xff])
+            }
+            #[cfg(not(unix))]
+            {
+                OsString::from("unrelated")
+            }
+        };
+        let args = vec![
+            OsString::from("--ipc-bind=relative.sock"),
+            OsString::from("--ipc-pid-file=relative.pid"),
+            unrelated.clone(),
+        ];
+        let normalized = normalize_interactive_args(
+            args,
+            Some(OsString::from("/tmp/effective.sock").as_os_str()),
+            Some(OsString::from("/tmp/effective.pid").as_os_str()),
+        );
+        assert_eq!(normalized[0], "--ipc-bind=/tmp/effective.sock");
+        assert_eq!(normalized[1], "--ipc-pid-file=/tmp/effective.pid");
+        assert_eq!(normalized[2], unrelated);
+    }
+
+    #[test]
+    fn normalize_args_without_ipc_options_preserves_arguments() {
+        let args = vec![OsString::from("--with-ipc"), OsString::from("--verbose")];
+        assert_eq!(normalize_interactive_args(args.clone(), None, None), args);
+    }
+
+    #[test]
+    fn normalize_args_preserves_options_after_terminator() {
+        let args = vec![
+            OsString::from("--ipc-bind=before.sock"),
+            OsString::from("--"),
+            OsString::from("--ipc-bind=after.sock"),
+            OsString::from("--ipc-pid-file=after.pid"),
+        ];
+        let normalized = normalize_interactive_args(
+            args,
+            Some(OsString::from("/tmp/effective.sock").as_os_str()),
+            Some(OsString::from("/tmp/effective.pid").as_os_str()),
+        );
+        assert_eq!(normalized[0], "--ipc-bind=/tmp/effective.sock");
+        assert_eq!(normalized[1], "--");
+        assert_eq!(normalized[2], "--ipc-bind=after.sock");
+        assert_eq!(normalized[3], "--ipc-pid-file=after.pid");
     }
 
     #[test]

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -602,10 +602,7 @@ fn normalize_interactive_args(
             continue;
         }
         if let Some(bind) = bind_path.as_ref()
-            && arg
-                .to_str()
-                .and_then(|s| s.strip_prefix("--ipc-bind="))
-                .is_some()
+            && os_str_has_ascii_prefix(arg, b"--ipc-bind=")
         {
             let mut rewritten = OsString::from("--ipc-bind=");
             rewritten.push(bind);
@@ -614,10 +611,7 @@ fn normalize_interactive_args(
             continue;
         }
         if let Some(pid) = pid_path.as_ref()
-            && arg
-                .to_str()
-                .and_then(|s| s.strip_prefix("--ipc-pid-file="))
-                .is_some()
+            && os_str_has_ascii_prefix(arg, b"--ipc-pid-file=")
         {
             let mut rewritten = OsString::from("--ipc-pid-file=");
             rewritten.push(pid);
@@ -629,6 +623,30 @@ fn normalize_interactive_args(
         index += 1;
     }
     normalized
+}
+
+/// Check an ASCII option prefix without requiring the complete argument to be
+/// UTF-8. This preserves and rewrites non-UTF-8 path values losslessly.
+fn os_str_has_ascii_prefix(value: &OsStr, prefix: &[u8]) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        value.as_bytes().starts_with(prefix)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        value
+            .encode_wide()
+            .take(prefix.len())
+            .eq(prefix.iter().copied().map(u16::from))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        value
+            .to_str()
+            .is_some_and(|value| value.as_bytes().starts_with(prefix))
+    }
 }
 
 /// Read the startup environment snapshot before R initialization can add any
@@ -1038,8 +1056,18 @@ mod tests {
                 OsString::from("unrelated")
             }
         };
+        #[cfg(unix)]
+        let non_utf_bind = OsString::from_vec(b"--ipc-bind=relative\xff.sock".to_vec());
+        #[cfg(unix)]
+        let non_utf_pid = OsString::from_vec(b"--ipc-pid-file=relative\xfe.pid".to_vec());
         let args = vec![
+            #[cfg(unix)]
+            non_utf_bind,
+            #[cfg(not(unix))]
             OsString::from("--ipc-bind=relative.sock"),
+            #[cfg(unix)]
+            non_utf_pid,
+            #[cfg(not(unix))]
             OsString::from("--ipc-pid-file=relative.pid"),
             unrelated.clone(),
         ];

--- a/crates/arf-console/src/main.rs
+++ b/crates/arf-console/src/main.rs
@@ -100,6 +100,11 @@ fn run() -> Result<()> {
     let matches = command.clone().get_matches();
     validate_top_level_scope(&command, &matches);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    if let Some(path) = cli.ipc_pid_file.as_deref() {
+        // Resolve this before R initialization: profiles may change cwd, but
+        // a relative PID path must continue to identify its initial file.
+        pid_file::set_initial_pid_file_path(path);
+    }
     let no_r_auto_discovery = match &cli.command {
         Some(Commands::Headless(args)) => args.r_source.no_r_auto_discovery,
         Some(Commands::R(args)) => {
@@ -346,6 +351,15 @@ fn run() -> Result<()> {
         // threads are spawned and before R is initialized, so mutating the
         // process environment here cannot race with a concurrent read.
         unsafe { std::env::set_var(STARTUP_ENV_CARRIER, startup_env_carrier()) };
+        if let Some((path, pid)) = pid_file::restart_context_carrier() {
+            // Forward the restart ownership context through this possible
+            // loader re-exec. capture_startup_env removes it in the image
+            // that finally starts R.
+            unsafe {
+                std::env::set_var(pid_file::RESTART_PID_PATH_ENV, path);
+                std::env::set_var(pid_file::RESTART_PID_ENV, pid);
+            }
+        }
         if let Err(e) = arf_libr::ensure_ld_library_path_with_pre_exec(
             console_mode::restore_original_input_mode,
         ) {
@@ -361,6 +375,10 @@ fn run() -> Result<()> {
         //
         // SAFETY: same single-threaded, pre-R-init context as above.
         unsafe { std::env::remove_var(STARTUP_ENV_CARRIER) };
+        unsafe {
+            std::env::remove_var(pid_file::RESTART_PID_PATH_ENV);
+            std::env::remove_var(pid_file::RESTART_PID_ENV);
+        }
     }
     #[cfg(not(unix))]
     if let Err(e) = arf_libr::ensure_ld_library_path() {
@@ -504,6 +522,7 @@ fn run() -> Result<()> {
 /// R-specific variables, using the carrier forwarded through a prior re-exec
 /// when present and otherwise capturing the current environment.
 fn capture_startup_env() {
+    pid_file::capture_restart_context();
     // SAFETY: run() calls this at the start of process initialization, before
     // arf starts any threads or initializes R, so changing the process
     // environment is safe here.

--- a/crates/arf-console/src/pid_file.rs
+++ b/crates/arf-console/src/pid_file.rs
@@ -184,15 +184,18 @@ fn pid_file_contains_current_pid(path: &Path, expected: &[u8]) -> bool {
 fn validate_inherited_pid_fd(fd: std::os::unix::io::RawFd, path: &Path, expected: &[u8]) -> bool {
     use std::io::{Read, Seek, SeekFrom};
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    use std::os::unix::io::FromRawFd;
 
     // Never close the carrier fd during validation. A clone is used for all
     // reads, while the original remains available for adoption or is left
     // untouched when validation fails.
-    let borrowed = unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) };
-    let file = match borrowed.try_clone_to_owned() {
-        Ok(file) => std::fs::File::from(file),
-        Err(_) => return false,
-    };
+    let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 3) };
+    if duplicate < 0 {
+        return false;
+    }
+    // SAFETY: F_DUPFD_CLOEXEC returned a new owned descriptor. The original
+    // carrier descriptor remains open with its flags unchanged.
+    let file = unsafe { std::fs::File::from_raw_fd(duplicate) };
     let fd_meta = match file.metadata() {
         Ok(meta) if meta.file_type().is_file() => meta,
         _ => return false,

--- a/crates/arf-console/src/pid_file.rs
+++ b/crates/arf-console/src/pid_file.rs
@@ -1,6 +1,77 @@
 //! PID file management for `--ipc-pid-file` / `arf headless --pid-file`.
 
 use anyhow::{Context, Result};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Environment carriers used only for a restart replacement.  The path is a
+/// separate value so Unix paths that are not valid UTF-8 are preserved.
+pub(crate) const RESTART_PID_ENV: &str = "_ARF_INTERNAL_RESTART_PID";
+pub(crate) const RESTART_PID_PATH_ENV: &str = "_ARF_INTERNAL_RESTART_PID_PATH";
+
+#[derive(Clone, Debug)]
+pub(crate) struct RestartPidContext {
+    pub(crate) pid: u32,
+    pub(crate) path: PathBuf,
+}
+
+static RESTART_PID_CONTEXT: std::sync::OnceLock<RestartPidContext> = std::sync::OnceLock::new();
+static INITIAL_PID_FILE_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+/// Consume the restart carriers before R or any child process can observe
+/// them. Invalid or incomplete carriers are ignored and cannot enable adopt.
+pub(crate) fn capture_restart_context() {
+    // SAFETY: called during single-threaded process startup, before R and its
+    // threads are initialized.
+    let (pid, path) = unsafe {
+        let pid = std::env::var_os(RESTART_PID_ENV);
+        let path = std::env::var_os(RESTART_PID_PATH_ENV);
+        std::env::remove_var(RESTART_PID_ENV);
+        std::env::remove_var(RESTART_PID_PATH_ENV);
+        (pid, path)
+    };
+
+    let Some(pid) = pid.and_then(|value| value.to_str()?.parse::<u32>().ok()) else {
+        return;
+    };
+    let Some(path) = path.map(PathBuf::from).filter(|path| path.is_absolute()) else {
+        return;
+    };
+    let _ = RESTART_PID_CONTEXT.set(RestartPidContext { pid, path });
+}
+
+pub(crate) fn restart_pid_context() -> Option<RestartPidContext> {
+    RESTART_PID_CONTEXT.get().cloned()
+}
+
+/// Resolve the configured path before R profiles can change the working
+/// directory. A restart carrier takes precedence so relative CLI paths keep
+/// referring to the original process's absolute path.
+pub(crate) fn set_initial_pid_file_path(path: &Path) {
+    let resolved = restart_pid_context()
+        .map(|context| context.path)
+        .unwrap_or_else(|| absolute_path(path));
+    let _ = INITIAL_PID_FILE_PATH.set(resolved);
+}
+
+pub(crate) fn initial_pid_file_path() -> Option<PathBuf> {
+    INITIAL_PID_FILE_PATH.get().cloned()
+}
+
+/// Return the carriers needed by a replacement command, if this session has
+/// a PID file. OsString is intentional: Unix path arguments may be non-UTF-8.
+pub(crate) fn restart_command_context() -> Option<(OsString, OsString)> {
+    let path = initial_pid_file_path()?;
+    Some((path.into_os_string(), std::process::id().to_string().into()))
+}
+
+pub(crate) fn restart_context_carrier() -> Option<(OsString, OsString)> {
+    let context = restart_pid_context()?;
+    Some((
+        context.path.into_os_string(),
+        context.pid.to_string().into(),
+    ))
+}
 
 /// Write the current process ID to a file.
 ///
@@ -8,6 +79,21 @@ use anyhow::{Context, Result};
 /// intended to be removed on shutdown by the caller.
 pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
     let pid = std::process::id().to_string();
+
+    #[cfg(unix)]
+    if let Some(context) = restart_pid_context() {
+        // Unix exec keeps the process ID and the old file open only in the
+        // filesystem namespace. Adopt only the exact file/path/PID tuple; in
+        // particular, symlinks and directories are never adopted.
+        let matches = context.pid == std::process::id()
+            && context.path == path
+            && pid_file_contains_current_pid(path, pid.as_bytes());
+        if matches {
+            log::info!("Adopted PID file for restart: {}", path.display());
+            return Ok(());
+        }
+    }
+
     // Use create_new to fail if the file already exists, avoiding overwrite
     // of unrelated files or symlink-following attacks.
     #[cfg(unix)]
@@ -40,7 +126,49 @@ pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Check the existing PID file through one descriptor. `O_NOFOLLOW` and
+/// descriptor metadata prevent a symlink replacement between the type check
+/// and the read from being treated as an adoptable file.
+#[cfg(unix)]
+fn pid_file_contains_current_pid(path: &Path, expected: &[u8]) -> bool {
+    use std::io::Read;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let Ok(file) = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    else {
+        return false;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return false;
+    };
+    if !metadata.file_type().is_file() {
+        return false;
+    }
+
+    // Read at most one byte beyond the expected value. This both verifies
+    // exact contents and avoids allocating for an unexpectedly large file.
+    let mut contents = Vec::with_capacity(expected.len() + 1);
+    if file
+        .take(expected.len() as u64 + 1)
+        .read_to_end(&mut contents)
+        .is_err()
+    {
+        return false;
+    }
+    contents == expected
+}
+
 pub(crate) fn absolute_pid_file_path(path: &std::path::Path) -> std::path::PathBuf {
+    INITIAL_PID_FILE_PATH
+        .get()
+        .cloned()
+        .unwrap_or_else(|| absolute_path(path))
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
     std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
@@ -99,6 +227,55 @@ pub(crate) fn cleanup_ipc_pid_file(path: &std::path::Path) {
         );
     }
 
-    // Disarm the atexit handler only after attempting the same absolute path.
+    // Disarm after attempting the same absolute path. This is the normal
+    // final cleanup path; restart handoff uses the fallible relinquish helper
+    // below and disarms only after successful removal.
     IPC_PID_FILE_CLEANUP_DONE.store(true, std::sync::atomic::Ordering::Release);
+}
+
+/// Remove the parent's PID file before a non-Unix replacement is spawned.
+/// The atexit handler remains armed if removal fails, so the old PID is never
+/// restored or overwritten by a best-effort operation.
+#[cfg(not(unix))]
+pub(crate) fn relinquish_pid_file_for_restart(path: &Path) -> Result<()> {
+    let cleanup_path = IPC_PID_FILE_PATH
+        .get()
+        .cloned()
+        .unwrap_or_else(|| absolute_pid_file_path(path));
+    std::fs::remove_file(&cleanup_path).with_context(|| {
+        format!(
+            "Failed to relinquish PID file before restart: {}",
+            cleanup_path.display()
+        )
+    })?;
+    IPC_PID_FILE_CLEANUP_DONE.store(true, std::sync::atomic::Ordering::Release);
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::pid_file_contains_current_pid;
+
+    #[test]
+    fn adoption_check_requires_exact_regular_file_contents() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("arf.pid");
+        std::fs::write(&path, b"1234").expect("write PID file");
+
+        assert!(pid_file_contains_current_pid(&path, b"1234"));
+        assert!(!pid_file_contains_current_pid(&path, b"123"));
+        std::fs::write(&path, b"1234\n").expect("write non-exact PID file");
+        assert!(!pid_file_contains_current_pid(&path, b"1234"));
+    }
+
+    #[test]
+    fn adoption_check_rejects_symlink() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let target = directory.path().join("target");
+        let link = directory.path().join("arf.pid");
+        std::fs::write(&target, b"1234").expect("write target file");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        assert!(!pid_file_contains_current_pid(&link, b"1234"));
+    }
 }

--- a/crates/arf-console/src/pid_file.rs
+++ b/crates/arf-console/src/pid_file.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 /// The only restart capability carried through the environment is the
 /// inherited PID-file descriptor number. The authoritative path comes from
 /// the normalized argv, never from an environment value.
+#[cfg(unix)]
 pub(crate) const RESTART_PID_FD_ENV: &str = "_ARF_INTERNAL_RESTART_PID_FD";
 
 #[cfg(unix)]
@@ -21,21 +22,20 @@ static INITIAL_PID_FILE_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock
 /// Consume the restart fd carrier before R or any child process can observe
 /// it. Parsing does not acquire or close the descriptor.
 pub(crate) fn capture_restart_context() {
-    #[cfg(not(unix))]
-    return;
-
     #[cfg(unix)]
-    // SAFETY: called during single-threaded process startup, before R and its
-    // threads are initialized.
-    let fd = unsafe {
-        let value = std::env::var_os(RESTART_PID_FD_ENV);
-        std::env::remove_var(RESTART_PID_FD_ENV);
-        value
-            .and_then(|value| value.to_str()?.parse::<std::os::unix::io::RawFd>().ok())
-            .filter(|fd| *fd >= 3)
-    };
+    {
+        // SAFETY: called during single-threaded process startup, before R and
+        // its threads are initialized.
+        let fd = unsafe {
+            let value = std::env::var_os(RESTART_PID_FD_ENV);
+            std::env::remove_var(RESTART_PID_FD_ENV);
+            value
+                .and_then(|value| value.to_str()?.parse::<std::os::unix::io::RawFd>().ok())
+                .filter(|fd| *fd >= 3)
+        };
 
-    let _ = INHERITED_PID_FD.set(fd);
+        let _ = INHERITED_PID_FD.set(fd);
+    }
 }
 
 /// Resolve the configured path before R profiles can change the working
@@ -85,11 +85,6 @@ pub(crate) fn finish_loader_reexec() {
     {
         let _ = set_fd_cloexec(fd, true);
     }
-}
-
-#[cfg(not(unix))]
-pub(crate) fn restart_fd_carrier() -> Option<std::ffi::OsString> {
-    None
 }
 
 /// Write the current process ID to a file.

--- a/crates/arf-console/src/pid_file.rs
+++ b/crates/arf-console/src/pid_file.rs
@@ -1,76 +1,95 @@
 //! PID file management for `--ipc-pid-file` / `arf headless --pid-file`.
 
 use anyhow::{Context, Result};
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-/// Environment carriers used only for a restart replacement.  The path is a
-/// separate value so Unix paths that are not valid UTF-8 are preserved.
-pub(crate) const RESTART_PID_ENV: &str = "_ARF_INTERNAL_RESTART_PID";
-pub(crate) const RESTART_PID_PATH_ENV: &str = "_ARF_INTERNAL_RESTART_PID_PATH";
+/// The only restart capability carried through the environment is the
+/// inherited PID-file descriptor number. The authoritative path comes from
+/// the normalized argv, never from an environment value.
+pub(crate) const RESTART_PID_FD_ENV: &str = "_ARF_INTERNAL_RESTART_PID_FD";
 
-#[derive(Clone, Debug)]
-pub(crate) struct RestartPidContext {
-    pub(crate) pid: u32,
-    pub(crate) path: PathBuf,
-}
-
-static RESTART_PID_CONTEXT: std::sync::OnceLock<RestartPidContext> = std::sync::OnceLock::new();
+#[cfg(unix)]
+static INHERITED_PID_FD: std::sync::OnceLock<Option<std::os::unix::io::RawFd>> =
+    std::sync::OnceLock::new();
+#[cfg(unix)]
+static INHERITED_PID_FD_VALID: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+#[cfg(unix)]
+static OWNED_PID_FD: std::sync::OnceLock<std::sync::Mutex<Option<std::fs::File>>> =
+    std::sync::OnceLock::new();
 static INITIAL_PID_FILE_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
-/// Consume the restart carriers before R or any child process can observe
-/// them. Invalid or incomplete carriers are ignored and cannot enable adopt.
+/// Consume the restart fd carrier before R or any child process can observe
+/// it. Parsing does not acquire or close the descriptor.
 pub(crate) fn capture_restart_context() {
+    #[cfg(not(unix))]
+    return;
+
+    #[cfg(unix)]
     // SAFETY: called during single-threaded process startup, before R and its
     // threads are initialized.
-    let (pid, path) = unsafe {
-        let pid = std::env::var_os(RESTART_PID_ENV);
-        let path = std::env::var_os(RESTART_PID_PATH_ENV);
-        std::env::remove_var(RESTART_PID_ENV);
-        std::env::remove_var(RESTART_PID_PATH_ENV);
-        (pid, path)
+    let fd = unsafe {
+        let value = std::env::var_os(RESTART_PID_FD_ENV);
+        std::env::remove_var(RESTART_PID_FD_ENV);
+        value
+            .and_then(|value| value.to_str()?.parse::<std::os::unix::io::RawFd>().ok())
+            .filter(|fd| *fd >= 3)
     };
 
-    let Some(pid) = pid.and_then(|value| value.to_str()?.parse::<u32>().ok()) else {
-        return;
-    };
-    let Some(path) = path.map(PathBuf::from).filter(|path| path.is_absolute()) else {
-        return;
-    };
-    let _ = RESTART_PID_CONTEXT.set(RestartPidContext { pid, path });
-}
-
-pub(crate) fn restart_pid_context() -> Option<RestartPidContext> {
-    RESTART_PID_CONTEXT.get().cloned()
+    let _ = INHERITED_PID_FD.set(fd);
 }
 
 /// Resolve the configured path before R profiles can change the working
-/// directory. A restart carrier takes precedence so relative CLI paths keep
-/// referring to the original process's absolute path.
+/// directory.
 pub(crate) fn set_initial_pid_file_path(path: &Path) {
-    let resolved = restart_pid_context()
-        .map(|context| context.path)
-        .unwrap_or_else(|| absolute_path(path));
+    let resolved = absolute_path(path);
     let _ = INITIAL_PID_FILE_PATH.set(resolved);
 }
 
+#[cfg(not(unix))]
 pub(crate) fn initial_pid_file_path() -> Option<PathBuf> {
     INITIAL_PID_FILE_PATH.get().cloned()
 }
 
-/// Return the carriers needed by a replacement command, if this session has
-/// a PID file. OsString is intentional: Unix path arguments may be non-UTF-8.
-pub(crate) fn restart_command_context() -> Option<(OsString, OsString)> {
-    let path = initial_pid_file_path()?;
-    Some((path.into_os_string(), std::process::id().to_string().into()))
+/// Validate the inherited descriptor against the authoritative CLI path before
+/// allowing it to cross another loader re-exec.
+#[cfg(unix)]
+pub(crate) fn authorize_inherited_pid_fd(path: &Path) {
+    let valid = INHERITED_PID_FD.get().copied().flatten().is_some_and(|fd| {
+        validate_inherited_pid_fd(fd, path, std::process::id().to_string().as_bytes())
+    });
+    let _ = INHERITED_PID_FD_VALID.set(valid);
 }
 
-pub(crate) fn restart_context_carrier() -> Option<(OsString, OsString)> {
-    let context = restart_pid_context()?;
-    Some((
-        context.path.into_os_string(),
-        context.pid.to_string().into(),
-    ))
+#[cfg(unix)]
+fn owned_pid_fd() -> &'static std::sync::Mutex<Option<std::fs::File>> {
+    OWNED_PID_FD.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+#[cfg(unix)]
+pub(crate) fn restart_fd_carrier() -> Option<std::ffi::OsString> {
+    use std::os::unix::io::AsRawFd;
+    if INHERITED_PID_FD_VALID.get().copied() == Some(true) {
+        let fd = INHERITED_PID_FD.get().copied().flatten()?;
+        return Some(fd.to_string().into());
+    }
+    let guard = owned_pid_fd().lock().ok()?;
+    guard
+        .as_ref()
+        .map(|file| file.as_raw_fd().to_string().into())
+}
+
+#[cfg(unix)]
+pub(crate) fn finish_loader_reexec() {
+    if INHERITED_PID_FD_VALID.get().copied() == Some(true)
+        && let Some(fd) = INHERITED_PID_FD.get().copied().flatten()
+    {
+        let _ = set_fd_cloexec(fd, true);
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn restart_fd_carrier() -> Option<std::ffi::OsString> {
+    None
 }
 
 /// Write the current process ID to a file.
@@ -81,14 +100,16 @@ pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
     let pid = std::process::id().to_string();
 
     #[cfg(unix)]
-    if let Some(context) = restart_pid_context() {
-        // Unix exec keeps the process ID and the old file open only in the
-        // filesystem namespace. Adopt only the exact file/path/PID tuple; in
-        // particular, symlinks and directories are never adopted.
-        let matches = context.pid == std::process::id()
-            && context.path == path
-            && pid_file_contains_current_pid(path, pid.as_bytes());
-        if matches {
+    if let Some(fd) = INHERITED_PID_FD.get().copied().flatten() {
+        use std::os::unix::io::FromRawFd;
+        // The path is authoritative from argv. Adopt only when the inherited
+        // descriptor and path resolve to the same regular file and its exact
+        // contents identify this process.
+        if validate_inherited_pid_fd(fd, path, pid.as_bytes()) {
+            // SAFETY: validation succeeded and the descriptor was supplied by
+            // the prior arf image. Ownership is transferred exactly once.
+            let file = unsafe { std::fs::File::from_raw_fd(fd) };
+            *owned_pid_fd().lock().unwrap() = Some(file);
             log::info!("Adopted PID file for restart: {}", path.display());
             return Ok(());
         }
@@ -101,6 +122,7 @@ pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
         let mut file = std::fs::OpenOptions::new()
+            .read(true)
             .write(true)
             .create_new(true)
             .mode(0o600)
@@ -108,6 +130,7 @@ pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
             .with_context(|| format!("Failed to create PID file: {}", path.display()))?;
         file.write_all(pid.as_bytes())
             .with_context(|| format!("Failed to write PID file: {}", path.display()))?;
+        *owned_pid_fd().lock().unwrap() = Some(move_file_to_safe_fd(file)?);
     }
     #[cfg(not(unix))]
     {
@@ -130,6 +153,7 @@ pub(crate) fn write_pid_file(path: &std::path::Path) -> Result<()> {
 /// descriptor metadata prevent a symlink replacement between the type check
 /// and the read from being treated as an adoptable file.
 #[cfg(unix)]
+#[cfg(test)]
 fn pid_file_contains_current_pid(path: &Path, expected: &[u8]) -> bool {
     use std::io::Read;
     use std::os::unix::fs::OpenOptionsExt;
@@ -159,6 +183,106 @@ fn pid_file_contains_current_pid(path: &Path, expected: &[u8]) -> bool {
         return false;
     }
     contents == expected
+}
+
+#[cfg(unix)]
+fn validate_inherited_pid_fd(fd: std::os::unix::io::RawFd, path: &Path, expected: &[u8]) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    // Never close the carrier fd during validation. A clone is used for all
+    // reads, while the original remains available for adoption or is left
+    // untouched when validation fails.
+    let borrowed = unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) };
+    let file = match borrowed.try_clone_to_owned() {
+        Ok(file) => std::fs::File::from(file),
+        Err(_) => return false,
+    };
+    let fd_meta = match file.metadata() {
+        Ok(meta) if meta.file_type().is_file() => meta,
+        _ => return false,
+    };
+    let path_file = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(_) => return false,
+    };
+    let path_meta = match path_file.metadata() {
+        Ok(meta) if meta.file_type().is_file() => meta,
+        _ => return false,
+    };
+    if fd_meta.dev() != path_meta.dev() || fd_meta.ino() != path_meta.ino() {
+        return false;
+    }
+
+    let mut contents = Vec::with_capacity(expected.len() + 1);
+    let mut reader = file;
+    if reader.seek(SeekFrom::Start(0)).is_err()
+        || reader
+            .take(expected.len() as u64 + 1)
+            .read_to_end(&mut contents)
+            .is_err()
+    {
+        return false;
+    }
+    contents == expected
+}
+
+/// Temporarily make the owned PID file descriptor survive Unix exec. The
+/// guard restores FD_CLOEXEC if exec returns with an error.
+#[cfg(unix)]
+pub(crate) struct PidFdExecGuard {
+    fd: std::os::unix::io::RawFd,
+}
+
+#[cfg(unix)]
+impl Drop for PidFdExecGuard {
+    fn drop(&mut self) {
+        let _ = set_fd_cloexec(self.fd, true);
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn prepare_pid_fd_for_exec() -> Option<anyhow::Result<PidFdExecGuard>> {
+    use std::os::unix::io::AsRawFd;
+    let guard = owned_pid_fd().lock().ok()?;
+    let fd = guard.as_ref()?.as_raw_fd();
+    Some(set_fd_cloexec(fd, false).map(|()| PidFdExecGuard { fd }))
+}
+
+#[cfg(unix)]
+fn set_fd_cloexec(fd: std::os::unix::io::RawFd, enabled: bool) -> anyhow::Result<()> {
+    let current = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if current < 0 {
+        return Err(anyhow::anyhow!(std::io::Error::last_os_error()));
+    }
+    let flags = if enabled {
+        current | libc::FD_CLOEXEC
+    } else {
+        current & !libc::FD_CLOEXEC
+    };
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags) } < 0 {
+        return Err(anyhow::anyhow!(std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn move_file_to_safe_fd(file: std::fs::File) -> anyhow::Result<std::fs::File> {
+    use std::os::unix::io::{FromRawFd, IntoRawFd};
+    let raw = file.into_raw_fd();
+    let safe = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, 3) };
+    if safe < 0 {
+        // This function owns the raw descriptor after into_raw_fd(); close it
+        // explicitly when duplication fails.
+        unsafe { libc::close(raw) };
+        return Err(anyhow::anyhow!(std::io::Error::last_os_error()));
+    }
+    unsafe { libc::close(raw) };
+    Ok(unsafe { std::fs::File::from_raw_fd(safe) })
 }
 
 pub(crate) fn absolute_pid_file_path(path: &std::path::Path) -> std::path::PathBuf {
@@ -254,7 +378,8 @@ pub(crate) fn relinquish_pid_file_for_restart(path: &Path) -> Result<()> {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::pid_file_contains_current_pid;
+    use super::{pid_file_contains_current_pid, validate_inherited_pid_fd};
+    use std::os::unix::io::AsRawFd;
 
     #[test]
     fn adoption_check_requires_exact_regular_file_contents() {
@@ -277,5 +402,40 @@ mod tests {
         std::os::unix::fs::symlink(&target, &link).expect("create symlink");
 
         assert!(!pid_file_contains_current_pid(&link, b"1234"));
+    }
+
+    #[test]
+    fn inherited_fd_validation_requires_matching_inode_and_content() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("arf.pid");
+        let other = directory.path().join("other.pid");
+        std::fs::write(&path, b"1234").expect("write PID file");
+        std::fs::write(&other, b"1234").expect("write other file");
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("open PID file");
+        let fd = file.as_raw_fd();
+
+        assert!(validate_inherited_pid_fd(fd, &path, b"1234"));
+        assert!(!validate_inherited_pid_fd(fd, &other, b"1234"));
+        assert!(!validate_inherited_pid_fd(fd, &path, b"5678"));
+    }
+
+    #[test]
+    fn inherited_fd_validation_rejects_symlink_and_invalid_fd_without_closing() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let target = directory.path().join("target");
+        let link = directory.path().join("arf.pid");
+        std::fs::write(&target, b"1234").expect("write target");
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        let file = std::fs::File::open(&target).expect("open target");
+        let fd = file.as_raw_fd();
+        assert!(!validate_inherited_pid_fd(fd, &link, b"1234"));
+        assert!(!validate_inherited_pid_fd(999_999, &target, b"1234"));
+        // The valid descriptor remains usable after validation failures.
+        assert_eq!(file.metadata().expect("descriptor remains open").len(), 4);
     }
 }

--- a/crates/arf-console/src/repl/shell.rs
+++ b/crates/arf-console/src/repl/shell.rs
@@ -161,6 +161,9 @@ fn build_restart_command(
         cmd.env(crate::pid_file::RESTART_PID_PATH_ENV, path);
         cmd.env(crate::pid_file::RESTART_PID_ENV, pid);
     }
+    if let Some(path) = crate::ipc_bind_path() {
+        cmd.env(crate::IPC_BIND_CARRIER, path);
+    }
     for (var, value) in &changes.restored {
         cmd.env(var, value);
     }

--- a/crates/arf-console/src/repl/shell.rs
+++ b/crates/arf-console/src/repl/shell.rs
@@ -288,11 +288,11 @@ pub fn restart_process(version: Option<&str>) {
         // Stop serving first, then relinquish the file; on failure the old
         // file is left alone and no child is started.
         crate::ipc::stop_server();
-        if let Some(pid_path) = crate::pid_file::initial_pid_file_path() {
-            if let Err(e) = crate::pid_file::relinquish_pid_file_for_restart(&pid_path) {
-                arf_eprintln!("Error: {}", e);
-                std::process::exit(1);
-            }
+        if let Some(pid_path) = crate::pid_file::initial_pid_file_path()
+            && let Err(e) = crate::pid_file::relinquish_pid_file_for_restart(&pid_path)
+        {
+            arf_eprintln!("Error: {}", e);
+            std::process::exit(1);
         }
         // On non-Unix platforms, spawn a new process and wait for it to exit.
         // Unlike Unix exec(), this doesn't replace the current process, so we

--- a/crates/arf-console/src/repl/shell.rs
+++ b/crates/arf-console/src/repl/shell.rs
@@ -1,7 +1,7 @@
 //! Shell command execution and process management.
 
 use crate::external::rig::{self, RigError};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
 
@@ -150,13 +150,17 @@ where
 /// returns, so mutating its environment directly would leak into it.
 fn build_restart_command(
     exe: &std::path::Path,
-    args: &[String],
+    args: &[OsString],
     changes: &EnvChanges,
     startup_env_carrier: &str,
 ) -> Command {
     let mut cmd = Command::new(exe);
     cmd.args(args);
     cmd.env(crate::STARTUP_ENV_CARRIER, startup_env_carrier);
+    if let Some((path, pid)) = crate::pid_file::restart_command_context() {
+        cmd.env(crate::pid_file::RESTART_PID_PATH_ENV, path);
+        cmd.env(crate::pid_file::RESTART_PID_ENV, pid);
+    }
     for (var, value) in &changes.restored {
         cmd.env(var, value);
     }
@@ -244,14 +248,14 @@ pub fn restart_process(version: Option<&str>) {
 
     // Get command-line arguments (skip the program name, we'll use current_exe instead)
     // Also filter out any existing --with-r-version argument if we're switching versions
-    let mut args: Vec<String> = std::env::args().skip(1).collect();
+    let mut args: Vec<OsString> = std::env::args_os().skip(1).collect();
 
     if let Some(v) = &version {
         // Remove existing --with-r-version arguments
         args = filter_r_version_args(args);
         // Add the new version
-        args.push("--with-r-version".to_string());
-        args.push(v.to_string());
+        args.push(OsString::from("--with-r-version"));
+        args.push(OsString::from(v));
     }
 
     let changes = env_changes_for_switch(version, crate::startup_env_value);
@@ -272,6 +276,16 @@ pub fn restart_process(version: Option<&str>) {
 
     #[cfg(not(unix))]
     {
+        // A spawned replacement cannot safely share the parent's PID file.
+        // Stop serving first, then relinquish the file; on failure the old
+        // file is left alone and no child is started.
+        crate::ipc::stop_server();
+        if let Some(pid_path) = crate::pid_file::initial_pid_file_path() {
+            if let Err(e) = crate::pid_file::relinquish_pid_file_for_restart(&pid_path) {
+                arf_eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
         // On non-Unix platforms, spawn a new process and wait for it to exit.
         // Unlike Unix exec(), this doesn't replace the current process, so we
         // wait for the child and then exit with its status code. This keeps the
@@ -316,7 +330,7 @@ where
 }
 
 /// Filter out --with-r-version and its value from command-line arguments.
-fn filter_r_version_args(args: Vec<String>) -> Vec<String> {
+fn filter_r_version_args(args: Vec<OsString>) -> Vec<OsString> {
     let mut result = Vec::new();
     let mut skip_next = false;
 
@@ -326,13 +340,13 @@ fn filter_r_version_args(args: Vec<String>) -> Vec<String> {
             continue;
         }
 
-        if arg == "--with-r-version" {
+        if arg == OsStr::new("--with-r-version") {
             // Skip this and the next argument (the version value)
             skip_next = true;
             continue;
         }
 
-        if arg.starts_with("--with-r-version=") {
+        if arg.to_string_lossy().starts_with("--with-r-version=") {
             // Skip --with-r-version=value form
             continue;
         }

--- a/crates/arf-console/src/repl/shell.rs
+++ b/crates/arf-console/src/repl/shell.rs
@@ -157,12 +157,9 @@ fn build_restart_command(
     let mut cmd = Command::new(exe);
     cmd.args(args);
     cmd.env(crate::STARTUP_ENV_CARRIER, startup_env_carrier);
-    if let Some((path, pid)) = crate::pid_file::restart_command_context() {
-        cmd.env(crate::pid_file::RESTART_PID_PATH_ENV, path);
-        cmd.env(crate::pid_file::RESTART_PID_ENV, pid);
-    }
-    if let Some(path) = crate::ipc_bind_path() {
-        cmd.env(crate::IPC_BIND_CARRIER, path);
+    #[cfg(unix)]
+    if let Some(fd) = crate::pid_file::restart_fd_carrier() {
+        cmd.env(crate::pid_file::RESTART_PID_FD_ENV, fd);
     }
     for (var, value) in &changes.restored {
         cmd.env(var, value);
@@ -251,7 +248,7 @@ pub fn restart_process(version: Option<&str>) {
 
     // Get command-line arguments (skip the program name, we'll use current_exe instead)
     // Also filter out any existing --with-r-version argument if we're switching versions
-    let mut args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let mut args: Vec<OsString> = crate::normalized_args();
 
     if let Some(v) = &version {
         // Remove existing --with-r-version arguments
@@ -270,6 +267,14 @@ pub fn restart_process(version: Option<&str>) {
     {
         use std::os::unix::process::CommandExt;
 
+        let _pid_fd_guard = match crate::pid_file::prepare_pid_fd_for_exec() {
+            Some(Ok(guard)) => Some(guard),
+            Some(Err(error)) => {
+                arf_eprintln!("Error: Failed to prepare PID file for restart: {error}");
+                return;
+            }
+            None => None,
+        };
         let mut cmd = build_restart_command(&exe, &args, &changes, &startup_env_carrier);
 
         // exec() replaces the current process - this should not return

--- a/crates/arf-console/tests/common/mod.rs
+++ b/crates/arf-console/tests/common/mod.rs
@@ -117,6 +117,17 @@ impl Terminal {
         rows: u16,
         cols: u16,
     ) -> Result<Self, String> {
+        Self::spawn_with_size_and_env_in(args, envs, rows, cols, None)
+    }
+
+    /// Spawn arf with an explicitly selected working directory.
+    pub fn spawn_with_size_and_env_in(
+        args: &[&str],
+        envs: &[(&str, &str)],
+        rows: u16,
+        cols: u16,
+        cwd: Option<&std::path::Path>,
+    ) -> Result<Self, String> {
         assert!(rows > 0 && cols > 0, "PTY size must be non-zero");
         let bin_path = env!("CARGO_BIN_EXE_arf");
 
@@ -143,6 +154,9 @@ impl Terminal {
         }
         for (key, value) in envs {
             cmd.env(key, value);
+        }
+        if let Some(cwd) = cwd {
+            cmd.cwd(cwd);
         }
 
         // Spawn the process

--- a/crates/arf-console/tests/pty_ipc_tests.rs
+++ b/crates/arf-console/tests/pty_ipc_tests.rs
@@ -1337,6 +1337,26 @@ mod ipc_tests {
         );
     }
 
+    /// A normal startup must retain create_new semantics: an existing file is
+    /// never adopted unless the process carries a validated restart context.
+    #[test]
+    fn test_with_ipc_pid_file_existing_file_is_rejected() {
+        let tmp = tempfile::TempDir::new().expect("create temp dir");
+        let pid_path = tmp.path().join("arf.pid");
+        std::fs::write(&pid_path, "unrelated").expect("write sentinel PID file");
+        let pid_str = pid_path.display().to_string();
+
+        let mut terminal = Terminal::spawn_with_args(&["--with-ipc", "--ipc-pid-file", &pid_str])
+            .expect("Failed to spawn arf with --with-ipc --ipc-pid-file");
+        terminal
+            .wait_for_exit(Duration::from_secs(10))
+            .expect("Startup should fail when the PID file already exists");
+        assert_eq!(
+            std::fs::read_to_string(&pid_path).expect("sentinel PID file should remain"),
+            "unrelated"
+        );
+    }
+
     /// Test that --with-ipc --ipc-pid-file works with Ctrl+D exit.
     #[test]
     fn test_with_ipc_pid_file_ctrld_cleanup() {

--- a/crates/arf-console/tests/pty_regression_tests.rs
+++ b/crates/arf-console/tests/pty_regression_tests.rs
@@ -82,3 +82,130 @@ fn test_pty_restart_preserves_session_environment() {
 
     terminal.quit().expect("Should quit cleanly");
 }
+
+/// A Unix exec restart must adopt the existing PID file instead of briefly
+/// deleting it or failing create_new. The PID stays stable, while the new
+/// image re-registers atexit cleanup for the same file.
+#[test]
+#[cfg(unix)]
+fn test_pty_restart_preserves_pid_file_ownership() {
+    use std::os::unix::net::UnixStream;
+
+    let initial_dir = std::env::current_dir().expect("Should read the test working directory");
+    let config_dir = tempfile::tempdir_in(&initial_dir).expect("Should create a temp config dir");
+    let changed_dir =
+        tempfile::tempdir_in(&initial_dir).expect("Should create a changed working directory");
+    let config_path = config_dir.path().join("arf.toml");
+    std::fs::write(&config_path, "[startup]\nshow_banner = true\n")
+        .expect("Should write the temp config file");
+    let pid_path = config_dir.path().join("arf.pid");
+    let relative_pid_path = relative_path_from(&initial_dir, &pid_path);
+    let path_from_changed_dir = changed_dir.path().join(&relative_pid_path);
+    assert_ne!(
+        path_from_changed_dir, pid_path,
+        "The relative PID argument must resolve differently after setwd"
+    );
+    let socket_dir = tempfile::tempdir().expect("Should create a temp socket directory");
+    let socket_path = socket_dir.path().join("custom.sock");
+    let _ = std::fs::remove_file(&socket_path);
+    let socket_arg = socket_path
+        .to_str()
+        .expect("Socket path should be valid UTF-8");
+    let config_arg = config_path
+        .to_str()
+        .expect("Config path should be valid UTF-8");
+
+    let mut terminal = Terminal::spawn_with_size_and_env_in(
+        &[
+            "--with-ipc",
+            "--ipc-pid-file",
+            relative_pid_path
+                .to_str()
+                .expect("Relative PID path should be valid UTF-8"),
+            "--ipc-bind",
+            socket_arg,
+            "--no-auto-match",
+            "--no-completion",
+            "--config",
+            config_arg,
+        ],
+        &[],
+        24,
+        80,
+        Some(&initial_dir),
+    )
+    .expect("Failed to spawn arf with IPC");
+    terminal.wait_for_prompt().expect("Should show prompt");
+
+    let pid_before = terminal.process_id().expect("Should have process ID");
+    assert_eq!(
+        std::fs::read_to_string(&pid_path).expect("PID file should be readable"),
+        pid_before.to_string()
+    );
+    assert!(
+        socket_path.exists(),
+        "Custom socket should exist before restart"
+    );
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear output before changing the working directory");
+    let changed_dir_arg = changed_dir
+        .path()
+        .to_str()
+        .expect("Changed directory should be valid UTF-8")
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    terminal
+        .send_line(&format!("setwd(\"{changed_dir_arg}\"); getwd()"))
+        .expect("Should change the R working directory before restart");
+    let changed_dir_text = changed_dir
+        .path()
+        .to_str()
+        .expect("Changed directory should be valid UTF-8");
+    terminal
+        .expect(&format!("[1] \"{changed_dir_text}\""))
+        .expect("R should report the changed working directory");
+
+    terminal
+        .clear_buffer()
+        .expect("Should clear output before restart");
+    terminal
+        .send_line(":restart!")
+        .expect("Should send :restart!");
+    terminal
+        .expect("Restarting R session...")
+        .expect("Should announce the restart");
+    terminal
+        .expect("is ready.")
+        .expect("Should wait for the replacement image");
+
+    assert!(pid_path.exists(), "PID file must remain during restart");
+    assert_eq!(
+        std::fs::read_to_string(&pid_path).expect("PID file should remain readable"),
+        pid_before.to_string()
+    );
+    UnixStream::connect(&socket_path)
+        .expect("Custom socket should accept connections after restart");
+    terminal.quit().expect("Should quit cleanly");
+    assert!(!pid_path.exists(), "PID file should be cleaned up on exit");
+}
+
+#[cfg(unix)]
+fn relative_path_from(base: &std::path::Path, target: &std::path::Path) -> std::path::PathBuf {
+    let base_components: Vec<_> = base.components().collect();
+    let target_components: Vec<_> = target.components().collect();
+    let common = base_components
+        .iter()
+        .zip(&target_components)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = std::path::PathBuf::new();
+    for _ in common..base_components.len() {
+        relative.push("..");
+    }
+    for component in target_components.iter().skip(common) {
+        relative.push(component.as_os_str());
+    }
+    relative
+}

--- a/crates/arf-console/tests/pty_regression_tests.rs
+++ b/crates/arf-console/tests/pty_regression_tests.rs
@@ -108,9 +108,15 @@ fn test_pty_restart_preserves_pid_file_ownership() {
     let socket_dir = tempfile::tempdir().expect("Should create a temp socket directory");
     let socket_path = socket_dir.path().join("custom.sock");
     let _ = std::fs::remove_file(&socket_path);
-    let socket_arg = socket_path
+    let relative_socket_path = relative_path_from(&initial_dir, &socket_path);
+    let socket_path_from_changed_dir = changed_dir.path().join(&relative_socket_path);
+    assert_ne!(
+        socket_path_from_changed_dir, socket_path,
+        "The relative IPC bind argument must resolve differently after setwd"
+    );
+    let socket_arg = relative_socket_path
         .to_str()
-        .expect("Socket path should be valid UTF-8");
+        .expect("Relative socket path should be valid UTF-8");
     let config_arg = config_path
         .to_str()
         .expect("Config path should be valid UTF-8");

--- a/crates/arf-console/tests/pty_regression_tests.rs
+++ b/crates/arf-console/tests/pty_regression_tests.rs
@@ -105,7 +105,11 @@ fn test_pty_restart_preserves_pid_file_ownership() {
         path_from_changed_dir, pid_path,
         "The relative PID argument must resolve differently after setwd"
     );
-    let socket_dir = tempfile::tempdir().expect("Should create a temp socket directory");
+    // Keep the socket under the test's initial directory. macOS limits the
+    // length of Unix socket addresses, and the system temp directory can have
+    // a much longer runner-specific prefix than this workspace path.
+    let socket_dir =
+        tempfile::tempdir_in(&initial_dir).expect("Should create a temp socket directory");
     let socket_path = socket_dir.path().join("custom.sock");
     let _ = std::fs::remove_file(&socket_path);
     let relative_socket_path = relative_path_from(&initial_dir, &socket_path);

--- a/crates/arf-libr/src/lib.rs
+++ b/crates/arf-libr/src/lib.rs
@@ -26,8 +26,6 @@ pub use types::{Rstart, SaType, UImode};
 // sys
 #[cfg(unix)]
 pub use sys::askpass_handler_code;
-#[cfg(unix)]
-pub use sys::ensure_ld_library_path_with_pre_exec;
 pub use sys::{
     ReadConsolePromptInfo, clear_r_interrupt_pending, clear_write_console_callback,
     command_had_error, ensure_ld_library_path, find_r_library, finish_ipc_capture,
@@ -39,4 +37,8 @@ pub use sys::{
     run_r_mainloop, set_r_auto_discovery_disabled, set_r_interrupt_pending,
     set_read_console_callback, set_reprex_mode, set_spinner_color, set_spinner_frames,
     set_write_console_callback, start_ipc_capture, start_spinner, stop_spinner, suppress_stderr,
+};
+#[cfg(unix)]
+pub use sys::{
+    ensure_ld_library_path_with_pre_exec, ensure_ld_library_path_with_pre_exec_and_args,
 };

--- a/crates/arf-libr/src/sys.rs
+++ b/crates/arf-libr/src/sys.rs
@@ -10,12 +10,14 @@ mod spinner;
 
 #[cfg(unix)]
 pub use askpass::askpass_handler_code;
-#[cfg(unix)]
-pub use discovery::ensure_ld_library_path_with_pre_exec;
 pub use discovery::{
     ensure_ld_library_path, find_r_library, get_r_home, is_r_auto_discovery_disabled,
     r_home_from_library_path, r_home_from_rhome_output, r_library_path,
     set_r_auto_discovery_disabled,
+};
+#[cfg(unix)]
+pub use discovery::{
+    ensure_ld_library_path_with_pre_exec, ensure_ld_library_path_with_pre_exec_and_args,
 };
 pub use error_state::{
     command_had_error, global_error_handler_code, mark_error_condition,

--- a/crates/arf-libr/src/sys/discovery.rs
+++ b/crates/arf-libr/src/sys/discovery.rs
@@ -290,6 +290,18 @@ pub fn ensure_ld_library_path_with_pre_exec<F>(pre_exec: F) -> RResult<bool>
 where
     F: FnOnce(),
 {
+    let args: Vec<_> = env::args_os().skip(1).collect();
+    ensure_ld_library_path_with_pre_exec_and_args(&args, pre_exec)
+}
+
+#[cfg(unix)]
+pub fn ensure_ld_library_path_with_pre_exec_and_args<F>(
+    args: &[std::ffi::OsString],
+    pre_exec: F,
+) -> RResult<bool>
+where
+    F: FnOnce(),
+{
     let lib_path = find_r_library()?;
     let Some(lib_dir) = lib_path.parent() else {
         return Ok(false);
@@ -313,9 +325,8 @@ where
     // SAFETY: We're about to exec, so modifying environment is safe
     unsafe { env::set_var("LD_LIBRARY_PATH", &new_path) };
 
-    // Re-execute the current process. Preserve OsString arguments so non-UTF-8
-    // paths (for example --ipc-pid-file) do not panic during re-exec.
-    let args: Vec<_> = env::args_os().skip(1).collect();
+    // Re-execute the current process with the caller's authoritative argv.
+    // Preserve OsString arguments so non-UTF-8 values do not get rewritten.
     let exe = env::current_exe().map_err(|e| RError::LibraryNotFound(e.to_string()))?;
 
     log::info!("Re-executing with LD_LIBRARY_PATH={}", new_path);

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -47,6 +47,21 @@ The server runs until interrupted by `Ctrl+C`, `SIGTERM`, or `arf ipc shutdown`.
 | `--no-r-source-overrides` | Disable directory-level R source overrides |
 | `--vanilla` | Start R without init files |
 
+### PID file lifecycle (interactive and headless)
+
+The PID file is the current-process pointer for an integration slot; it is not
+a readiness marker. Readiness is established by the IPC session metadata (or
+the `--json` output). Interactive `:restart` and `:switch` are a
+short transition: clients should use bounded retries, re-read the PID and
+session metadata, and detect the new generation by a changed `started_at`
+value. On Unix the replacement keeps ownership of a matching PID file. On
+Windows the parent relinquishes the file before spawning the replacement, so
+the file is briefly absent and then publishes a new PID. The default endpoint
+also changes because it contains the PID; each retry must resolve it again.
+An explicitly configured `--ipc-bind` path is reused by the replacement on
+both platforms. Headless sessions follow the same pointer/readiness contract
+until shutdown.
+
 ### JSON Output (`--json`)
 
 When `--json` is specified, arf prints session connection info to stdout as a single JSON object once the server is ready:

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -56,11 +56,16 @@ short transition: clients should use bounded retries, re-read the PID and
 session metadata, and detect the new generation by a changed `started_at`
 value. On Unix the replacement keeps ownership of a matching PID file. On
 Windows the parent relinquishes the file before spawning the replacement, so
-the file is briefly absent and then publishes a new PID. The default endpoint
-also changes because it contains the PID; each retry must resolve it again.
+the file is briefly absent and then publishes a new PID. On Windows only, the
+default endpoint also changes because it contains the child PID; each retry
+must resolve it again. On Unix the default endpoint path remains the same
+across an exec restart, although it is temporarily unavailable during the
+restart window. In both cases, `started_at` changes for the new generation.
 An explicitly configured `--ipc-bind` path is reused by the replacement on
-both platforms. Headless sessions follow the same pointer/readiness contract
-until shutdown.
+both platforms. For an interactive session, a relative custom path is resolved
+once against arf's initial working directory, before R startup profiles can
+change it. Headless sessions follow the same pointer/readiness contract until
+shutdown.
 
 ### JSON Output (`--json`)
 


### PR DESCRIPTION
## Summary

- preserve --ipc-pid-file ownership across restart and switch
- keep relative IPC bind and PID paths tied to the initial working directory
- document the PID-file and endpoint lifecycle without duplicating force-command variants

## Design

- treat normalized CLI argv as the authoritative source for restart-sensitive paths
- on Unix, pass the owned PID-file descriptor across exec and adopt it only after validating the regular file, device/inode, path, and current PID contents
- reject stale or spoofed descriptor carriers without closing or mutating unrelated descriptors
- on Windows, retain the existing stop, relinquish, and exclusive child-create handoff
- pass normalized argv through the loader re-exec path while preserving unrelated non-UTF arguments

## Testing

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-targets --all-features --locked

The regression coverage includes relative PID/bind paths after setwd(), restart ownership, custom socket reuse, existing PID-file rejection, argv normalization, and inherited descriptor validation.

Windows runtime and cross-target compilation were not available locally; the existing Windows handoff behavior is covered by the documented CI/manual verification plan.

Closes #342