### PR TITLE
refactor: use raw strings for embedded quotes

### DIFF
--- a/crates/arf-console/src/app/config_load.rs
+++ b/crates/arf-console/src/app/config_load.rs
@@ -228,7 +228,7 @@ mod tests {
             crate::config::HistoryMode::Volatile
         ));
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("history.mode = \"volatile\""));
+        assert!(warnings[0].contains(r#"history.mode = "volatile""#));
     }
 
     #[test]

--- a/crates/arf-console/src/app/setup/overrides.rs
+++ b/crates/arf-console/src/app/setup/overrides.rs
@@ -331,7 +331,7 @@ where
             diagnostics.push(warning(
                 "r_source_override.provider_unsupported",
                 format!(
-                    "Warning: R version \"{name}\" from {} is unsupported in the R source override path; trying the next R source override.",
+                    r#"Warning: R version "{name}" from {} is unsupported in the R source override path; trying the next R source override."#,
                     provider.location()
                 ),
                 provider.file_path(),
@@ -425,7 +425,7 @@ where
                 diagnostics.push(warning(
                     "r_source_override.resolution_failed",
                     format!(
-                        "Warning: Failed to use R version \"{}\" from {}: {error}; trying the next R source override.",
+                        r#"Warning: Failed to use R version "{}" from {}: {error}; trying the next R source override."#,
                         trimmed_version,
                         provider.location()
                     ),
@@ -866,7 +866,7 @@ mod r_source_override_tests {
         assert!(status.rig_enabled());
         assert_eq!(
             status.display(),
-            "rig (R 4.4.2; override: toml-key rproject.toml:project.r_version = \"4.4\")"
+            r#"rig (R 4.4.2; override: toml-key rproject.toml:project.r_version = "4.4")"#
         );
     }
 
@@ -958,7 +958,7 @@ mod r_source_override_tests {
 
         assert_eq!(
             script_override_notice(&report).as_deref(),
-            Some("# R source override: version-file .r-version = \"4.4\"")
+            Some(r#"# R source override: version-file .r-version = "4.4""#)
         );
     }
 

--- a/crates/arf-console/src/completion/r_completer/tests.rs
+++ b/crates/arf-console/src/completion/r_completer/tests.rs
@@ -348,7 +348,7 @@ fn test_detect_library_context_comma_skipped() {
 
 #[test]
 fn test_detect_library_context_quoted_skipped() {
-    let result = detect_library_context("library(\"dpl", 12, &lib_funcs());
+    let result = detect_library_context(r#"library("dpl"#, 12, &lib_funcs());
     assert_eq!(result, None);
 }
 

--- a/crates/arf-console/src/completion/shell.rs
+++ b/crates/arf-console/src/completion/shell.rs
@@ -180,7 +180,7 @@ impl ShellCompleter {
                 if s.value.ends_with('\\') {
                     s.value.push('\\');
                 }
-                s.value = format!("\"{}\"", s.value);
+                s.value = format!(r#""{}""#, s.value);
                 if let Some(match_indices) = &mut s.match_indices {
                     for index in match_indices.iter_mut() {
                         *index += 1;

--- a/crates/arf-console/src/completion/string_context.rs
+++ b/crates/arf-console/src/completion/string_context.rs
@@ -184,8 +184,8 @@ pub fn detect_string_context(line: &str, cursor_pos: usize) -> Option<StringCont
         let string_text = &line[string_start..string_end.min(line.len())];
 
         // Determine quote type and extract content
-        let (quote_char, content_start_offset) = if string_text.starts_with("r\"")
-            || string_text.starts_with("R\"")
+        let (quote_char, content_start_offset) = if string_text.starts_with(r#"r""#)
+            || string_text.starts_with(r#"R""#)
             || string_text.starts_with("r'")
             || string_text.starts_with("R'")
         {

--- a/crates/arf-console/src/config/editor.rs
+++ b/crates/arf-console/src/config/editor.rs
@@ -45,7 +45,7 @@ pub enum AutoSuggestions {
 /// Custom JSON schema for AutoSuggestions that accepts both boolean and string values.
 fn auto_suggestions_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
-        "description": "History-based autosuggestions mode. Accepts boolean (true/false) or string (\"none\", \"all\", \"cwd\").",
+        "description": r#"History-based autosuggestions mode. Accepts boolean (true/false) or string ("none", "all", "cwd")."#,
         "oneOf": [
             {
                 "type": "boolean",
@@ -101,7 +101,7 @@ impl<'de> Deserialize<'de> for AutoSuggestions {
             type Value = AutoSuggestions;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a boolean or string (\"none\", \"all\", \"cwd\")")
+                formatter.write_str(r#"a boolean or string ("none", "all", "cwd")"#)
             }
 
             fn visit_bool<E>(self, value: bool) -> Result<AutoSuggestions, E>

--- a/crates/arf-console/src/config/experimental.rs
+++ b/crates/arf-console/src/config/experimental.rs
@@ -177,7 +177,7 @@ impl JsonSchema for SpinnerConfigSchema {
             "properties": {
                 "frames": {
                     "type": "string",
-                    "description": "Spinner animation frames as a string where each character is one frame. Empty string disables the spinner. Example: \"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏\" (braille dots), \"|/-\\\\\" (ASCII spinner).",
+                    "description": r#"Spinner animation frames as a string where each character is one frame. Empty string disables the spinner. Example: "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏" (braille dots), "|/-\\" (ASCII spinner)."#,
                     "default": ""
                 },
                 "color": color_prop!("Color for the spinner.", default = "Cyan")

--- a/crates/arf-console/src/config/mod.rs
+++ b/crates/arf-console/src/config/mod.rs
@@ -265,8 +265,7 @@ fn removed_reprex_keys(document: &toml::Value) -> Option<String> {
         .and_then(|value| value.get("mode"))
         .is_some()
     {
-        messages
-            .push("[startup.mode] was removed; use [startup] reprex = \"off\"|\"on\"|\"format\"");
+        messages.push(r#"[startup.mode] was removed; use [startup] reprex = "off"|"on"|"format""#);
     }
     if document
         .get("mode")
@@ -303,11 +302,11 @@ fn history_migration_warning(document: &toml::Value) -> Option<String> {
     let has_legacy_dir = history.contains_key("dir");
     match (has_mode, has_legacy_dir, disabled) {
         (true, _, Some(_)) => Some("Config key history.disabled is deprecated and ignored because history.mode is set; use history.mode only.".to_string()),
-        (false, true, Some(true)) => Some("Config keys history.disabled and history.dir are deprecated; use history.mode = \"volatile\" instead.".to_string()),
-        (false, true, Some(false)) => Some("Config keys history.disabled and history.dir are deprecated; use persistent history.mode = { dir = \"...\" } instead.".to_string()),
-        (false, true, None) => Some("Config key history.dir is deprecated; use history.mode = { dir = \"...\" } instead.".to_string()),
-        (false, false, Some(true)) => Some("Config key history.disabled is deprecated; use history.mode = \"volatile\" instead.".to_string()),
-        (false, false, Some(false)) => Some("Config key history.disabled is deprecated; use history.mode = \"persistent\" instead.".to_string()),
+        (false, true, Some(true)) => Some(r#"Config keys history.disabled and history.dir are deprecated; use history.mode = "volatile" instead."#.to_string()),
+        (false, true, Some(false)) => Some(r#"Config keys history.disabled and history.dir are deprecated; use persistent history.mode = { dir = "..." } instead."#.to_string()),
+        (false, true, None) => Some(r#"Config key history.dir is deprecated; use history.mode = { dir = "..." } instead."#.to_string()),
+        (false, false, Some(true)) => Some(r#"Config key history.disabled is deprecated; use history.mode = "volatile" instead."#.to_string()),
+        (false, false, Some(false)) => Some(r#"Config key history.disabled is deprecated; use history.mode = "persistent" instead."#.to_string()),
         _ => None,
     }
 }
@@ -715,7 +714,7 @@ mode = "volatile"
         let serialized = toml::to_string(&config).unwrap();
         assert!(
             serialized.contains("[history.mode]")
-                && serialized.contains("dir = \"/custom/history\""),
+                && serialized.contains(r#"dir = "/custom/history""#),
             "serialized history config used an unexpected TOML shape: {serialized}"
         );
         assert!(!serialized.contains("[history]\ndir = "));
@@ -1094,7 +1093,7 @@ allowed_functions = ["mean", "stats::median", "+"]
 
         // Reprex mode is part of the startup section.
         assert!(
-            config_str.contains("reprex = \"off\""),
+            config_str.contains(r#"reprex = "off""#),
             "Should have reprex mode in startup section"
         );
 
@@ -1124,7 +1123,7 @@ allowed_functions = ["mean", "stats::median", "+"]
             "Should have [editor] section"
         );
         assert!(
-            config_str.contains("mode = \"persistent\""),
+            config_str.contains(r#"mode = "persistent""#),
             "History should default to persistent mode"
         );
         assert!(

--- a/crates/arf-console/src/config/startup.rs
+++ b/crates/arf-console/src/config/startup.rs
@@ -110,7 +110,7 @@ impl RSourceOverrideInfo {
             (None, None) => "pixi".to_string(),
         };
         format!(
-            "{} {} = \"{}\"",
+            r#"{} {} = "{}""#,
             self.provider, source, self.requested_version
         )
     }

--- a/crates/arf-console/src/editor/validator.rs
+++ b/crates/arf-console/src/editor/validator.rs
@@ -373,7 +373,7 @@ mod tests {
         assert!(is_incomplete(validator.validate("x[")));
 
         // Unclosed strings
-        assert!(is_incomplete(validator.validate("\"hello")));
+        assert!(is_incomplete(validator.validate(r#""hello"#)));
         assert!(is_incomplete(validator.validate("'world")));
 
         // Trailing operators
@@ -504,7 +504,7 @@ mod tests {
         // Raw-string-like text that is actually just content of an ordinary
         // unclosed double-quoted string must not be misdetected here; it's
         // still correctly caught as Incomplete by the generic MISSING-close check.
-        assert!(is_incomplete(validator.validate("\"foo r'(bar")));
+        assert!(is_incomplete(validator.validate(r#""foo r'(bar"#)));
 
         // Malformed non-raw forms (missing quote/delimiter) are not raw
         // strings at all and must not spuriously match this workaround;

--- a/crates/arf-console/src/history/import.rs
+++ b/crates/arf-console/src/history/import.rs
@@ -849,7 +849,7 @@ fn read_history_table(
     // Table names are validated by validate_table_name() before reaching here.
     let columns = HistoryTableColumns::read(db, table_name)?;
     let query = format!(
-        "SELECT id, command_line, start_timestamp, {}, {}, {}, {}, {}, {} FROM \"{}\" ORDER BY id",
+        r#"SELECT id, command_line, start_timestamp, {}, {}, {}, {}, {}, {} FROM "{}" ORDER BY id"#,
         columns.expression("session_id"),
         columns.expression("hostname"),
         columns.expression("cwd"),
@@ -954,7 +954,7 @@ struct HistoryTableColumns {
 impl HistoryTableColumns {
     fn read(db: &rusqlite::Connection, table_name: &str) -> Result<Self> {
         let mut names = HashSet::new();
-        let query = format!("PRAGMA table_info(\"{}\")", table_name);
+        let query = format!(r#"PRAGMA table_info("{}")"#, table_name);
         let mut stmt = db
             .prepare(&query)
             .context("Failed to inspect history table")?;

--- a/crates/arf-console/src/ipc/capture.rs
+++ b/crates/arf-console/src/ipc/capture.rs
@@ -234,7 +234,7 @@ mod tests {
         let path = tmpdir.join(".arf_test_capture_val.dat");
 
         // value present, error absent
-        let value = b"[1] \"hello\"";
+        let value = br#"[1] "hello""#;
         let header = format!("{} -1\n", value.len());
         let mut file = std::fs::File::create(&path).unwrap();
         file.write_all(header.as_bytes()).unwrap();
@@ -244,7 +244,7 @@ mod tests {
         let result = parse_capture_file(&path);
         let _ = std::fs::remove_file(&path);
 
-        assert_eq!(result.value.as_deref(), Some("[1] \"hello\""));
+        assert_eq!(result.value.as_deref(), Some(r#"[1] "hello""#));
         assert!(result.error.is_none());
         // Verify JSON serialization
         let json = serde_json::to_string(&result).unwrap();

--- a/crates/arf-console/src/ipc/server/tests.rs
+++ b/crates/arf-console/src/ipc/server/tests.rs
@@ -3,13 +3,13 @@ use super::*;
 #[test]
 fn test_extract_body_http() {
     let http = b"POST / HTTP/1.1\r\nContent-Type: application/json\r\n\r\n{\"jsonrpc\":\"2.0\"}";
-    assert_eq!(extract_body(http), b"{\"jsonrpc\":\"2.0\"}");
+    assert_eq!(extract_body(http), br#"{"jsonrpc":"2.0"}"#);
 }
 
 #[test]
 fn test_extract_body_raw_json() {
-    let raw = b"{\"jsonrpc\":\"2.0\"}";
-    assert_eq!(extract_body(raw), b"{\"jsonrpc\":\"2.0\"}");
+    let raw = br#"{"jsonrpc":"2.0"}"#;
+    assert_eq!(extract_body(raw), br#"{"jsonrpc":"2.0"}"#);
 }
 
 /// Tests that dispatch_request rejects both evaluate and user_input

--- a/crates/arf-console/src/pager/history_schema.rs
+++ b/crates/arf-console/src/pager/history_schema.rs
@@ -217,11 +217,11 @@ fn generate_schema_lines(history_path: &str) -> Vec<String> {
     lines.push(String::new());
     lines.push("con <- dbConnect(".to_string());
     lines.push("  RSQLite::SQLite(),".to_string());
-    lines.push(format!("  \"{}/r.db\"", history_path));
+    lines.push(format!(r#"  "{}/r.db""#, history_path));
     lines.push(")".to_string());
     lines.push("history_data <- dbGetQuery(".to_string());
     lines.push("  con,".to_string());
-    lines.push("  \"SELECT * FROM history ORDER BY id DESC LIMIT 10\"".to_string());
+    lines.push(r#"  "SELECT * FROM history ORDER BY id DESC LIMIT 10""#.to_string());
     lines.push(") |>".to_string());
     lines.push("  as_tibble()".to_string());
     lines.push("dbDisconnect(con)".to_string());
@@ -646,7 +646,7 @@ fn print_r_example_code(s: &SchemaStyles, history_path: &str) {
     println!("  RSQLite::{}(),", s.r_keyword.paint("SQLite"));
     println!(
         "  {}",
-        s.r_string.paint(format!("\"{}/r.db\"", history_path))
+        s.r_string.paint(format!(r#""{}/r.db""#, history_path))
     );
     println!(")");
 
@@ -660,7 +660,7 @@ fn print_r_example_code(s: &SchemaStyles, history_path: &str) {
     println!(
         "  {}",
         s.r_string
-            .paint("\"SELECT * FROM history ORDER BY id DESC LIMIT 10\"")
+            .paint(r#""SELECT * FROM history ORDER BY id DESC LIMIT 10""#)
     );
     println!(") {}", s.r_operator.paint("|>"));
     println!("  {}()", s.r_keyword.paint("as_tibble"));

--- a/crates/arf-console/src/repl/banner.rs
+++ b/crates/arf-console/src/repl/banner.rs
@@ -149,7 +149,7 @@ mod tests {
         let banner = format_banner(&config, true, Some(&info), Some(FormatterBackend::Air));
         assert!(
             banner.contains(
-                "# R source override: toml-key rproject.toml:project.r_version = \"4.4\""
+                r#"# R source override: toml-key rproject.toml:project.r_version = "4.4""#,
             )
         );
     }
@@ -166,7 +166,7 @@ mod tests {
         let line = format_override_line(&info);
         assert_eq!(
             line,
-            "# R source override: version-file .r-version = \"4.4\""
+            r#"# R source override: version-file .r-version = "4.4""#
         );
         assert!(!line.contains('\n'));
     }

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -114,7 +114,7 @@ pub(super) fn read_console_callback(
             prompt_info.options_are_ambiguous,
         ) {
             arf_eprintln!(
-                "Warning: options(\"prompt\") and options(\"continue\") are identical; arf cannot distinguish top-level and continuation prompts."
+                r#"Warning: options("prompt") and options("continue") are identical; arf cannot distinguish top-level and continuation prompts."#
             );
         }
 

--- a/crates/arf-console/tests/tui/history.rs
+++ b/crates/arf-console/tests/tui/history.rs
@@ -189,17 +189,17 @@ fn history_menu_selection_replaces_auto_matched_quote_pair() -> Result<()> {
         "history-menu-quote-pair",
         &["--no-completion"],
         |terminal| {
-            terminal.submit("nchar(\"``\")", "[1] 2", PROMPT)?;
+            terminal.submit(r#"nchar("``")"#, "[1] 2", PROMPT)?;
             let checkpoint = terminal.checkpoint()?;
             terminal.write("`")?;
             terminal.wait_for("auto-matched quote pair", |_, line| line.contains("``"))?;
             terminal.write("\x12")?;
             terminal.wait_for("quote history item is visible", |state, _| {
-                state.text.contains("Page 1:") && state.text.contains("nchar(\"``\")")
+                state.text.contains("Page 1:") && state.text.contains(r#"nchar("``")"#)
             })?;
             terminal.key("Enter")?;
             terminal.wait_for("quote history item replaces buffer", |_, line| {
-                line.trim_end() == "ARF> nchar(\"``\")"
+                line.trim_end() == r#"ARF> nchar("``")"#
             })?;
             terminal.key("Enter")?;
             terminal.wait_for_prompt(None, PROMPT)?;

--- a/crates/arf-console/tests/tui/input.rs
+++ b/crates/arf-console/tests/tui/input.rs
@@ -158,10 +158,10 @@ fn backtick_error_does_not_crash_and_repl_recovers() -> Result<()> {
 #[test]
 fn multiline_raw_string_round_trip() -> Result<()> {
     run_case("multiline-raw-string", &["--no-auto-match"], |terminal| {
-        terminal.write("x <- r\"(hello")?;
+        terminal.write(r#"x <- r"(hello"#)?;
         terminal.key("Enter")?;
         terminal.wait_for("raw string continuation", |_, line| line.trim_end() == "+")?;
-        terminal.write("world)\"")?;
+        terminal.write(r#"world)""#)?;
         terminal.key("Enter")?;
         terminal.wait_for_prompt(None, PROMPT)?;
         terminal.submit("nchar(x)", "[1] 11", PROMPT)
@@ -179,7 +179,7 @@ fn multiline_quoted_string_preserves_newline() -> Result<()> {
             terminal.wait_for("quoted string continuation", |_, line| {
                 line.trim_end() == "+"
             })?;
-            terminal.write("end\"")?;
+            terminal.write(r#"end""#)?;
             terminal.key("Enter")?;
             terminal.wait_for_prompt(None, PROMPT)?;
             terminal.submit("nchar(x)", "[1] 8", PROMPT)?;

--- a/crates/arf-console/tests/tui/prompt.rs
+++ b/crates/arf-console/tests/tui/prompt.rs
@@ -41,12 +41,12 @@ continuation = "CONT> "
                     .output_since(options_checkpoint)?
                     .contains("options(continue ")
             );
-            terminal.write("x <- r\"(hello")?;
+            terminal.write(r#"x <- r"(hello"#)?;
             terminal.key("Enter")?;
             terminal.wait_for("custom continuation prompt", |_, line| {
                 line.trim_end() == "CONT>"
             })?;
-            terminal.write("world)\"")?;
+            terminal.write(r#"world)""#)?;
             terminal.key("Enter")?;
             terminal.wait_for("custom main prompt after completion", |_, line| {
                 line.trim_end() == "MAIN>"
@@ -147,7 +147,7 @@ continuation = "CONT> "
 
 #[test]
 fn identical_r_prompts_warn_once_per_transition() -> Result<()> {
-    const WARNING: &str = "# [arf] Warning: options(\"prompt\") and options(\"continue\") are identical; arf cannot distinguish top-level and continuation prompts.";
+    const WARNING: &str = r#"# [arf] Warning: options("prompt") and options("continue") are identical; arf cannot distinguish top-level and continuation prompts."#;
 
     run_case("identical-r-prompts", &["--no-auto-match"], |terminal| {
         terminal.enter("options(prompt = '> ', continue = '> ')")?;

--- a/crates/arf-console/tests/tui/shell.rs
+++ b/crates/arf-console/tests/tui/shell.rs
@@ -62,7 +62,7 @@ fn readline_accepts_input_and_returns_to_r_prompt() -> Result<()> {
             state
                 .text
                 .lines()
-                .any(|line| line.contains("\"readline_answer\""))
+                .any(|line| line.contains(r#""readline_answer""#))
                 && line.trim_end() == PROMPT
         })
     })

--- a/crates/arf-harp/tests/startup.rs
+++ b/crates/arf-harp/tests/startup.rs
@@ -43,7 +43,7 @@ fn test_lib_paths_re_evaluates_after_r_lib_paths_changes() {
 
         assert!(!baseline.iter().any(|path| path == &new_path));
         eval_string_in_base(&format!(
-            "invisible(.libPaths(c(\"{}\", .libPaths())))",
+            r#"invisible(.libPaths(c("{}", .libPaths())))"#,
             escape_r_string(&new_path)
         ))
         .expect(".libPaths() should accept the extra directory");
@@ -71,7 +71,7 @@ impl Drop for LibPathsRestore {
         let paths = self
             .paths
             .iter()
-            .map(|path| format!("\"{}\"", escape_r_string(path)))
+            .map(|path| format!(r#""{}""#, escape_r_string(path)))
             .collect::<Vec<_>>()
             .join(", ");
         if let Err(error) = eval_string_in_base(&format!("invisible(.libPaths(c({paths})))")) {
@@ -83,7 +83,7 @@ impl Drop for LibPathsRestore {
 fn escape_r_string(value: &str) -> String {
     value
         .replace('\\', "\\\\")
-        .replace('"', "\\\"")
+        .replace('"', r#"\""#)
         .replace('\n', "\\n")
         .replace('\r', "\\r")
 }

--- a/crates/arf-libr/src/sys/tests.rs
+++ b/crates/arf-libr/src/sys/tests.rs
@@ -186,7 +186,7 @@ fn test_strip_cr() {
 
     // Standalone CR should also be stripped
     let stripped = strip_cr("Error: \"{\r\" の)");
-    assert_eq!(stripped, "Error: \"{\" の)");
+    assert_eq!(stripped, r#"Error: "{" の)"#);
 
     // Mixed line endings: all CR should be removed
     let stripped = strip_cr("line1\r\nline2\nline3\r");


### PR DESCRIPTION
## Summary

- replace 52 escaped-quote literals across 22 Rust files with equivalent raw strings
- cover R input and terminal expectations, configuration diagnostics, SQL/JSON fixtures, and string-generation helpers
- retain ordinary strings where control characters, line continuations, escaping behavior, or raw delimiters would make the result less clear

This follows up on the TUI test migration in #347 and restores the codebase-wide raw-string style established by the earlier escaped-quote cleanup. The change is readability-only and preserves the runtime string and byte contents.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p arf-console --bin arf` (995 passed, 6 ignored)
- `cargo test -p arf-console --test tui_tests` (82 passed, 1 known ignored test)
- `cargo test -p arf-harp --test startup` (10 passed)
- `cargo test -p arf-libr test_strip_cr` (1 passed)
- `cargo check --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- roborev job 1199: no issues found
