### PR TITLE
chore: prepare release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@
 
 ### Added
 
-- arf now warns when R's `prompt` and `continue` options are set to the same string, which makes the two prompt types indistinguishable (#328).
 - **Experimental:** Opt-in `json-key` R source override provider for reading a version from JSON files such as `renv.lock` (`{ type = "json-key", file = "renv.lock", key = "R.Version" }`) (#321).
 
 ### Fixed
 
-- A continuation prompt set with `options(continue = ...)` is now classified correctly, so history recording, formatting, and display no longer treat continuation lines as new top-level input (#327).
+- A continuation prompt set with `options(continue = ...)` is now classified correctly, so history recording, formatting, and display no longer treat continuation lines as new top-level input. When `prompt` and `continue` are set to the same string, arf warns that the two cannot be told apart (#327, #328).
 - Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).
 - **Experimental:** IPC PID file ownership and handoff now preserve tracking across interactive `:restart` and `:switch`; relative paths and loader re-exec are preserved across the replacement (#342).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-01
+
 ### Added
 
+- arf now warns when R's `prompt` and `continue` options are set to the same string, which makes the two prompt types indistinguishable (#328).
 - **Experimental:** Opt-in `json-key` R source override provider for reading a version from JSON files such as `renv.lock` (`{ type = "json-key", file = "renv.lock", key = "R.Version" }`) (#321).
 
 ### Fixed
 
+- A continuation prompt set with `options(continue = ...)` is now classified correctly, so history recording, formatting, and display no longer treat continuation lines as new top-level input (#327).
 - Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).
 - **Experimental:** IPC PID file ownership and handoff now preserve tracking across interactive `:restart` and `:switch`; relative paths and loader re-exec are preserved across the replacement (#342).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "arf-console"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arf-libr",
  "insta",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1619,7 +1619,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "htmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.5.0", path = "crates/arf-harp" }
-arf-libr = { version = "0.5.0", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.5.0", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.5.1", path = "crates/arf-harp" }
+arf-libr = { version = "0.5.1", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.5.1", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: emacs
 # Reprex: on | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_format_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_format_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: emacs
 # Reprex: format | Comment: "#> " | Formatter: auto (air)
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: emacs
 # Reprex: on | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.0
+# arf console v0.5.1
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump the workspace version from 0.5.0 to 0.5.1 and refresh `Cargo.lock` for the workspace packages
- Finalize the CHANGELOG `[Unreleased]` section as `[0.5.1] - 2026-09-01` and open a fresh `[Unreleased]`
- Update the banner snapshots for the new version string

The changelog gained two entries that were not yet recorded: the custom continuation prompt classification fix (#327) and the ambiguous prompt option warning (#328), consolidated into a single Fixed entry since they are part of the same change. The remaining commits since 0.5.0 are dependency bumps, CI configuration, and a clippy fix, which are not user-facing.

## Changelog

```markdown
## [0.5.1] - 2026-09-01

### Added

- **Experimental:** Opt-in `json-key` R source override provider for reading a version from JSON files such as `renv.lock` (`{ type = "json-key", file = "renv.lock", key = "R.Version" }`) (#321).

### Fixed

- A continuation prompt set with `options(continue = ...)` is now classified correctly, so history recording, formatting, and display no longer treat continuation lines as new top-level input. When `prompt` and `continue` are set to the same string, arf warns that the two cannot be told apart (#327, #328).
- Vi pending character motions now correctly accept `v` as the motion character instead of entering visual mode (#329).
- **Experimental:** IPC PID file ownership and handoff now preserve tracking across interactive `:restart` and `:switch`; relative paths and loader re-exec are preserved across the replacement (#342).
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test --workspace` (1359 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRYyZ6uGxJHZJcTncQeWP6
