### PR TITLE
chore: prepare release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-09-11
+
 ### Fixed
 
 - Restored the original Unix terminal mode after the first interactive reedline input so terminal security indicators are not triggered by a startup-only `ECHO` suppression state (#352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "arf-console"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "arf-harp",
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "arf-harp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arf-libr",
  "insta",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "arf-libr"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "encoding_rs",
  "exec",
@@ -1793,7 +1793,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-vignette-to-md"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "htmd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ members = ["crates/*"]
 default-members = ["crates/arf-console"]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/eitsupi/arf"
 
 [workspace.dependencies]
 # Internal crates
-arf-harp = { version = "0.5.1", path = "crates/arf-harp" }
-arf-libr = { version = "0.5.1", path = "crates/arf-libr" }
-r-vignette-to-md = { version = "0.5.1", path = "crates/r-vignette-to-md" }
+arf-harp = { version = "0.5.2", path = "crates/arf-harp" }
+arf-libr = { version = "0.5.2", path = "crates/arf-libr" }
+r-vignette-to-md = { version = "0.5.2", path = "crates/r-vignette-to-md" }
 
 # R FFI
 libloading = "0.9"

--- a/crates/arf-console/src/repl/banner.rs
+++ b/crates/arf-console/src/repl/banner.rs
@@ -74,18 +74,28 @@ pub(crate) fn format_override_line(info: &RSourceOverrideInfo) -> String {
 mod tests {
     use super::*;
 
+    fn assert_banner_snapshot(name: &str, banner: String) {
+        let version_line = format!("# arf console v{}", env!("CARGO_PKG_VERSION"));
+        assert!(
+            banner.contains(&version_line),
+            "banner should contain the package version"
+        );
+        let banner = banner.replacen(&version_line, "# arf console v<version>", 1);
+        insta::assert_snapshot!(name, banner);
+    }
+
     #[test]
     fn test_banner_default_r_initialized() {
         let config = Config::default();
         let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_default_r_initialized", banner);
+        assert_banner_snapshot("banner_default_r_initialized", banner);
     }
 
     #[test]
     fn test_banner_default_r_not_initialized() {
         let config = Config::default();
         let banner = format_banner(&config, false, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_default_r_not_initialized", banner);
+        assert_banner_snapshot("banner_default_r_not_initialized", banner);
     }
 
     #[test]
@@ -93,7 +103,7 @@ mod tests {
         let mut config = Config::default();
         config.startup.reprex = ReprexMode::On;
         let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_reprex_mode", banner);
+        assert_banner_snapshot("banner_reprex_mode", banner);
     }
 
     #[test]
@@ -102,7 +112,7 @@ mod tests {
         config.startup.reprex = ReprexMode::On;
         config.reprex.comment = "## ".to_string();
         let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_reprex_custom_comment", banner);
+        assert_banner_snapshot("banner_reprex_custom_comment", banner);
     }
 
     #[test]
@@ -110,7 +120,7 @@ mod tests {
         let mut config = Config::default();
         config.startup.reprex = ReprexMode::Format;
         let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_reprex_format_mode", banner);
+        assert_banner_snapshot("banner_reprex_format_mode", banner);
     }
 
     #[test]
@@ -118,7 +128,14 @@ mod tests {
         let mut config = Config::default();
         config.editor.mode = crate::config::EditorMode::Vi;
         let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
-        insta::assert_snapshot!("banner_vi_mode", banner);
+        assert_banner_snapshot("banner_vi_mode", banner);
+    }
+
+    #[test]
+    fn test_banner_includes_package_version() {
+        let config = Config::default();
+        let banner = format_banner(&config, true, None, Some(FormatterBackend::Air));
+        assert!(banner.contains(concat!("# arf console v", env!("CARGO_PKG_VERSION"))));
     }
 
     #[test]

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: emacs
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_default_r_not_initialized.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: emacs
 # R is not initialized. Commands will not be evaluated.
 # Type :cmds for meta commands list, Ctrl+D to exit.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_custom_comment.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: emacs
 # Reprex: on | Comment: "## "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_format_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_format_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: emacs
 # Reprex: format | Comment: "#> " | Formatter: auto (air)
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_reprex_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: emacs
 # Reprex: on | Comment: "#> "
 # R is ready.

--- a/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
+++ b/crates/arf-console/src/repl/snapshots/arf__repl__banner__tests__banner_vi_mode.snap
@@ -2,7 +2,7 @@
 source: crates/arf-console/src/repl/banner.rs
 expression: banner
 ---
-# arf console v0.5.1
+# arf console v<version>
 # Edit mode: vi
 # R is ready.
 # Type :cmds for meta commands list, Ctrl+D to exit.


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.5.1 to 0.5.2
- Finalize CHANGELOG `[Unreleased]` as `[0.5.2] - 2026-09-11`
- Restore the original Unix terminal mode after the first interactive reedline input (#352)
- Normalize banner snapshot version lines so releases do not create version-only snapshot diffs

## Changelog

### Fixed

- Restored the original Unix terminal mode after the first interactive reedline input so terminal security indicators are not triggered by a startup-only `ECHO` suppression state (#352).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo insta test --accept -- banner`
