### PR TITLE
fix: restore terminal mode after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the original Unix terminal mode after the first interactive reedline input so terminal security indicators are not triggered by a startup-only `ECHO` suppression state (#352).
+
 ## [0.5.1] - 2026-09-01
 
 ### Added

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -57,9 +57,13 @@ mod imp {
 
     /// Complete the handoff from startup input suppression to reedline.
     ///
-    /// Windows keeps the startup snapshot until process exit. Reedline owns
-    /// the console mode after its first successful read, so there is no
-    /// startup mode to restore at this boundary.
+    /// The patched crossterm Windows implementation does not restore a
+    /// pre-raw snapshot when `disable_raw_mode()` runs. It reads the current
+    /// mode and re-enables the three non-raw bits (`ENABLE_LINE_INPUT`,
+    /// `ENABLE_ECHO_INPUT`, and `ENABLE_PROCESSED_INPUT`), so startup's
+    /// echo-off mode cannot remain as the cooked baseline after the first
+    /// read. Keep the guard's full snapshot until process exit, though, so
+    /// cleanup still restores all console state, including VT-input bits.
     pub(crate) fn handoff_to_reedline() -> std::io::Result<()> {
         Ok(())
     }
@@ -183,10 +187,18 @@ mod imp {
     /// Restore the mode captured before startup suppression after reedline has
     /// returned from its first raw-mode read.
     ///
+    /// Unix crossterm snapshots the complete termios immediately before
+    /// enabling raw mode, then restores that snapshot in
+    /// `disable_raw_mode()`. Because startup already cleared ECHO, that
+    /// snapshot would otherwise become the cooked baseline again. This
+    /// explicit handoff restores the true startup mode after the first read.
+    ///
     /// This is deliberately called after `read_line()` returns. Restoring just
     /// before that call would leave a window in which early PTY input could be
     /// echoed before reedline enables raw mode. A failed restore leaves both
-    /// the pending flag and the snapshot intact so Drop/atexit can retry it.
+    /// the pending flag and the snapshot intact solely so Drop/atexit cleanup
+    /// can retry it; normal R or standalone processing must stop while the
+    /// terminal state is unknown.
     pub(crate) fn handoff_to_reedline() -> std::io::Result<()> {
         if !STARTUP_RESTORE_PENDING.load(Ordering::Acquire) {
             return Ok(());

--- a/crates/arf-console/src/console_mode.rs
+++ b/crates/arf-console/src/console_mode.rs
@@ -55,6 +55,15 @@ mod imp {
         }
     }
 
+    /// Complete the handoff from startup input suppression to reedline.
+    ///
+    /// Windows keeps the startup snapshot until process exit. Reedline owns
+    /// the console mode after its first successful read, so there is no
+    /// startup mode to restore at this boundary.
+    pub(crate) fn handoff_to_reedline() -> std::io::Result<()> {
+        Ok(())
+    }
+
     fn stdin_handle() -> Option<HANDLE> {
         let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
         if handle.is_null() || handle == INVALID_HANDLE_VALUE {
@@ -129,6 +138,10 @@ mod imp {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     static ORIGINAL_TERMIOS: Mutex<Option<libc::termios>> = Mutex::new(None);
+    // The startup snapshot remains available for Drop/atexit restoration after
+    // the one-time handoff. Keeping these responsibilities separate prevents
+    // the startup guard from becoming reedline's baseline terminal state.
+    static STARTUP_RESTORE_PENDING: AtomicBool = AtomicBool::new(false);
     static ATEXIT_REGISTERED: AtomicBool = AtomicBool::new(false);
 
     /// Restores the original terminal mode when dropped.
@@ -148,6 +161,7 @@ mod imp {
                 let mut mode: libc::termios = unsafe { std::mem::zeroed() };
                 if unsafe { libc::tcgetattr(libc::STDIN_FILENO, &mut mode) } == 0 {
                     *original = Some(mode);
+                    STARTUP_RESTORE_PENDING.store(true, Ordering::Release);
                     disable_echo_input(&mode);
                 }
             }
@@ -163,6 +177,36 @@ mod imp {
     impl Drop for ConsoleModeGuard {
         fn drop(&mut self) {
             restore_original_input_mode();
+        }
+    }
+
+    /// Restore the mode captured before startup suppression after reedline has
+    /// returned from its first raw-mode read.
+    ///
+    /// This is deliberately called after `read_line()` returns. Restoring just
+    /// before that call would leave a window in which early PTY input could be
+    /// echoed before reedline enables raw mode. A failed restore leaves both
+    /// the pending flag and the snapshot intact so Drop/atexit can retry it.
+    pub(crate) fn handoff_to_reedline() -> std::io::Result<()> {
+        if !STARTUP_RESTORE_PENDING.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let original = match ORIGINAL_TERMIOS.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let Some(mode) = original.as_ref() else {
+            STARTUP_RESTORE_PENDING.store(false, Ordering::Release);
+            return Ok(());
+        };
+
+        if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, mode) } == 0 {
+            STARTUP_RESTORE_PENDING.store(false, Ordering::Release);
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
         }
     }
 
@@ -207,6 +251,7 @@ mod imp {
 
         if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, mode) } == 0 {
             *original = None;
+            STARTUP_RESTORE_PENDING.store(false, Ordering::Release);
         } else {
             log::warn!(
                 "Failed to restore terminal input mode: {}",
@@ -229,5 +274,6 @@ mod imp {
 }
 
 pub(crate) use imp::ConsoleModeGuard;
+pub(crate) use imp::handoff_to_reedline;
 #[cfg(unix)]
 pub(crate) use imp::restore_original_input_mode;

--- a/crates/arf-console/src/repl/mod.rs
+++ b/crates/arf-console/src/repl/mod.rs
@@ -845,7 +845,18 @@ impl Repl {
         let mut dir_stack: Vec<std::path::PathBuf> = Vec::new();
 
         loop {
-            match line_editor.read_line(&prompt) {
+            let read_result = line_editor.read_line(&prompt);
+            // Keep startup echo suppression through the raw-mode transition.
+            // Restore the original cooked mode after reedline returns so its
+            // raw-mode handoff has no interval in which input can be echoed.
+            if read_result.is_ok()
+                && let Err(error) = crate::console_mode::handoff_to_reedline()
+            {
+                eprintln!("Error: {}", error);
+                break;
+            }
+
+            match read_result {
                 Ok(Signal::Success(line)) => {
                     let save_outcome = history_handle.receipt_outcome();
 

--- a/crates/arf-console/src/repl/read_console.rs
+++ b/crates/arf-console/src/repl/read_console.rs
@@ -275,7 +275,19 @@ pub(super) fn read_console_callback(
             // Track whether we're in a non-standard prompt mode (menu selection, etc.)
             let is_menu_prompt = prompt_kind.is_other();
 
-            match editor.read_line(&prompt) {
+            let read_result = editor.read_line(&prompt);
+            // Keep startup echo suppression through the raw-mode transition.
+            // The original cooked mode is restored only after reedline returns,
+            // so early PTY input cannot pass through an echo window.
+            if read_result.is_ok()
+                && let Err(error) = crate::console_mode::handoff_to_reedline()
+            {
+                eprintln!("Error: {}", error);
+                state.should_exit = true;
+                return None;
+            }
+
+            match read_result {
                 Ok(Signal::Success(line)) => {
                     let save_outcome = history_handle.receipt_outcome();
 

--- a/crates/arf-console/tests/tui/input.rs
+++ b/crates/arf-console/tests/tui/input.rs
@@ -320,7 +320,7 @@ fn bracketed_paste_before_first_prompt_is_not_echoed() -> Result<()> {
 fn cooked_terminal_mode_is_restored_during_evaluation() -> Result<()> {
     run_case("cooked-terminal-mode", &[], |terminal| {
         terminal.enter(
-            "system(\"printf 'ARF_TERM_BEGIN_352\\n'; stty -a 2>&1; printf 'ARF_TERM_END_352\\n'\")",
+            r#"system("printf 'ARF_TERM_BEGIN_352\n'; stty -a 2>&1; printf 'ARF_TERM_END_352\n'")"#,
         )?;
         terminal.wait_for("cooked terminal mode", |state, line| {
             let Some(begin) = state.text.rfind("ARF_TERM_BEGIN_352") else {

--- a/crates/arf-console/tests/tui/input.rs
+++ b/crates/arf-console/tests/tui/input.rs
@@ -312,6 +312,36 @@ fn bracketed_paste_before_first_prompt_is_not_echoed() -> Result<()> {
     )
 }
 
+/// The startup guard must not remain the terminal mode baseline once reedline
+/// has completed its first raw-mode read. Inspect the PTY from R evaluation so
+/// this exercises the same terminal inherited by child processes.
+#[cfg(unix)]
+#[test]
+fn cooked_terminal_mode_is_restored_during_evaluation() -> Result<()> {
+    run_case("cooked-terminal-mode", &[], |terminal| {
+        terminal.enter(
+            "system(\"printf 'ARF_TERM_BEGIN_352\\n'; stty -a 2>&1; printf 'ARF_TERM_END_352\\n'\")",
+        )?;
+        terminal.wait_for("cooked terminal mode", |state, line| {
+            let Some(begin) = state.text.rfind("ARF_TERM_BEGIN_352") else {
+                return false;
+            };
+            let Some(end) = state.text[begin..].find("ARF_TERM_END_352") else {
+                return false;
+            };
+            let output = state.text[begin..begin + end].to_ascii_lowercase();
+            let flags: Vec<_> = output.split_whitespace().collect();
+            line.trim_end() == PROMPT
+                && flags.contains(&"icanon")
+                && flags.contains(&"echo")
+                && !flags.contains(&"-icanon")
+                && !flags.contains(&"-echo")
+        })?;
+        bracketed_paste(terminal, "cat('COOKED_PASTE_OK\\n')")?;
+        terminal.submit("cat('COOKED_MODE_OK\\n')", "COOKED_MODE_OK", PROMPT)
+    })
+}
+
 #[test]
 fn multiline_function_uses_continuation_then_returns_to_prompt() -> Result<()> {
     run_case("multiline", &["--no-auto-match"], |terminal| {


### PR DESCRIPTION
Fixes #352.

## Summary

- Restore the original Unix terminal mode after reedline completes its first successful interactive read, so startup-only echo suppression does not become the cooked-mode baseline during R evaluation.
- Keep the original terminal snapshot for process-exit restoration and preserve the existing Windows console-mode lifecycle.
- Add Unix PTY coverage for `ICANON` and `ECHO` during evaluation, including a subsequent bracketed paste, while retaining the cross-platform pre-prompt bracketed-paste regression test from #213.

This keeps the startup protection introduced by #219 without adding Ghostty detection or terminal-specific escape-sequence workarounds.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --offline -p arf-console --all-targets`
- `cargo test --offline --workspace`
- Manual tmux verification for Ctrl+C, SIGINT spam, nested `readline()`, startup-profile interruption, SIGTERM, and terminal restoration after Ctrl+D
- roborev job 1200: no issues found
